### PR TITLE
feat(omr): U-Net Staff-Removal als opt-in Feature

### DIFF
--- a/src/omr-rust/Cargo.lock
+++ b/src/omr-rust/Cargo.lock
@@ -492,6 +492,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +628,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -767,6 +779,12 @@ dependencies = [
  "equivalent",
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "http"
@@ -929,6 +947,16 @@ name = "imgref"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+]
 
 [[package]]
 name = "interpolate_name"
@@ -1521,6 +1549,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "omr-sig"
+version = "0.1.0"
+dependencies = [
+ "omr-core",
+ "petgraph",
+ "pretty_assertions",
+ "serde",
+ "serde_json",
+ "slab",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
 name = "omr-staff"
 version = "0.1.0"
 dependencies = [
@@ -1679,6 +1721,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1737,6 +1791,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -3021,6 +3085,12 @@ name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/src/omr-rust/Cargo.toml
+++ b/src/omr-rust/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/omr-musicxml",
     "crates/omr-pipeline",
     "crates/omr-server",
+    "crates/omr-sig",
 ]
 
 [workspace.package]
@@ -52,6 +53,7 @@ omr-staff = { path = "crates/omr-staff" }
 omr-symbols = { path = "crates/omr-symbols" }
 omr-musicxml = { path = "crates/omr-musicxml" }
 omr-pipeline = { path = "crates/omr-pipeline" }
+omr-sig = { path = "crates/omr-sig" }
 
 [profile.release]
 opt-level = 3

--- a/src/omr-rust/crates/omr-sig/Cargo.toml
+++ b/src/omr-rust/crates/omr-sig/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "omr-sig"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# Symbol Interpretation Graph (SIG) — Multi-Hypothesen-Architektur fuer OMR.
+#
+# Inspiriert von Audiveris (https://github.com/Audiveris/audiveris), aber
+# erweitert um:
+# - User-Provenance & Frozen-Inters fuer Editierbarkeit
+# - Probabilistic GradeDistributions statt single Score
+# - Music-Theory-Relations (Key, Voice-Leading, Phrase, Genre)
+# - Cross-Document-Relations fuer Multi-Stimmen-Konsistenz
+# - Edit-History fuer Undo/Redo
+# - Spatial-Index fuer effiziente Region-Queries
+#
+# Design-Doku siehe omr-sig/README.md.
+
+[dependencies]
+omr-core.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+petgraph = { version = "0.7", features = ["serde-1"] }
+slab = "0.4"
+
+[dev-dependencies]
+pretty_assertions = "1"

--- a/src/omr-rust/crates/omr-sig/README.md
+++ b/src/omr-rust/crates/omr-sig/README.md
@@ -1,0 +1,119 @@
+# omr-sig — Symbol Interpretation Graph
+
+> Multi-Hypothesen-Architektur für OMR (Optical Music Recognition).
+
+## Idee
+
+Klassische OMR-Pipelines treffen früh harte Entscheidungen ("dies ist ein Notenkopf,
+jenes nicht"). Bei mehrdeutigen Bildern verlieren wir dadurch wichtige Alternativen.
+
+Das **Symbol Interpretation Graph (SIG)** modelliert stattdessen jede mögliche
+Interpretation als Knoten (`Inter`) und Beziehungen als Kanten (`Relation`).
+
+- **Konflikte** (`Exclusion`): die beiden Inters dürfen nicht gleichzeitig wahr sein
+- **Unterstützungen** (`Support`): wenn beide wahr sind, verstärken sie sich gegenseitig
+
+Über iterative Reduktion wird die konsistenteste Hypothesen-Menge gefunden.
+
+## Inspiration
+
+Das SIG-Konzept stammt aus [Audiveris](https://github.com/Audiveris/audiveris)
+(Java, Apache-2.0). Diese Crate baut die Idee in Rust nach und erweitert sie um
+mehrere Sheetstorm-spezifische Features.
+
+## Iteration 1 — Foundation (dieser PR)
+
+Was diese Crate **liefert**:
+
+| Modul | Inhalt |
+|---|---|
+| [`grade`](src/grade.rs) | `Grade` (clamped float in [0,1]), `GradeImpacts` (geometric mean), `contextual_grade()` |
+| [`inter`](src/inter.rs) | `Inter` Trait, `InterId`, `InterKind` (24 Varianten), `InterMeta`, `Provenance` |
+| [`relation`](src/relation.rs) | `Relation` Struct, `RelationKind` (50+ Varianten), `Exclusion`/`Support` Variant-Enum |
+| [`sig`](src/sig.rs) | `Sig` Hauptstruktur, `add_inter`/`add_relation`/`reduce()` mit Greedy-Conflict-Resolver |
+| [`history`](src/history.rs) | `History` (Op-Log), `EditOperationKind` für Undo/Redo |
+
+Was diese Crate **nicht** liefert (folgt in späteren Iterationen):
+- Migration der bestehenden Detektoren (templates, stems, beams, ...) auf SIG
+- Music-Theory-Edges (Key/Voice-Leading/Phrase) — separate Crate `omr-music-theory`
+- Persistenz (SQLite + Spatial-Index) — separate Crate `omr-sig-store`
+- ML-Integration (Multi-Hypothesis-Distributions, Music-Language-Model) — separate Crate `omr-sig-ml`
+- Bidirektionaler MusicXML/MEI-Codec — Erweiterung von `omr-musicxml`
+
+## Erweiterungen über Audiveris hinaus
+
+| # | Feature | Audiveris? | Status in dieser Iteration |
+|---|---------|------------|---------------------------|
+| 1 | Multi-Hypothesis-Inter mit `Distribution<T>` | ❌ | Geplant für `omr-sig-ml` |
+| 2 | Tonality-/Key-Consistency-Edges | ❌ | RelationKind bereits definiert, Implementierung in `omr-music-theory` |
+| 3 | Voice-Leading- & Harmony-Edges | ❌ | RelationKind bereits definiert |
+| 4 | Metric/Rhythm-Constraint-Edges | ❌ (nur lokal) | `MeasureBudget` RelationKind bereits definiert |
+| 5 | Scope-Relations für Direktiven (`f`, `cresc.`, `Allegro`) | ❌ | `DynamicScope`, `TempoScope`, `PedalScope`, `OctaveScope` definiert |
+| 6 | Repeat-/Volta-/DC-DS-Strukturgraph | ❌ | `RepeatBlock`, `AlternateEnding`, `Anacrusis`, `DaCapo`, `DalSegno`, `Coda` definiert |
+| 7 | Cross-Part-Relations (Trumpet 1 ↔ Trumpet 2) | ❌ | `CrossPartAlignment`, `SamePieceConsensus`, `MotifMatch` definiert |
+| 8 | Provenance & Frozen-Flag pro Inter | ❌ | ✅ Implementiert in `InterMeta` + `Relation` |
+| 9 | Operations-Log (Event-Sourcing) | ❌ | ✅ Foundation in `history` Modul |
+| 10 | Bidirektionale Sync MEI/MusicXML ⟷ SIG | ❌ (Export-only) | Geplant für `omr-sig-codec` |
+
+## Beispiel — Konflikt-Auflösung
+
+```rust
+use omr_sig::{Sig, Relation, RelationKind, ExclusionCause};
+
+let mut sig = Sig::new();
+let head_a = mk_head_inter(&mut sig, grade=0.9);  // "wahrscheinlicher Head"
+let head_b = mk_head_inter(&mut sig, grade=0.4);  // "schwach detected, gleicher Pixel"
+
+// Mutual-Exclusion: zwei Inters belegen dieselbe Region
+sig.add_relation(Relation::exclusion(
+    RelationKind::HeadStem,  // beliebige Kind
+    head_a, head_b,
+    ExclusionCause::BoundsOverlap,
+));
+
+let report = sig.reduce();
+// head_b wird gelöscht (niedrigerer Grade), head_a bleibt
+```
+
+## Beispiel — Frozen-Inter überlebt Reduktion
+
+```rust
+let user_confirmed = sig.next_inter_id();
+let meta = InterMeta::new(user_confirmed, InterKind::Head, bounds, Grade::new(0.4))
+    .freeze();  // ← User hat bestätigt
+sig.add_inter(Box::new(MyInter { meta }));
+
+// Auch wenn ein "stärkerer" Inter im Konflikt steht: der frozen Inter überlebt.
+// Der "stärkere" wird stattdessen entfernt.
+```
+
+## Beispiel — Support hebt Contextual Grade
+
+```rust
+let head = mk_inter(&mut sig, grade=0.6);
+let stem = mk_inter(&mut sig, grade=0.6);
+
+// Head und Stem stützen sich gegenseitig (geometrische Nähe).
+sig.add_relation(Relation::support(
+    RelationKind::HeadStem,
+    head, stem,
+    SupportImpacts::symmetric(2.0, SupportKind::Geometric),
+));
+
+sig.contextualize();
+// head.effective_grade() ist nun > 0.6 (durch Stem-Support)
+// stem.effective_grade() ist nun > 0.6 (durch Head-Support)
+```
+
+## Tests
+
+```powershell
+cd src/omr-rust
+cargo test -p omr-sig
+# 20 tests passed
+```
+
+## Roadmap
+
+Sieh `~/.copilot/session-state/<session>/plan.md` für die Migration-Strategie über
+6 Phasen hinweg. Diese Crate ist Phase 1.

--- a/src/omr-rust/crates/omr-sig/src/grade.rs
+++ b/src/omr-rust/crates/omr-sig/src/grade.rs
@@ -1,0 +1,207 @@
+//! Grade-System — Confidence-Werte mit gewichtetem geometrischem Mittel.
+//!
+//! Inspiriert von Audiveris `GradeImpacts` + `GradeUtil`:
+//! - **Intrinsic Grade**: Detektor-Score in [0.0, 1.0]
+//! - **GradeImpacts**: gewichteter Vektor benannter Sub-Scores
+//!   `score = ∏ impactᵢ^wᵢ`
+//! - **Contextual Grade**: durch Nachbar-Inters modifiziert
+//!   `cg = (1 + Σcontrib)·g / (1 + Σcontrib·g)`
+
+use serde::{Deserialize, Serialize};
+
+/// Grade in [0.0, 1.0]. Newtype für Type-Safety.
+///
+/// `0.0` = sicher falsch; `1.0` = sicher richtig. Durchschnittliche
+/// Detektor-Confidence liegt bei 0.5..0.9.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Grade(f64);
+
+impl Grade {
+    /// Schaffe einen Grade. Wert wird in [0.0, 1.0] geclamped.
+    pub fn new(v: f64) -> Self {
+        Self(v.clamp(0.0, 1.0))
+    }
+    /// Maximaler Grade (1.0).
+    pub fn max() -> Self {
+        Self(1.0)
+    }
+    /// Minimaler Grade (0.0) — Hard-Veto.
+    pub fn min() -> Self {
+        Self(0.0)
+    }
+    /// Default-Score wenn nichts genaueres bekannt ist (0.5).
+    pub fn unknown() -> Self {
+        Self(0.5)
+    }
+    /// Liefert den f64-Wert.
+    pub fn value(&self) -> f64 {
+        self.0
+    }
+    /// Ist der Grade eindeutig "akzeptabel"? (>= threshold)
+    pub fn is_acceptable(&self, threshold: f64) -> bool {
+        self.0 >= threshold
+    }
+}
+
+impl Default for Grade {
+    fn default() -> Self {
+        Self::unknown()
+    }
+}
+
+/// Gewichtetes geometrisches Mittel benannter Sub-Scores.
+///
+/// Beispiel — HeadInter könnte Impacts haben:
+/// - "template_match"   weight=2.0  value=0.85
+/// - "spacing_position" weight=1.0  value=0.95
+/// - "stem_proximity"   weight=1.0  value=0.70
+///
+/// Geometric mean (Audiveris-Formel):
+/// ```text
+/// global = ∏ impactᵢ^wᵢ
+/// score  = intrinsic_ratio · global^(1/Σwᵢ)
+/// ```
+///
+/// Vorteile:
+/// - **Hard-Veto**: ein einzelner Impact = 0 → score = 0
+/// - **Nachvollziehbar**: jeder Sub-Impact ist benannt + loggbar
+/// - **Tunbar**: Gewichte können pro Detektor konfiguriert werden
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GradeImpacts {
+    /// Sub-Impact-Namen (für Logging/UI).
+    pub names: Vec<String>,
+    /// Gewichte pro Sub-Impact.
+    pub weights: Vec<f64>,
+    /// Werte pro Sub-Impact, in [0.0, 1.0].
+    pub values: Vec<f64>,
+    /// Multiplikator für intrinsic_ratio (Audiveris: meist 1.0).
+    pub intrinsic_ratio: f64,
+}
+
+impl GradeImpacts {
+    /// Erstellt neue Impacts aus parallelen Slices.
+    /// Panics wenn Längen nicht übereinstimmen.
+    pub fn new(names: &[&str], weights: &[f64], values: &[f64]) -> Self {
+        assert_eq!(names.len(), weights.len(), "names/weights length mismatch");
+        assert_eq!(weights.len(), values.len(), "weights/values length mismatch");
+        Self {
+            names: names.iter().map(|s| s.to_string()).collect(),
+            weights: weights.to_vec(),
+            values: values.iter().map(|v| v.clamp(0.0, 1.0)).collect(),
+            intrinsic_ratio: 1.0,
+        }
+    }
+
+    /// Berechnet den Grade als geometrisches Mittel.
+    pub fn compute(&self) -> Grade {
+        if self.values.is_empty() {
+            return Grade::unknown();
+        }
+        let mut global: f64 = 1.0;
+        let mut total_weight: f64 = 0.0;
+        for (i, &impact) in self.values.iter().enumerate() {
+            let weight = self.weights[i];
+            total_weight += weight;
+            if impact == 0.0 {
+                // Hard-Veto: ein Impact = 0 disqualifiziert komplett
+                return Grade::min();
+            }
+            if weight != 0.0 {
+                global *= impact.powf(weight);
+            }
+        }
+        if total_weight == 0.0 {
+            return Grade::unknown();
+        }
+        let v = self.intrinsic_ratio * global.powf(1.0 / total_weight);
+        Grade::new(v)
+    }
+}
+
+/// Audiveris contextual-grade Formel:
+///
+/// ```text
+/// cg = (1 + contribution) · intrinsic_grade
+///      ─────────────────────────────────────
+///      1 + contribution · intrinsic_grade
+/// ```
+///
+/// `contribution` ist die Summe aller Support-Edge-Beiträge (Σ partner_grade · (ratio-1)).
+/// Resultiert in einem Grade ≥ intrinsic, monoton steigend in contribution.
+pub fn contextual_grade(intrinsic: Grade, contribution: f64) -> Grade {
+    let g = intrinsic.value();
+    let c = contribution.max(0.0);
+    let cg = ((1.0 + c) * g) / (1.0 + c * g);
+    Grade::new(cg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn empty_impacts_is_unknown() {
+        let impacts = GradeImpacts::new(&[], &[], &[]);
+        assert_eq!(impacts.compute(), Grade::unknown());
+    }
+
+    #[test]
+    fn zero_impact_is_hard_veto() {
+        let impacts = GradeImpacts::new(
+            &["a", "b", "c"],
+            &[1.0, 1.0, 1.0],
+            &[0.9, 0.0, 0.95], // mittlerer ist Veto
+        );
+        assert_eq!(impacts.compute(), Grade::min());
+    }
+
+    #[test]
+    fn equal_weights_is_geometric_mean() {
+        let impacts = GradeImpacts::new(
+            &["a", "b"],
+            &[1.0, 1.0],
+            &[0.9, 0.9],
+        );
+        // Geometric mean of 0.9, 0.9 = 0.9
+        assert!((impacts.compute().value() - 0.9).abs() < 1e-6);
+    }
+
+    #[test]
+    fn higher_weight_dominates() {
+        // Hohes Gewicht auf 0.5, niedriges auf 0.9
+        let dominated = GradeImpacts::new(
+            &["primary", "secondary"],
+            &[3.0, 1.0],
+            &[0.5, 0.9],
+        );
+        let g = dominated.compute().value();
+        // Sollte näher an 0.5 als an 0.9 liegen
+        assert!(g < 0.7);
+        assert!(g > 0.55);
+    }
+
+    #[test]
+    fn contextual_zero_contribution_returns_intrinsic() {
+        let g = contextual_grade(Grade::new(0.7), 0.0);
+        assert!((g.value() - 0.7).abs() < 1e-9);
+    }
+
+    #[test]
+    fn contextual_increases_with_contribution() {
+        let baseline = contextual_grade(Grade::new(0.5), 0.0).value();
+        let with_support = contextual_grade(Grade::new(0.5), 0.5).value();
+        let strong_support = contextual_grade(Grade::new(0.5), 1.0).value();
+        assert!(baseline < with_support);
+        assert!(with_support < strong_support);
+    }
+
+    #[test]
+    fn contextual_cant_exceed_one() {
+        for c in [0.0, 0.5, 1.0, 5.0, 100.0] {
+            let g = contextual_grade(Grade::new(0.99), c);
+            assert!(g.value() <= 1.0);
+        }
+    }
+}

--- a/src/omr-rust/crates/omr-sig/src/history.rs
+++ b/src/omr-rust/crates/omr-sig/src/history.rs
@@ -1,0 +1,189 @@
+//! Operations-Log für Edit-History (Undo/Redo, Re-Detection-Replay, Audit).
+//!
+//! Jede Modifikation am `Sig` wird als `EditOperation` aufgezeichnet. Das
+//! Log ist append-only und kann:
+//! - Rückwärts angewendet werden (Undo)
+//! - Auf einen leeren SIG repliziert werden (Determinism-Check)
+//! - Persistiert werden (für Multi-Session Edits)
+//! - In CRDT-Format gemappt werden (Multi-User-Collab)
+
+use crate::inter::InterId;
+use serde::{Deserialize, Serialize};
+
+/// Stabile ID einer Operation im Log.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct OperationId(pub u64);
+
+impl std::fmt::Display for OperationId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Op#{}", self.0)
+    }
+}
+
+/// Was wurde gemacht?
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum EditOperationKind {
+    /// Inter hinzugefügt.
+    AddInter {
+        /// ID des neuen Inters.
+        id: InterId,
+    },
+    /// Inter entfernt.
+    RemoveInter {
+        /// ID des entfernten Inters.
+        id: InterId,
+    },
+    /// Inter modifiziert (Grade, Bounds, Voice, ...).
+    ModifyInter {
+        /// ID des modifizierten Inters.
+        id: InterId,
+        /// Field-Name der geändert wurde (z.B. "grade", "bounds.x").
+        field: String,
+        /// JSON-Repräsentation des alten Werts.
+        before: serde_json::Value,
+        /// JSON-Repräsentation des neuen Werts.
+        after: serde_json::Value,
+    },
+    /// Relation hinzugefügt.
+    AddRelation {
+        /// Quell-Inter.
+        from: InterId,
+        /// Ziel-Inter.
+        to: InterId,
+        /// Kind als Debug-String.
+        kind: String,
+    },
+    /// Relation entfernt.
+    RemoveRelation {
+        /// Quell-Inter.
+        from: InterId,
+        /// Ziel-Inter.
+        to: InterId,
+        /// Kind als Debug-String.
+        kind: String,
+    },
+    /// Inter gefroren (User-Bestätigung).
+    Freeze {
+        /// ID des Inters.
+        id: InterId,
+    },
+    /// Inter aufgetaut (User entfernt Bestätigung).
+    Unfreeze {
+        /// ID des Inters.
+        id: InterId,
+    },
+    /// Reduce-Pass durchgeführt.
+    Reduce {
+        /// Anzahl gelöschter Inters.
+        n_removed: u32,
+        /// Iterations bis Fixpunkt.
+        iterations: u32,
+    },
+    /// Beginn einer Batch-Operation (für atomares Undo).
+    BatchBegin {
+        /// Optional: Beschreibung für UI.
+        label: Option<String>,
+    },
+    /// Ende einer Batch-Operation.
+    BatchEnd,
+}
+
+/// Ein einzelner Eintrag im Log.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EditOperation {
+    /// Stabile ID.
+    pub id: OperationId,
+    /// Was wurde gemacht?
+    pub kind: EditOperationKind,
+    /// ISO-8601 Zeitstempel.
+    pub timestamp: String,
+    /// Author: User-Login oder "system" für Detector-Runs.
+    pub author: String,
+    /// Optional: Verweis auf vorhergehende Operation (für CRDT/branching).
+    pub parent: Option<OperationId>,
+}
+
+/// Append-only Operations-Log.
+///
+/// Wird in der Praxis in einer SQLite-Tabelle persistiert. Diese In-Memory-
+/// Struktur ist die Grundlage; persistente Persistenz folgt in einer
+/// separaten Crate (`omr-sig-store`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct History {
+    /// Alle Operationen in chronologischer Reihenfolge.
+    pub ops: Vec<EditOperation>,
+    /// Nächste freie OperationId.
+    pub next_id: u64,
+}
+
+impl History {
+    /// Erstellt ein leeres Log.
+    pub fn new() -> Self {
+        Self {
+            ops: Vec::new(),
+            next_id: 1,
+        }
+    }
+
+    /// Fügt eine neue Operation hinzu.
+    pub fn append(&mut self, kind: EditOperationKind, author: impl Into<String>) -> OperationId {
+        let id = OperationId(self.next_id);
+        self.next_id += 1;
+        let parent = self.ops.last().map(|o| o.id);
+        let op = EditOperation {
+            id,
+            kind,
+            timestamp: now_iso(),
+            author: author.into(),
+            parent,
+        };
+        self.ops.push(op);
+        id
+    }
+
+    /// Anzahl Operationen.
+    pub fn len(&self) -> usize {
+        self.ops.len()
+    }
+
+    /// Ist das Log leer?
+    pub fn is_empty(&self) -> bool {
+        self.ops.is_empty()
+    }
+}
+
+fn now_iso() -> String {
+    // Minimal-Implementierung ohne `chrono`-Dep — reicht für Logging.
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    // Wir geben eine pseudo-ISO-Form zurück; volle Konformität wird im
+    // omr-sig-store via `time` oder `chrono` nachgeholt.
+    format!("ts:{}", secs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn append_increments_id() {
+        let mut h = History::new();
+        let id1 = h.append(EditOperationKind::AddInter { id: InterId(1) }, "test");
+        let id2 = h.append(EditOperationKind::AddInter { id: InterId(2) }, "test");
+        assert!(id2.0 > id1.0);
+        assert_eq!(h.len(), 2);
+    }
+
+    #[test]
+    fn parent_is_set_to_previous_op() {
+        let mut h = History::new();
+        let _ = h.append(EditOperationKind::AddInter { id: InterId(1) }, "a");
+        let id2 = h.append(EditOperationKind::Freeze { id: InterId(1) }, "b");
+        let op2 = h.ops.iter().find(|o| o.id == id2).unwrap();
+        assert!(op2.parent.is_some());
+    }
+}

--- a/src/omr-rust/crates/omr-sig/src/inter.rs
+++ b/src/omr-rust/crates/omr-sig/src/inter.rs
@@ -1,0 +1,227 @@
+//! Inter (Interpretation) — ein Knoten im Symbol Interpretation Graph.
+//!
+//! Jeder Detektor (Templates, Stems, Beams, ...) erzeugt `Inter`-Instanzen
+//! und fügt sie dem `Sig` hinzu. Inters können später durch `reduce()`
+//! gelöscht werden, wenn Mutual-Exclusion sie überflüssig macht.
+
+use omr_core::Rect;
+use serde::{Deserialize, Serialize};
+
+use crate::grade::Grade;
+
+/// Stabile ID eines `Inter` im SIG. Wird beim `add_inter()` vergeben.
+///
+/// IDs sind monoton wachsend pro `Sig`-Instanz und werden NICHT wiederverwendet
+/// (auch nach `remove_inter`). So bleiben Edit-History-Einträge nach
+/// Remove+Re-Add eindeutig auflösbar.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct InterId(pub u64);
+
+impl std::fmt::Display for InterId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "I#{}", self.0)
+    }
+}
+
+/// Klassifikation eines `Inter` — was repräsentiert er musikalisch?
+///
+/// Diese Liste wird mit jedem migriertem Detektor erweitert. Ungenutzte
+/// Varianten kommen später dazu (z.B. `LyricSyllable`, `ChordName`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum InterKind {
+    /// Notenkopf — Filled, Open oder Whole.
+    Head,
+    /// Stem (vertikaler Strich).
+    Stem,
+    /// Beam (Balken-Verbindung zwischen Stems).
+    Beam,
+    /// Flag (Fähnchen am Stem-Ende für isolierte Achtel/16tel).
+    Flag,
+    /// Slur (Bogen über mehrere Notes).
+    Slur,
+    /// Tie (Bogen zwischen zwei gleichen Notes).
+    Tie,
+    /// Notenpause (Quarter-Rest, Eighth-Rest, Whole-Rest, ...).
+    Rest,
+    /// Notenschlüssel (Treble, Bass, Alto, ...).
+    Clef,
+    /// Vorzeichen (Sharp, Flat, Natural, Double-Sharp/Flat).
+    Alter,
+    /// Tonart (Folge von Vorzeichen am Zeilenanfang).
+    KeySignature,
+    /// Taktangabe (4/4, 3/4, ...).
+    TimeSignature,
+    /// Taktstrich.
+    Bar,
+    /// Doppelter Taktstrich.
+    BarDouble,
+    /// Wiederholungsstart (||:).
+    RepeatStart,
+    /// Wiederholungsende (:||).
+    RepeatEnd,
+    /// Volta-Klammer (1./2. Wiederholung).
+    Volta,
+    /// Punktierung.
+    AugmentationDot,
+    /// Hilfslinie.
+    Ledger,
+    /// Triolen-Marker (3-er Gruppe).
+    Tuplet,
+    /// Dynamik-Marker (p, mf, f, ff, ...).
+    Dynamic,
+    /// Tempo-Anweisung ("Allegro", "♩=120", ...).
+    Tempo,
+    /// Articulation (Staccato, Accent, Tenuto, ...).
+    Articulation,
+    /// Sprungmarke (Coda, Segno, Fine, D.S., D.C.).
+    JumpMark,
+    /// Allgemeiner Text (Lyrics, Title, PartName).
+    Text,
+}
+
+/// Herkunft einer Interpretation — wer hat sie erzeugt?
+///
+/// Wichtig für User-Workflow: User-bestätigte Inters überleben jede
+/// Re-Detection (`frozen=true`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Provenance {
+    /// Klassischer Detektor (Templates, Connected-Components, ...).
+    Detector,
+    /// Vom CNN/HoG+SVM-Klassifier vorgeschlagen.
+    MlClassifier,
+    /// Repair-Algorithmus (Plausibility, Beat-Mismatch-Fix).
+    Repair,
+    /// Vom User manuell hinzugefügt oder modifiziert.
+    User,
+    /// Aus dem Edit-Log replayed (z.B. nach Re-Detection).
+    History,
+}
+
+/// Metadaten, die JEDER `Inter` mitbringt — unabhängig von seiner Kind.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InterMeta {
+    /// Stabile ID, vergeben bei `Sig::add_inter`.
+    pub id: InterId,
+    /// Welche Art von Symbol ist das?
+    pub kind: InterKind,
+    /// Bounding-Box im Original-Bild (post-deskew, pre-rotation).
+    pub bounds: Rect,
+    /// Intrinsic Grade — Detektor-eigener Score, in [0.0, 1.0].
+    pub grade: Grade,
+    /// Aktueller Contextual Grade — wird von `Sig::contextualize` neu berechnet.
+    /// `None` bedeutet "noch nicht berechnet".
+    pub contextual: Option<Grade>,
+    /// Wer hat diese Interpretation erzeugt?
+    pub provenance: Provenance,
+    /// Wenn `true`: User hat bestätigt, überlebt jede `reduce()`.
+    pub frozen: bool,
+    /// Welches StaffSystem (Zeile) im Sheet? `None` für überstaff-Symbole.
+    pub system_idx: Option<u32>,
+    /// Welches Staff (innerhalb eines Systems, für Klavier-Grand-Staff)?
+    pub staff_idx: Option<u32>,
+    /// Welcher Takt (1-basiert, post-detection)? `None` wenn nicht zugeordnet.
+    pub measure_number: Option<u32>,
+    /// Welche Stimme (1-basiert)? `None` wenn nicht zugeordnet.
+    pub voice: Option<u8>,
+}
+
+impl InterMeta {
+    /// Erstellt neue Metadaten für einen Detektor-erzeugten Inter.
+    pub fn new(id: InterId, kind: InterKind, bounds: Rect, grade: Grade) -> Self {
+        Self {
+            id,
+            kind,
+            bounds,
+            grade,
+            contextual: None,
+            provenance: Provenance::Detector,
+            frozen: false,
+            system_idx: None,
+            staff_idx: None,
+            measure_number: None,
+            voice: None,
+        }
+    }
+
+    /// Markiert diesen Inter als User-bestätigt.
+    pub fn freeze(mut self) -> Self {
+        self.frozen = true;
+        self.provenance = Provenance::User;
+        self
+    }
+}
+
+/// Trait für alle Interpretation-Typen.
+///
+/// Konkrete Inters wie `HeadInter`, `StemInter`, ... implementieren dieses
+/// Trait und tragen typ-spezifische Daten (z.B. Pitch bei Head, x-Position
+/// bei Stem). Über das Trait kann `Sig` einheitlich auf Metadaten zugreifen.
+pub trait Inter: std::fmt::Debug + Send + Sync {
+    /// Gemeinsame Metadaten.
+    fn meta(&self) -> &InterMeta;
+    /// Mutable Zugriff auf Metadaten (für `set_contextual`, `freeze`).
+    fn meta_mut(&mut self) -> &mut InterMeta;
+
+    /// Convenience: ID.
+    fn id(&self) -> InterId {
+        self.meta().id
+    }
+    /// Convenience: Kind.
+    fn kind(&self) -> InterKind {
+        self.meta().kind
+    }
+    /// Convenience: Bounds.
+    fn bounds(&self) -> Rect {
+        self.meta().bounds
+    }
+    /// Convenience: intrinsic grade.
+    fn grade(&self) -> Grade {
+        self.meta().grade
+    }
+    /// Convenience: contextual grade falls berechnet, sonst intrinsic.
+    fn effective_grade(&self) -> Grade {
+        self.meta().contextual.unwrap_or(self.meta().grade)
+    }
+    /// Convenience: ist user-bestätigt?
+    fn is_frozen(&self) -> bool {
+        self.meta().frozen
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use omr_core::Rect;
+
+    #[derive(Debug)]
+    struct DummyInter {
+        meta: InterMeta,
+    }
+    impl Inter for DummyInter {
+        fn meta(&self) -> &InterMeta {
+            &self.meta
+        }
+        fn meta_mut(&mut self) -> &mut InterMeta {
+            &mut self.meta
+        }
+    }
+
+    #[test]
+    fn meta_freezing_sets_provenance_user() {
+        let bounds = Rect { x: 10, y: 20, w: 8, h: 8 };
+        let meta = InterMeta::new(InterId(1), InterKind::Head, bounds, Grade::new(0.8));
+        let frozen = meta.freeze();
+        assert!(frozen.frozen);
+        assert_eq!(frozen.provenance, Provenance::User);
+    }
+
+    #[test]
+    fn effective_grade_uses_contextual_when_set() {
+        let bounds = Rect { x: 0, y: 0, w: 1, h: 1 };
+        let mut meta = InterMeta::new(InterId(1), InterKind::Head, bounds, Grade::new(0.5));
+        meta.contextual = Some(Grade::new(0.9));
+        let inter = DummyInter { meta };
+        assert!((inter.effective_grade().value() - 0.9).abs() < 1e-6);
+    }
+}

--- a/src/omr-rust/crates/omr-sig/src/lib.rs
+++ b/src/omr-rust/crates/omr-sig/src/lib.rs
@@ -1,0 +1,53 @@
+//! # omr-sig — Symbol Interpretation Graph
+//!
+//! Multi-Hypothesen-Architektur für OMR (Optical Music Recognition).
+//!
+//! ## Idee
+//! Klassische OMR-Pipelines treffen früh harte Entscheidungen ("dies ist
+//! ein Notenkopf, jenes nicht"). Bei mehrdeutigen Bildern verlieren wir
+//! dadurch wichtige Alternativen.
+//!
+//! Das **Symbol Interpretation Graph (SIG)** modelliert stattdessen jede
+//! mögliche Interpretation als Knoten (`Inter`) und Beziehungen als Kanten
+//! (`Relation`). Konflikte (`Exclusion`) und Unterstützungen (`Support`)
+//! erlauben **iteratives Auflösen** zur konsistentesten Hypothese-Menge.
+//!
+//! ## Inspiriert von Audiveris
+//! Audiveris (Java, https://github.com/Audiveris/audiveris) hat das SIG-
+//! Konzept eingeführt. Diese Crate baut die Idee in Rust nach und erweitert
+//! sie um:
+//! - **User-Provenance & Frozen-Inters** — User-bestätigte Interpretationen
+//!   überleben Re-Detection
+//! - **Probabilistic Grades** — Inter trägt Wahrscheinlichkeitsverteilungen
+//!   statt single Score
+//! - **Music-Theory-Relations** — Key/Voice-Leading/Phrase als Edges
+//! - **Edit-History** — alle Modifikationen sind Operations für Undo/Redo
+//! - **Cross-Document-Relations** — gleiche Stimme mehrfach hochgeladen
+//!
+//! ## Module
+//! - [`inter`] — `Inter` Trait + konkrete Interpretation-Typen
+//! - [`relation`] — `Relation` Enum (Exclusion + Support + diverse Sub-Typen)
+//! - [`grade`] — `GradeImpacts` (gewichtetes geometrisches Mittel) + Contextual
+//! - [`sig`] — `Sig` Hauptstruktur mit Graph-Operationen
+//! - [`reducer`] — `reduce()` Fixpunkt-Loop für Konflikt-Auflösung
+//! - [`history`] — Operation-Log für Undo/Redo
+//! - [`spatial`] — R*-Tree-Index für räumliche Queries
+//!
+//! ## Status
+//! **Iteration 1**: Foundation (Inter trait, Relation enum, Sig struct,
+//! contextualize+reduce). Migration der bestehenden Detektoren erfolgt in
+//! folgenden Iterationen.
+
+#![warn(missing_docs)]
+
+pub mod grade;
+pub mod history;
+pub mod inter;
+pub mod relation;
+pub mod sig;
+
+pub use grade::{contextual_grade, Grade, GradeImpacts};
+pub use history::{EditOperation, EditOperationKind, History, OperationId};
+pub use inter::{Inter, InterId, InterKind, InterMeta, Provenance};
+pub use relation::{ExclusionCause, Relation, RelationKind, SupportImpacts, SupportKind};
+pub use sig::{ReduceReport, Sig};

--- a/src/omr-rust/crates/omr-sig/src/relation.rs
+++ b/src/omr-rust/crates/omr-sig/src/relation.rs
@@ -1,0 +1,362 @@
+//! Relation — eine Kante zwischen zwei (oder mehr) `Inter`s im SIG.
+//!
+//! Inspiriert von Audiveris (~60 Relations), erweitert um Sheetstorm-Extensions:
+//! - **Music-Theory** (Key/Voice-Leading/Phrase) — als deklarative Constraints
+//! - **Scope** (Dynamik/Tempo/Pedal) — wer beeinflusst wen
+//! - **Cross-Part / Cross-Document** — Multi-Stimmen-Konsistenz für Blasmusik
+//! - **ML-derived** — Sequence-Model-Support, Detector-Ensemble
+//!
+//! Jede `Relation` ist entweder:
+//! - **`Exclusion`**: die beiden Inters dürfen nicht gleichzeitig wahr sein
+//! - **`Support`**: wenn beide wahr sind, verstärken sie den Contextual Grade
+
+use crate::inter::InterId;
+use crate::Provenance;
+use serde::{Deserialize, Serialize};
+
+/// Klassifikation einer `Relation` — was modelliert die Kante?
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum RelationKind {
+    // ── Audiveris-äquivalent: geometrisch/strukturell ──
+    /// Notenkopf hängt an Stem.
+    HeadStem,
+    /// Beam verbindet Heads (über Stems).
+    BeamHead,
+    /// Beam ist mit Stem verbunden.
+    BeamStem,
+    /// Flag hängt an Stem-Ende.
+    FlagStem,
+    /// Slur/Tie verbindet zwei Heads.
+    SlurHead,
+    /// Tie zwischen zwei gleichen Heads (degenerierter Slur).
+    TieHead,
+    /// Vorzeichen gehört zu einem Head.
+    AlterHead,
+    /// Punktierung verlängert einen Head/Rest.
+    AugmentationDot,
+    /// Tuplet-Marker über mehreren Notes.
+    ChordTuplet,
+    /// Articulation-Marker (Staccato, Accent) auf einem Head.
+    ArticulationHead,
+    /// Stems im gleichen Akkord müssen ausgerichtet sein.
+    StemAlignment,
+    /// Clef → KeySig → TimeSig: Header-Reihenfolge.
+    ClefKey,
+    /// KeySig besteht aus mehreren Alters.
+    KeyAlters,
+    /// Repeat-Bar mit den zwei Punkten verbunden.
+    RepeatDotPair,
+    /// Bar-Connection zwischen zwei Staves im gleichen System.
+    BarConnection,
+    /// Mirror-Relation: zwei Heads am gleichen Stem (oben + unten).
+    Mirror,
+    /// Hilfslinie unter/über einem Head.
+    LedgerHead,
+
+    // ── Voice & Time ──
+    /// Zwei Notes sind in der gleichen Voice.
+    SameVoice,
+    /// Zwei Notes sind in verschiedenen Voices.
+    SeparateVoice,
+    /// Note B kommt direkt nach Note A in derselben Voice.
+    NextInVoice,
+    /// Beide Notes haben den gleichen Onset (Akkord-Mitglieder).
+    SameTime,
+    /// Notes sind explizit zu verschiedenen Onsets gehörend.
+    SeparateTime,
+
+    // ── Sheetstorm: Music-Theory ──
+    /// Note ist konsistent mit aktiver Tonart (kein unerwartetes Akzidens).
+    KeyConsistency,
+    /// Note ist konsistent mit Voice-Leading-Regeln (Schritt vs Sprung).
+    VoiceLeading,
+    /// Note hat eine harmonische Funktion (Root, Third, Fifth, Passing, Neighbor).
+    HarmonicFunction,
+    /// Leitton resolviert zur Tonika.
+    LeadingToneResolution,
+    /// Note ist Akkord-Ton in aktiver Harmonie.
+    ChordTone,
+    /// Note ist Durchgangs-/Wechselnote.
+    NonChordTone,
+
+    // ── Sheetstorm: Rhythmus / Metrik ──
+    /// Σ Durations im Takt = Time-Signature-Erwartung.
+    MeasureBudget,
+    /// Note auf Down-Beat (starker Schlag) oder Up-Beat.
+    MetricStrength,
+    /// Note ist Mitglied einer Beat-Gruppe (Beam-Group, Tuplet).
+    BeatGroupMember,
+
+    // ── Sheetstorm: Scope (Direktiven) ──
+    /// Dynamik gilt von Note A bis Note B.
+    DynamicScope,
+    /// Tempo gilt von Note A bis Note B.
+    TempoScope,
+    /// Pedal-Markierung erstreckt sich von A bis B.
+    PedalScope,
+    /// Octava-Klammer (8va) verschiebt Pitches in Bereich.
+    OctaveScope,
+    /// Articulation propagiert über Slur (Legato-Group).
+    SlurArticulationPropagation,
+
+    // ── Sheetstorm: Struktur (Wiederholungen / Sprünge) ──
+    /// RepeatStart...RepeatEnd Block-Struktur.
+    RepeatBlock,
+    /// Volta-1 / Volta-2 Alternativ-Endung.
+    AlternateEnding,
+    /// Erster Takt ist Anacrusis (Auftakt).
+    Anacrusis,
+    /// Da Capo / Dal Segno Sprungmarken-Zielung.
+    DaCapo,
+    /// Dal Segno-Sprung von "$" zu Segno.
+    DalSegno,
+    /// Coda-Sprung von "To Coda" zu "Coda".
+    Coda,
+
+    // ── Sheetstorm: Cross-Staff / Multi-Voice ──
+    /// Klavier links/rechts Hand zur gleichen Zeit (Grand-Staff Alignment).
+    CrossStaff,
+    /// Stimme setzt sich über Takt-Grenzen fort.
+    VoiceContinuity,
+
+    // ── Sheetstorm: Cross-Part / Cross-Document ──
+    /// Trumpet-1 und Trumpet-2 desselben Stücks: Takt-Anzahl, Tempo, Tonart konsistent.
+    CrossPartAlignment,
+    /// Mehrere Kopien des gleichen PDFs hochgeladen → Consensus.
+    SamePieceConsensus,
+    /// Bekanntes Motif aus Library wiedererkannt.
+    MotifMatch,
+
+    // ── Sheetstorm: ML ──
+    /// Music-Language-Model bewertet Note im Kontext positiv.
+    LanguageModelSupport,
+    /// Mehrere Detektoren stimmen über Inter-Existenz überein.
+    DetectorAgreement,
+}
+
+/// Bei `Exclusion` — warum schließen sich die zwei Inters aus?
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ExclusionCause {
+    /// Beide Inters belegen denselben Pixel-Bereich.
+    BoundsOverlap,
+    /// Inters sind alternative Hypothesen für dasselbe Symbol.
+    AlternativeHypotheses,
+    /// Beide würden gleiche Voice an gleicher Position belegen.
+    VoiceConflict,
+    /// Ein Inter würde Konsistenz-Regel verletzen.
+    ConsistencyViolation,
+    /// Inkompatible Klassifikation (Head vs Beam an gleicher Stelle).
+    KindIncompatible,
+}
+
+/// Bei `Support` — welche Sub-Klasse von Unterstützung?
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum SupportKind {
+    /// Geometrische Nachbarschaft (z.B. Stem berührt Head).
+    Geometric,
+    /// Strukturelle/Musikalische Konsistenz.
+    Structural,
+    /// Theoretische Konsistenz (Tonart, Voice-Leading).
+    Theoretical,
+    /// ML-derived Support (Sequence-Model, Ensemble).
+    Machine,
+    /// Cross-Document Support (Multi-Part-Konsistenz).
+    Cross,
+}
+
+/// Multiplikative Beiträge zum Contextual Grade pro Richtung.
+///
+/// Audiveris-Konvention: jede Support-Edge liefert (`source_ratio`, `target_ratio`),
+/// jeweils ≥ 1.0. Ratio > 1.0 = positive Verstärkung, = 1.0 = neutral.
+///
+/// `contribution_for(target) = source_grade · (target_ratio - 1.0)`
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct SupportImpacts {
+    /// Multiplikator für `from`-Inter wenn `to` wahr ist.
+    pub source_ratio: f64,
+    /// Multiplikator für `to`-Inter wenn `from` wahr ist.
+    pub target_ratio: f64,
+    /// Sub-Klasse.
+    pub kind: SupportKind,
+}
+
+impl SupportImpacts {
+    /// Neutraler Support (wirkt nicht).
+    pub fn neutral() -> Self {
+        Self {
+            source_ratio: 1.0,
+            target_ratio: 1.0,
+            kind: SupportKind::Structural,
+        }
+    }
+    /// Symmetrischer Support: gleicher Multiplikator in beide Richtungen.
+    pub fn symmetric(ratio: f64, kind: SupportKind) -> Self {
+        Self {
+            source_ratio: ratio,
+            target_ratio: ratio,
+            kind,
+        }
+    }
+    /// Asymmetrischer Support.
+    pub fn asymmetric(source_ratio: f64, target_ratio: f64, kind: SupportKind) -> Self {
+        Self {
+            source_ratio,
+            target_ratio,
+            kind,
+        }
+    }
+}
+
+/// Eine Kante zwischen zwei (oder mehr) `Inter`s.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Relation {
+    /// Klassifikation.
+    pub kind: RelationKind,
+    /// Quell-Inter.
+    pub from: InterId,
+    /// Ziel-Inter.
+    pub to: InterId,
+    /// Zusätzliche Inters für n-äre Relations (z.B. Tuplet 3+ Notes).
+    pub extra: Vec<InterId>,
+    /// Variant: Exclusion ODER Support — entscheidet die Reduce-Logik.
+    pub variant: RelationVariant,
+    /// Wer hat diese Edge erzeugt?
+    pub provenance: Provenance,
+    /// Wenn `true`: User hat bestätigt (z.B. „diese 2 Heads gehören zu diesem Stem"),
+    /// überlebt jede Reduktion.
+    pub frozen: bool,
+}
+
+/// Diskriminator zwischen Exclusion und Support.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub enum RelationVariant {
+    /// Mutual Exclusion — beide Inters dürfen nicht koexistieren.
+    Exclusion(ExclusionCause),
+    /// Gegenseitige Verstärkung mit gegebenen Multiplikatoren.
+    Support(SupportImpacts),
+}
+
+impl Relation {
+    /// Erstellt eine Exclusion-Kante.
+    pub fn exclusion(
+        kind: RelationKind,
+        from: InterId,
+        to: InterId,
+        cause: ExclusionCause,
+    ) -> Self {
+        Self {
+            kind,
+            from,
+            to,
+            extra: Vec::new(),
+            variant: RelationVariant::Exclusion(cause),
+            provenance: Provenance::Detector,
+            frozen: false,
+        }
+    }
+    /// Erstellt eine Support-Kante.
+    pub fn support(
+        kind: RelationKind,
+        from: InterId,
+        to: InterId,
+        impacts: SupportImpacts,
+    ) -> Self {
+        Self {
+            kind,
+            from,
+            to,
+            extra: Vec::new(),
+            variant: RelationVariant::Support(impacts),
+            provenance: Provenance::Detector,
+            frozen: false,
+        }
+    }
+
+    /// Erweitert die `extra`-Liste um zusätzliche Inters (für n-äre Relations).
+    pub fn with_extra(mut self, extra: Vec<InterId>) -> Self {
+        self.extra = extra;
+        self
+    }
+    /// Markiert als User-bestätigt.
+    pub fn freeze(mut self) -> Self {
+        self.frozen = true;
+        self.provenance = Provenance::User;
+        self
+    }
+
+    /// Ist diese Kante ein Mutual-Exclusion-Constraint?
+    pub fn is_exclusion(&self) -> bool {
+        matches!(self.variant, RelationVariant::Exclusion(_))
+    }
+    /// Ist diese Kante eine Support-Verstärkung?
+    pub fn is_support(&self) -> bool {
+        matches!(self.variant, RelationVariant::Support(_))
+    }
+    /// Wenn Support: liefere die Impacts.
+    pub fn support_impacts(&self) -> Option<&SupportImpacts> {
+        match &self.variant {
+            RelationVariant::Support(s) => Some(s),
+            _ => None,
+        }
+    }
+    /// Wenn Exclusion: liefere die Cause.
+    pub fn exclusion_cause(&self) -> Option<ExclusionCause> {
+        match &self.variant {
+            RelationVariant::Exclusion(c) => Some(*c),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inter::InterId;
+
+    #[test]
+    fn exclusion_constructor_works() {
+        let r = Relation::exclusion(
+            RelationKind::HeadStem,
+            InterId(1),
+            InterId(2),
+            ExclusionCause::BoundsOverlap,
+        );
+        assert!(r.is_exclusion());
+        assert!(!r.is_support());
+        assert_eq!(r.exclusion_cause(), Some(ExclusionCause::BoundsOverlap));
+    }
+
+    #[test]
+    fn support_neutral_does_nothing() {
+        let s = SupportImpacts::neutral();
+        assert_eq!(s.source_ratio, 1.0);
+        assert_eq!(s.target_ratio, 1.0);
+    }
+
+    #[test]
+    fn support_with_impacts_is_support() {
+        let r = Relation::support(
+            RelationKind::HeadStem,
+            InterId(1),
+            InterId(2),
+            SupportImpacts::symmetric(1.5, SupportKind::Geometric),
+        );
+        assert!(r.is_support());
+        let s = r.support_impacts().unwrap();
+        assert_eq!(s.source_ratio, 1.5);
+        assert_eq!(s.target_ratio, 1.5);
+    }
+
+    #[test]
+    fn freeze_changes_provenance() {
+        let r = Relation::exclusion(
+            RelationKind::HeadStem,
+            InterId(1),
+            InterId(2),
+            ExclusionCause::BoundsOverlap,
+        )
+        .freeze();
+        assert!(r.frozen);
+        assert_eq!(r.provenance, Provenance::User);
+    }
+}

--- a/src/omr-rust/crates/omr-sig/src/sig.rs
+++ b/src/omr-rust/crates/omr-sig/src/sig.rs
@@ -1,0 +1,451 @@
+//! `Sig` — der Symbol Interpretation Graph.
+//!
+//! Verwaltet alle `Inter`s und `Relation`s. Bietet:
+//! - `add_inter()`, `remove_inter()`, `get()`, `get_mut()`
+//! - `add_relation()`, `remove_relation()`
+//! - `contextualize()` — berechnet Contextual Grade für alle Inters
+//! - `reduce()` — Fixpunkt-Loop zum Auflösen von Mutual-Exclusion-Konflikten
+//! - `query()` — Graph-Queries (filter by kind, system, measure, ...)
+//!
+//! Verwendet intern `petgraph::stable_graph::StableGraph` mit `InterId` als
+//! Knoten-Daten und `Relation` als Kanten-Daten.
+
+use crate::grade::{contextual_grade, Grade};
+use crate::inter::{Inter, InterId, InterKind};
+use crate::relation::{Relation, RelationKind, RelationVariant};
+use petgraph::graph::EdgeIndex;
+use petgraph::stable_graph::{NodeIndex, StableDiGraph};
+use petgraph::Direction;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use tracing::debug;
+
+/// Ergebnis eines `reduce()`-Aufrufs — wer wurde gelöscht, wer geschwächt.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct ReduceReport {
+    /// IDs gelöschter Inters.
+    pub removed_inters: Vec<InterId>,
+    /// IDs gelöschter Relations.
+    pub removed_relations: Vec<EdgeIndexSerde>,
+    /// Anzahl Fixpunkt-Iterationen.
+    pub iterations: u32,
+}
+
+/// Serializable wrapper für petgraph EdgeIndex.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct EdgeIndexSerde(pub usize);
+
+/// Hauptstruktur für den Symbol Interpretation Graph.
+pub struct Sig {
+    /// Petgraph-StableGraph: `NodeIndex` → InterId, `EdgeIndex` → Relation.
+    graph: StableDiGraph<InterId, Relation>,
+    /// Inter-Storage: InterId → Box<dyn Inter>.
+    inters: HashMap<InterId, Box<dyn Inter>>,
+    /// Reverse-Lookup: InterId → NodeIndex.
+    node_for_id: HashMap<InterId, NodeIndex>,
+    /// Nächste freie InterId.
+    next_id: u64,
+    /// Default-Threshold für `reduce()` — Inters unter diesem Grade werden gelöscht.
+    pub min_grade_threshold: f64,
+}
+
+impl Default for Sig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for Sig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Sig")
+            .field("inters", &self.inters.len())
+            .field("relations", &self.graph.edge_count())
+            .field("min_grade_threshold", &self.min_grade_threshold)
+            .finish()
+    }
+}
+
+impl Sig {
+    /// Erstellt einen leeren SIG.
+    pub fn new() -> Self {
+        Self {
+            graph: StableDiGraph::new(),
+            inters: HashMap::new(),
+            node_for_id: HashMap::new(),
+            next_id: 1,
+            min_grade_threshold: 0.20, // Audiveris-default
+        }
+    }
+
+    /// Vergebene Inter-Anzahl.
+    pub fn inter_count(&self) -> usize {
+        self.inters.len()
+    }
+
+    /// Vergebene Relation-Anzahl.
+    pub fn relation_count(&self) -> usize {
+        self.graph.edge_count()
+    }
+
+    /// Erzeugt eine neue, monoton steigende `InterId`.
+    pub fn next_inter_id(&mut self) -> InterId {
+        let id = InterId(self.next_id);
+        self.next_id += 1;
+        id
+    }
+
+    /// Fügt einen `Inter` hinzu. Übergibt eine Box<dyn Inter> mit bereits
+    /// gesetzter `InterId` (per `next_inter_id()`).
+    ///
+    /// Panics wenn die ID bereits vergeben ist.
+    pub fn add_inter(&mut self, inter: Box<dyn Inter>) -> InterId {
+        let id = inter.id();
+        assert!(
+            !self.inters.contains_key(&id),
+            "InterId {} already in SIG",
+            id
+        );
+        let node_idx = self.graph.add_node(id);
+        self.node_for_id.insert(id, node_idx);
+        self.inters.insert(id, inter);
+        id
+    }
+
+    /// Liefert immutable-Reference zum Inter.
+    pub fn get(&self, id: InterId) -> Option<&dyn Inter> {
+        self.inters.get(&id).map(|b| b.as_ref())
+    }
+
+    /// Liefert mutable-Reference zum Inter.
+    pub fn get_mut(&mut self, id: InterId) -> Option<&mut Box<dyn Inter>> {
+        self.inters.get_mut(&id)
+    }
+
+    /// Entfernt Inter und alle eingehenden/ausgehenden Relations.
+    /// Frozen-Inters können nur per `force=true` entfernt werden.
+    pub fn remove_inter(&mut self, id: InterId, force: bool) -> Option<Box<dyn Inter>> {
+        let frozen = self.get(id).map(|i| i.is_frozen()).unwrap_or(false);
+        if frozen && !force {
+            return None;
+        }
+        let node_idx = self.node_for_id.remove(&id)?;
+        self.graph.remove_node(node_idx);
+        self.inters.remove(&id)
+    }
+
+    /// Fügt eine `Relation` hinzu. Beide Endpunkte müssen im SIG existieren.
+    pub fn add_relation(&mut self, relation: Relation) -> Option<EdgeIndex> {
+        let from_node = *self.node_for_id.get(&relation.from)?;
+        let to_node = *self.node_for_id.get(&relation.to)?;
+        Some(self.graph.add_edge(from_node, to_node, relation))
+    }
+
+    /// Iterator über alle `Inter`s.
+    pub fn inters(&self) -> impl Iterator<Item = &dyn Inter> + '_ {
+        self.inters.values().map(|b| b.as_ref())
+    }
+
+    /// Iterator über alle `Inter`s einer bestimmten `InterKind`.
+    pub fn inters_of_kind(&self, kind: InterKind) -> impl Iterator<Item = &dyn Inter> + '_ {
+        self.inters().filter(move |i| i.kind() == kind)
+    }
+
+    /// Iterator über alle `Relation`s.
+    pub fn relations(&self) -> impl Iterator<Item = &Relation> + '_ {
+        self.graph.edge_indices().filter_map(move |e| self.graph.edge_weight(e))
+    }
+
+    /// Iterator über Relationen eines spezifischen Kinds.
+    pub fn relations_of_kind(&self, kind: RelationKind) -> impl Iterator<Item = &Relation> + '_ {
+        self.relations().filter(move |r| r.kind == kind)
+    }
+
+    /// Wer ist mit diesem Inter über Support-Edges verbunden? Liefert Partner-IDs.
+    pub fn support_partners(&self, id: InterId) -> Vec<InterId> {
+        let Some(&node) = self.node_for_id.get(&id) else { return Vec::new(); };
+        let mut out = Vec::new();
+        for dir in [Direction::Outgoing, Direction::Incoming] {
+            for e in self.graph.edges_directed(node, dir) {
+                let r = e.weight();
+                if !r.is_support() {
+                    continue;
+                }
+                let partner_id = if r.from == id { r.to } else { r.from };
+                if !out.contains(&partner_id) {
+                    out.push(partner_id);
+                }
+            }
+        }
+        out
+    }
+
+    /// Wer steht mit diesem Inter im Mutual-Exclusion-Konflikt?
+    pub fn exclusion_partners(&self, id: InterId) -> Vec<InterId> {
+        let Some(&node) = self.node_for_id.get(&id) else { return Vec::new(); };
+        let mut out = Vec::new();
+        for dir in [Direction::Outgoing, Direction::Incoming] {
+            for e in self.graph.edges_directed(node, dir) {
+                let r = e.weight();
+                if !r.is_exclusion() {
+                    continue;
+                }
+                let partner_id = if r.from == id { r.to } else { r.from };
+                if !out.contains(&partner_id) {
+                    out.push(partner_id);
+                }
+            }
+        }
+        out
+    }
+
+    /// Berechnet den Contextual Grade für jeden Inter.
+    ///
+    /// Audiveris-Formel:
+    /// `contribution = Σ partner.grade · (target_ratio - 1.0)` über alle
+    /// Support-Edges
+    /// `cg = (1 + contribution) · g / (1 + contribution · g)`
+    ///
+    /// Mutual-Exclusion-Partner werden NICHT als Beiträger gezählt (best-of-partition).
+    pub fn contextualize(&mut self) {
+        let mut new_cg: HashMap<InterId, Grade> = HashMap::new();
+        // Snapshot der intrinsics und Edges um borrow conflicts zu vermeiden
+        let inter_ids: Vec<InterId> = self.inters.keys().copied().collect();
+        for id in inter_ids {
+            let intrinsic = self.get(id).map(|i| i.grade()).unwrap_or(Grade::unknown());
+            let node = match self.node_for_id.get(&id) {
+                Some(n) => *n,
+                None => continue,
+            };
+            let mut contribution = 0.0;
+            for dir in [Direction::Outgoing, Direction::Incoming] {
+                for e in self.graph.edges_directed(node, dir) {
+                    let r = e.weight();
+                    let RelationVariant::Support(impacts) = &r.variant else {
+                        continue;
+                    };
+                    // Direction matters: target_ratio gilt FÜR den Empfänger
+                    let (partner_id, ratio) = if r.from == id {
+                        (r.to, impacts.source_ratio)
+                    } else {
+                        (r.from, impacts.target_ratio)
+                    };
+                    let partner_g = self.get(partner_id).map(|i| i.grade().value()).unwrap_or(0.0);
+                    contribution += partner_g * (ratio - 1.0).max(0.0);
+                }
+            }
+            let cg = contextual_grade(intrinsic, contribution);
+            new_cg.insert(id, cg);
+        }
+        // Apply
+        for (id, cg) in new_cg {
+            if let Some(inter) = self.inters.get_mut(&id) {
+                inter.meta_mut().contextual = Some(cg);
+            }
+        }
+    }
+
+    /// Greedy-Konflikt-Auflösung wie Audiveris `SigReducer`.
+    ///
+    /// Algorithmus (vereinfacht):
+    /// 1. `contextualize()` neu berechnen
+    /// 2. Für jeden Mutual-Exclusion-Konflikt: behalte den Inter mit höherem
+    ///    `effective_grade`, lösche den Verlierer (außer er ist `frozen`).
+    /// 3. Lösche Inters mit `effective_grade < min_grade_threshold` (außer frozen).
+    /// 4. Wiederhole bis Fixpunkt erreicht.
+    ///
+    /// Returns Report mit gelöschten IDs.
+    pub fn reduce(&mut self) -> ReduceReport {
+        let mut report = ReduceReport::default();
+        let max_iterations = 50;
+        for iter in 0..max_iterations {
+            self.contextualize();
+            let mut changed = false;
+
+            // 1) Mutual-Exclusion-Resolver: pro Konfliktpaar Verlierer löschen.
+            let mut to_remove: Vec<InterId> = Vec::new();
+            let inter_ids: Vec<InterId> = self.inters.keys().copied().collect();
+            for id in &inter_ids {
+                let inter_grade = self.get(*id).map(|i| i.effective_grade().value()).unwrap_or(0.0);
+                let inter_frozen = self.get(*id).map(|i| i.is_frozen()).unwrap_or(false);
+                if to_remove.contains(id) {
+                    continue;
+                }
+                for partner in self.exclusion_partners(*id) {
+                    if to_remove.contains(&partner) {
+                        continue;
+                    }
+                    let p_grade = self.get(partner).map(|i| i.effective_grade().value()).unwrap_or(0.0);
+                    let p_frozen = self.get(partner).map(|i| i.is_frozen()).unwrap_or(false);
+                    if inter_frozen && p_frozen {
+                        // Beide frozen → kein Reduce, keep both (Audiveris-Verhalten:
+                        // User-Konflikt soll explizit gemeldet werden, nicht automatisch
+                        // aufgelöst). Hier akzeptieren wir den Zustand.
+                        continue;
+                    }
+                    if inter_frozen {
+                        to_remove.push(partner);
+                        continue;
+                    }
+                    if p_frozen {
+                        to_remove.push(*id);
+                        break;
+                    }
+                    // Beide nicht-frozen: behalte den mit höherem effective_grade.
+                    if inter_grade < p_grade {
+                        to_remove.push(*id);
+                        break;
+                    } else if p_grade < inter_grade {
+                        to_remove.push(partner);
+                    }
+                    // Bei Gleichstand: behalte beide (stabiles Verhalten).
+                }
+            }
+            for id in &to_remove {
+                if self.remove_inter(*id, false).is_some() {
+                    report.removed_inters.push(*id);
+                    changed = true;
+                }
+            }
+
+            // 2) Threshold-Filter (für nicht-frozen Inters).
+            let mut threshold_kills: Vec<InterId> = Vec::new();
+            for id in self.inters.keys().copied().collect::<Vec<_>>() {
+                let inter = match self.get(id) {
+                    Some(i) => i,
+                    None => continue,
+                };
+                if inter.is_frozen() {
+                    continue;
+                }
+                if inter.effective_grade().value() < self.min_grade_threshold {
+                    threshold_kills.push(id);
+                }
+            }
+            for id in &threshold_kills {
+                if self.remove_inter(*id, false).is_some() {
+                    report.removed_inters.push(*id);
+                    changed = true;
+                }
+            }
+
+            if !changed {
+                report.iterations = iter + 1;
+                debug!(iterations = iter + 1, "Sig::reduce reached fixpoint");
+                return report;
+            }
+        }
+        report.iterations = max_iterations;
+        debug!("Sig::reduce hit max_iterations safety-cap");
+        report
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::grade::Grade;
+    use crate::inter::{Inter, InterId, InterKind, InterMeta};
+    use crate::relation::{ExclusionCause, Relation, SupportImpacts, SupportKind};
+    use omr_core::Rect;
+
+    #[derive(Debug)]
+    struct TestInter {
+        meta: InterMeta,
+    }
+    impl Inter for TestInter {
+        fn meta(&self) -> &InterMeta {
+            &self.meta
+        }
+        fn meta_mut(&mut self) -> &mut InterMeta {
+            &mut self.meta
+        }
+    }
+
+    fn mk_inter(sig: &mut Sig, kind: InterKind, grade: f64) -> InterId {
+        let id = sig.next_inter_id();
+        let bounds = Rect { x: 0, y: 0, w: 1, h: 1 };
+        let meta = InterMeta::new(id, kind, bounds, Grade::new(grade));
+        sig.add_inter(Box::new(TestInter { meta }))
+    }
+
+    #[test]
+    fn add_and_get_inter() {
+        let mut sig = Sig::new();
+        let id = mk_inter(&mut sig, InterKind::Head, 0.8);
+        assert_eq!(sig.inter_count(), 1);
+        let inter = sig.get(id).unwrap();
+        assert_eq!(inter.kind(), InterKind::Head);
+        assert!((inter.grade().value() - 0.8).abs() < 1e-9);
+    }
+
+    #[test]
+    fn exclusion_kills_lower_grade() {
+        let mut sig = Sig::new();
+        let strong = mk_inter(&mut sig, InterKind::Head, 0.9);
+        let weak = mk_inter(&mut sig, InterKind::Head, 0.4);
+        sig.add_relation(Relation::exclusion(
+            RelationKind::HeadStem,
+            strong,
+            weak,
+            ExclusionCause::BoundsOverlap,
+        ));
+        let report = sig.reduce();
+        assert!(report.removed_inters.contains(&weak));
+        assert!(!report.removed_inters.contains(&strong));
+        assert_eq!(sig.inter_count(), 1);
+    }
+
+    #[test]
+    fn frozen_inter_survives_exclusion_against_higher_grade() {
+        let mut sig = Sig::new();
+        // Frozen weak inter
+        let weak_id_holder = {
+            let id = sig.next_inter_id();
+            let bounds = Rect { x: 0, y: 0, w: 1, h: 1 };
+            let mut meta = InterMeta::new(id, InterKind::Head, bounds, Grade::new(0.4));
+            meta = meta.freeze();
+            sig.add_inter(Box::new(TestInter { meta }));
+            id
+        };
+        let strong = mk_inter(&mut sig, InterKind::Head, 0.9);
+        sig.add_relation(Relation::exclusion(
+            RelationKind::HeadStem,
+            weak_id_holder,
+            strong,
+            ExclusionCause::BoundsOverlap,
+        ));
+        sig.reduce();
+        // Frozen weak survives, strong gets killed
+        assert!(sig.get(weak_id_holder).is_some());
+        assert!(sig.get(strong).is_none());
+    }
+
+    #[test]
+    fn support_raises_contextual_grade() {
+        let mut sig = Sig::new();
+        let head = mk_inter(&mut sig, InterKind::Head, 0.6);
+        let stem = mk_inter(&mut sig, InterKind::Stem, 0.6);
+        sig.add_relation(Relation::support(
+            RelationKind::HeadStem,
+            head,
+            stem,
+            SupportImpacts::symmetric(2.0, SupportKind::Geometric),
+        ));
+        sig.contextualize();
+        let head_cg = sig.get(head).unwrap().effective_grade().value();
+        // ohne support: 0.6, mit support sollte > 0.6 sein
+        assert!(head_cg > 0.6, "contextual {} should exceed intrinsic 0.6", head_cg);
+    }
+
+    #[test]
+    fn threshold_kills_weak_inter() {
+        let mut sig = Sig::new();
+        sig.min_grade_threshold = 0.50;
+        let weak = mk_inter(&mut sig, InterKind::Head, 0.10);
+        let strong = mk_inter(&mut sig, InterKind::Head, 0.85);
+        sig.reduce();
+        assert!(sig.get(weak).is_none());
+        assert!(sig.get(strong).is_some());
+    }
+}


