### PR TITLE
fix(eval): anacrusis-Bug + dedup_quality.py

### DIFF
--- a/tools/training/dedup_quality.py
+++ b/tools/training/dedup_quality.py
@@ -1,0 +1,93 @@
+"""dedup_quality.py — Aggregiert Quality-Stats pro UNIQUE PDF.
+
+Der reale Test-Filestore enthält viele Kopien desselben PDFs (durch
+unterschiedliche User-Sessions). Diese Aggregation verfälscht die
+Quality-Metriken — eine einzelne broken-Measure in einem oft-hochgeladenen
+PDF wird vielfach gezählt.
+
+Dieses Skript dedupliziert per filename-stem (alles nach dem ersten "-")
+und zeigt die wahre Quality auf eindeutigen PDFs.
+
+Usage:
+    python dedup_quality.py [--report reports/eval_xxx.json]
+"""
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "--report",
+        default="reports/eval_fixed_metrics.json",
+        type=Path,
+        help="Eval-Report JSON",
+    )
+    args = parser.parse_args()
+
+    report_path = args.report
+    if not report_path.is_absolute():
+        report_path = Path(__file__).parent / report_path
+
+    with open(report_path, encoding="utf-8") as f:
+        j = json.load(f)
+
+    by_base: dict[str, list[dict]] = defaultdict(list)
+    for p in j["per_pdf"]:
+        # Filestore-Namen sind typisch "<guid>-<original>.pdf" — splitte am ersten "-"
+        base = p["name"].split("-", 1)[1] if "-" in p["name"] else p["name"]
+        by_base[base].append(p)
+
+    unique_pdfs: list[dict] = []
+    for base, copies in by_base.items():
+        p = dict(copies[0])
+        p["name"] = base
+        p["n_copies_in_dataset"] = len(copies)
+        unique_pdfs.append(p)
+
+    n_total = len(j["per_pdf"])
+    print(f"Unique PDFs: {len(unique_pdfs)} (from {n_total} total copies)\n")
+
+    total_meas = sum(p["n_measures"] for p in unique_pdfs)
+    total_exact = sum(p["n_exact"] for p in unique_pdfs)
+    total_rep = sum(p["n_repaired"] for p in unique_pdfs)
+    total_ana = sum(p.get("n_anacrusis", 0) for p in unique_pdfs)
+    total_br = sum(p["n_broken"] for p in unique_pdfs)
+    total_nh = sum(p["n_noteheads"] for p in unique_pdfs)
+    total_st = sum(p["n_stems"] for p in unique_pdfs)
+    plau = (total_exact + total_rep + total_ana) / total_meas * 100
+    exact_pct = total_exact / total_meas * 100
+    stem_cov = total_st / total_nh * 100
+
+    print(f"Deduplicated Quality (across {len(unique_pdfs)} unique PDFs):")
+    print(f"  Total measures: {total_meas}")
+    print(f"  Plausibility:   {plau:.2f}% (exact+repaired+anacrusis)")
+    print(f"  Exact:          {exact_pct:.2f}%")
+    print(f"  Repaired:       {total_rep}")
+    print(f"  Anacrusis:      {total_ana}")
+    print(f"  Broken:         {total_br}")
+    print(f"  Stem-Coverage:  {stem_cov:.2f}%\n")
+
+    print("Per unique PDF:")
+    for p in sorted(
+        unique_pdfs, key=lambda x: -x.get("n_broken", 0) - x.get("n_repaired", 0)
+    ):
+        nm = p["name"][:55]
+        n_meas = p["n_measures"]
+        n_ex = p["n_exact"]
+        n_rep = p["n_repaired"]
+        n_ana = p.get("n_anacrusis", 0)
+        n_br = p["n_broken"]
+        n_cop = p["n_copies_in_dataset"]
+        print(
+            f"  {nm:<55} meas={n_meas:3d} ex={n_ex:3d} "
+            f"rep={n_rep:2d} ana={n_ana:2d} br={n_br:2d}  copies={n_cop}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/tools/training/eval_pipeline.py
+++ b/tools/training/eval_pipeline.py
@@ -55,6 +55,8 @@ def analyze_response(detections: dict) -> dict:
         "n_exact": 0,
         "n_repaired": 0,
         "n_broken": 0,
+        "n_anacrusis": 0,
+        "n_unknown": 0,
         "n_noteheads": 0,
         "n_stems": 0,
         "n_bars": 0,
@@ -84,7 +86,9 @@ def analyze_response(detections: dict) -> dict:
             p = m.get("plausibility")
             if p == "exact": summary["n_exact"] += 1
             elif p == "broken": summary["n_broken"] += 1
-            else: summary["n_repaired"] += 1
+            elif p == "repaired": summary["n_repaired"] += 1
+            elif p == "anacrusis": summary["n_anacrusis"] += 1
+            else: summary["n_unknown"] = summary.get("n_unknown", 0) + 1
         rs = page.get("reading_stream") or {}
         for sys_data in rs.get("systems") or []:
             for a in sys_data.get("anomalies") or []:
@@ -99,8 +103,13 @@ def compute_metrics(s: dict) -> dict:
     m = dict(s)
     n_meas = max(1, s["n_measures"])
     n_nh = max(1, s["n_noteheads"])
-    m["plausibility_pct"] = round(100.0 * (s["n_exact"] + s["n_repaired"]) / n_meas, 2)
+    # Plausibility: exact + repaired + anacrusis sind alle "valid"
+    # (anacrusis = leere Takte / Whole-Rest-Takte, sind korrekt erkannt aber leer).
+    valid = s["n_exact"] + s["n_repaired"] + s.get("n_anacrusis", 0)
+    m["plausibility_pct"] = round(100.0 * valid / n_meas, 2)
     m["exact_pct"] = round(100.0 * s["n_exact"] / n_meas, 2)
+    m["repaired_pct"] = round(100.0 * s["n_repaired"] / n_meas, 2)
+    m["anacrusis_pct"] = round(100.0 * s.get("n_anacrusis", 0) / n_meas, 2)
     m["broken_pct"] = round(100.0 * s["n_broken"] / n_meas, 2)
     m["stem_coverage_pct"] = round(100.0 * s["n_stems"] / n_nh, 2)
     return m
@@ -132,6 +141,7 @@ def main():
     per_pdf = []
     aggregate = {
         "n_pages": 0, "n_measures": 0, "n_exact": 0, "n_repaired": 0, "n_broken": 0,
+        "n_anacrusis": 0, "n_unknown": 0,
         "n_noteheads": 0, "n_stems": 0, "n_bars": 0, "n_rests": 0,
         "n_slurs": 0, "n_ties": 0, "n_anomalies": 0,
         "anomaly_breakdown": {}, "kind_breakdown": {"Filled": 0, "Open": 0, "Whole": 0},
@@ -155,6 +165,7 @@ def main():
         })
         # Aggregate
         for k in ["n_pages", "n_measures", "n_exact", "n_repaired", "n_broken",
+                  "n_anacrusis", "n_unknown",
                   "n_noteheads", "n_stems", "n_bars", "n_rests",
                   "n_slurs", "n_ties", "n_anomalies"]:
             aggregate[k] += summary[k]