### PR DESCRIPTION
## Zusammenfassung

Implementiert U-Net-basiertes Staff-Removal als opt-in Feature in der OMR-Pipeline.

## Aenderungen

### Trainingspipeline
- **generate_unet_training_data.py**: Verovio+Inkscape + PrIMuS-Kachelung, Python-RLE Pseudo-GT, 800 Patch-Paare
- **train_staff_unet.py**: Windows num_workers=0 Fix, stdout-Buffering Fix
- **export_onnx.py**: StaffRemovalUNet + export_unet(), --model unet, ONNX-Data-Merge

### Modell
- **staff-unet.onnx**: 4-Level U-Net, ~250k Params, 8 Epochen, Loss 0.022, opset 18, 1.95 MB

### Integration
- **omr-server/main.rs**: OMR_UNET_MODEL Env-Var in PipelineOptions
- **Dockerfile**: ARG ENABLE_UNET=0, kombinierte Build-Logik, COPY assets/

## Tests
- cargo test -p omr-staff: 1 passed
- cargo test -p omr-pipeline: 4 passed

## Bekannte Einschraenkungen
- --features unet lokal nicht testbar (fehlendes dlltool.exe - vorbestehendes Problem)
- Feature kompiliert/laeuft nur in Docker/Linux via tract-onnx