@@ -185,9 +196,11 @@ def main():
     print("=" * 70)
     print(f"EVAL-SUMMARY ({len(per_pdf)} PDFs)")
     print("=" * 70)
-    print(f"  Plausibility:     {final['plausibility_pct']:.2f}%  ({final['n_exact'] + final['n_repaired']} / {final['n_measures']})")
+    valid = final['n_exact'] + final['n_repaired'] + final['n_anacrusis']
+    print(f"  Plausibility:     {final['plausibility_pct']:.2f}%  ({valid} / {final['n_measures']})")
     print(f"    Exact:          {final['exact_pct']:.2f}%  ({final['n_exact']})")
-    print(f"    Repaired:       {round(100.0 * final['n_repaired'] / max(1, final['n_measures']), 2):.2f}%  ({final['n_repaired']})")
+    print(f"    Repaired:       {final['repaired_pct']:.2f}%  ({final['n_repaired']})")
+    print(f"    Anacrusis:      {final['anacrusis_pct']:.2f}%  ({final['n_anacrusis']})")
     print(f"    Broken:         {final['broken_pct']:.2f}%  ({final['n_broken']})")
     print(f"  Stem-Coverage:    {final['stem_coverage_pct']:.2f}%  ({final['n_stems']} / {final['n_noteheads']})")
     print(f"  Slurs / Ties:     {final['n_slurs']} / {final['n_ties']}")


### PR DESCRIPTION
## Inhalt

### ec24aef fix(eval): zähle anacrusis nicht als 'repaired'
Der eval-pipeline.py-Fallback else-Branch hat Takte mit Status 'anacrusis'
(valide Whole-Rest-Takte) faelschlich als 'repaired' gezählt. Korrigiert mit
explizitem if-elif-else.

### 2736070 feat(eval): dedup_quality.py
Aggregiert Quality-Stats pro UNIQUE PDF (deduplized um Multi-Upload-Effekte).

## Quality-Stand korrigiert (auf 7 unique PDFs)

| Metric | Wert |
|---|---|
| Total measures | 560 |
| **Plausibility** | **99.82%** (exact+repaired+anacrusis) |
| Exact | 98.21% (550) |
| Repaired | 4 |
| Anacrusis | 5 |
| Broken | 1 (Dichterliebe Multi-Staff Klavier) |
| Stem-Coverage | 91.07% |

Auf den 26 Test-Kopien waren 14 Broken-Measures (alle aus Dichterliebe
mehrfach in der Datenbank). Die wahre PDF-Diversitaet ist 7 unique PDFs.

## Nicht-PDF-spezifische Wins
- ANGELS, Blas Musik: 100% exakt
- Lichterkinder, Anita, BeachBoys: nur 1 Repaired (Edge-Case)
- Dichterliebe: 1 Broken (multi-staff piano, bekannte Limitation)

🤖 AFK-Session 2 final
