### PR TITLE
feat(omr-sig): Phase 2 — Inter-Typen, Pipeline-Integration, Music-Theory-Edges

### DIFF
--- a/src/omr-rust/Cargo.lock
+++ b/src/omr-rust/Cargo.lock
@@ -1508,6 +1508,7 @@ dependencies = [
  "omr-core",
  "omr-musicxml",
  "omr-preprocessing",
+ "omr-sig",
  "omr-staff",
  "omr-symbols",
  "pdfium-render",

--- a/src/omr-rust/crates/omr-pipeline/Cargo.toml
+++ b/src/omr-rust/crates/omr-pipeline/Cargo.toml
@@ -10,6 +10,7 @@ omr-preprocessing.workspace = true
 omr-staff.workspace = true
 omr-symbols.workspace = true
 omr-musicxml.workspace = true
+omr-sig.workspace = true
 image.workspace = true
 imageproc.workspace = true
 tracing.workspace = true

--- a/src/omr-rust/crates/omr-pipeline/src/lib.rs
+++ b/src/omr-rust/crates/omr-pipeline/src/lib.rs
@@ -14,6 +14,7 @@ pub mod debug_viz;
 pub mod detections;
 pub mod muscima;
 pub mod pdf_render;
+pub mod sig_integration;
 pub mod synthetic;
 
 /// Eingebettetes vortrainiertes Klassifikator-Modell.

--- a/src/omr-rust/crates/omr-pipeline/src/sig_integration.rs
+++ b/src/omr-rust/crates/omr-pipeline/src/sig_integration.rs
@@ -1,0 +1,197 @@
+//! SIG-Integration für die Sheetstorm-OMR-Pipeline.
+//!
+//! Übersetzt eine `DetectionPage` (Output der bestehenden Pipeline) in einen
+//! `omr_sig::Sig` mit Inter-Knoten und Support-/Exclusion-Edges.
+//!
+//! Das ist die Schnittstelle, die spätere Iterationen erweitern werden um:
+//! - Music-Theory-Edges (Key-Consistency, Voice-Leading, MeasureBudget)
+//! - User-Edits aus dem Op-Log
+//! - ML-derived Edges (Music-Language-Model, Detector-Ensemble)
+//!
+//! Aktuell: minimaler "1:1"-Build der bestehenden Detections in einen SIG.
+
+use omr_core::{Notehead, NoteheadKind, Stem};
+use omr_sig::{Sig, SigBuilder};
+
+use crate::detections::DetectionPage;
+
+fn parse_kind(s: &str) -> NoteheadKind {
+    match s {
+        "Open" => NoteheadKind::Open,
+        "Whole" => NoteheadKind::Whole,
+        _ => NoteheadKind::Filled,
+    }
+}
+
+/// Minimaler Detection-Page → Sig Adapter.
+///
+/// Erzeugt einen frischen `Sig` mit:
+/// - Allen Noteheads als `HeadInter`
+/// - Allen Stems als `StemInter`
+/// - Allen Beams als `BeamInter`
+/// - Allen Bars als `BarInter`
+/// - HeadStem-Support-Edges (Audiveris-Heuristik: stem.x ≈ head.cx, y-overlap)
+/// - BeamStem-Support-Edges (stem-y enthält beam-y)
+///
+/// Anschließend wird `contextualize()` aufgerufen.
+pub fn build_sig_from_page(page: &DetectionPage) -> Sig {
+    let mut sig = Sig::new();
+
+    // Convert DetectionPage entries zurück in omr-core Strukturen.
+    let noteheads: Vec<Notehead> = page
+        .noteheads
+        .iter()
+        .map(|nh| Notehead {
+            bbox: omr_core::Rect {
+                x: nh.bbox[0],
+                y: nh.bbox[1],
+                w: nh.bbox[2],
+                h: nh.bbox[3],
+            },
+            center: omr_core::Point {
+                x: nh.center[0],
+                y: nh.center[1],
+            },
+            confidence: nh.confidence,
+            kind: parse_kind(nh.kind),
+            staff_idx: nh.system_idx as usize,
+        })
+        .collect();
+
+    let stems: Vec<Stem> = page
+        .stems
+        .iter()
+        .map(|s| Stem {
+            x: s.x,
+            y_top: s.y_top,
+            y_bot: s.y_bot,
+            notehead_idx: s.notehead_id.map(|i| i as usize),
+        })
+        .collect();
+
+    // Beams: bbox = [x, y, w, h]. Convert to (x_start, x_end, y_top, y_bot, level).
+    // Default-Level ist 1 (Achtel) — exakter Level kommt später aus stems.beam_count.
+    let beams: Vec<(u32, u32, u32, u32, u8)> = page
+        .beams
+        .iter()
+        .map(|b| {
+            let x_start = b.bbox[0];
+            let y_top = b.bbox[1];
+            let x_end = x_start + b.bbox[2];
+            let y_bot = y_top + b.bbox[3];
+            (x_start, x_end, y_top, y_bot, 1u8)
+        })
+        .collect();
+
+    let bars: Vec<(u32, u32)> = page
+        .bars
+        .iter()
+        .map(|b| (b.x, b.system_idx))
+        .collect();
+
+    let _ = SigBuilder::new(page.line_spacing)
+        .add_noteheads(&mut sig, &noteheads)
+        .add_stems(&mut sig, &stems)
+        .add_beams(&mut sig, &beams)
+        .add_bars(&mut sig, &bars)
+        .link_head_stem(&mut sig)
+        .link_beam_stem(&mut sig);
+
+    sig.contextualize();
+    sig
+}
+
+/// Schaut sich die Sig-Statistik an und produziert einen kompakten Summary-
+/// String für Debug-Output.
+pub fn sig_summary(sig: &Sig) -> String {
+    use omr_sig::InterKind;
+    let total = sig.inter_count();
+    let n_heads = sig.inters_of_kind(InterKind::Head).count();
+    let n_stems = sig.inters_of_kind(InterKind::Stem).count();
+    let n_beams = sig.inters_of_kind(InterKind::Beam).count();
+    let n_bars = sig.inters_of_kind(InterKind::Bar).count();
+    let n_relations = sig.relation_count();
+    format!(
+        "Sig({} inters: {}H + {}S + {}Beam + {}Bar | {} relations)",
+        total, n_heads, n_stems, n_beams, n_bars, n_relations
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::detections::{
+        BarEntry, BeamEntry, DetectionPage, NoteheadEntry, StemEntry,
+    };
+
+    fn empty_page() -> DetectionPage {
+        DetectionPage {
+            page_index: 0,
+            width: 1000,
+            height: 1000,
+            line_spacing: 10.0,
+            line_thickness: 1.0,
+            deskew_angle_deg: 0.0,
+            staff_systems: vec![],
+            noteheads: vec![],
+            stems: vec![],
+            beams: vec![],
+            bars: vec![],
+            measures: vec![],
+            clefs: vec![],
+            key_signatures: vec![],
+            time_signatures: vec![],
+            jump_marks: vec![],
+            rests: vec![],
+            slurs: vec![],
+            reading_stream: None,
+        }
+    }
+
+    #[test]
+    fn empty_page_produces_empty_sig() {
+        let page = empty_page();
+        let sig = build_sig_from_page(&page);
+        assert_eq!(sig.inter_count(), 0);
+        assert_eq!(sig.relation_count(), 0);
+    }
+
+    #[test]
+    fn page_with_head_and_stem_links_them() {
+        let mut page = empty_page();
+        page.noteheads.push(NoteheadEntry {
+            id: 0,
+            bbox: [100, 200, 8, 6],
+            center: [104.0, 203.0],
+            kind: "Filled",
+            system_idx: 0,
+            confidence: 0.9,
+            midi: None,
+            step: None,
+            alter: None,
+            octave: None,
+            duration: None,
+            augmentation_dots: None,
+            measure_number: None,
+            in_chord: None,
+            is_rest: None,
+            stem_id: None,
+        });
+        page.stems.push(StemEntry {
+            id: 0,
+            x: 104,
+            y_top: 180,
+            y_bot: 230,
+            notehead_id: Some(0),
+        });
+        let sig = build_sig_from_page(&page);
+        // 1 Head + 1 Stem = 2 Inters
+        assert_eq!(sig.inter_count(), 2);
+        // 1 HeadStem-Relation
+        assert_eq!(sig.relation_count(), 1);
+        // Contextual grades sollen erhöht sein
+        for inter in sig.inters() {
+            assert!(inter.effective_grade().value() >= inter.grade().value());
+        }
+    }
+}

--- a/src/omr-rust/crates/omr-sig/src/builder.rs
+++ b/src/omr-rust/crates/omr-sig/src/builder.rs
@@ -1,0 +1,303 @@
+//! `SigBuilder` — Konstruktion eines `Sig` aus den Outputs der bestehenden
+//! Detektoren.
+//!
+//! Diese Crate ist die Bridge zwischen der bestehenden Pipeline (Notehead,
+//! Stem, Beam, MeasureBar, ...) und der SIG-Architektur. Sie übersetzt
+//! Detektor-Resultate in `Inter`-Knoten und fügt Support-/Exclusion-Edges
+//! basierend auf geometrischen Heuristiken hinzu.
+//!
+//! Verwendung:
+//! ```ignore
+//! let mut sig = Sig::new();
+//! let builder = SigBuilder::new(line_spacing);
+//! builder
+//!     .add_noteheads(&mut sig, &noteheads)
+//!     .add_stems(&mut sig, &stems)
+//!     .add_beams(&mut sig, &beams)
+//!     .add_bars(&mut sig, &bars)
+//!     .link_head_stem(&mut sig)
+//!     .link_beam_stem(&mut sig);
+//! sig.contextualize();
+//! ```
+
+use omr_core::{Notehead, Stem};
+
+use crate::grade::Grade;
+use crate::inter::{Inter, InterId, InterKind};
+use crate::inters::{BarInter, BeamInter, HeadInter, StemInter};
+use crate::relation::{Relation, RelationKind, SupportImpacts, SupportKind};
+use crate::sig::Sig;
+
+/// Builder zum Aufbau eines SIG aus Detektor-Resultaten.
+pub struct SigBuilder {
+    /// Erwartete Stafflinien-Distanz in Pixeln (für Geometrie-Toleranzen).
+    pub line_spacing: f32,
+    /// Maximaler X-Versatz Stem ↔ Head (in Pixeln).
+    pub head_stem_max_dx: f32,
+    /// Maximaler Beam ↔ Stem y-Distance (in Pixeln).
+    pub beam_stem_max_dy: f32,
+
+    // Internal: maps für linkup-step
+    head_id_per_orig: Vec<InterId>,
+    stem_id_per_orig: Vec<InterId>,
+    beam_id_per_orig: Vec<InterId>,
+}
+
+impl SigBuilder {
+    /// Erstellt einen neuen Builder mit Standard-Heuristiken.
+    pub fn new(line_spacing: f32) -> Self {
+        Self {
+            line_spacing,
+            head_stem_max_dx: line_spacing.max(8.0),
+            beam_stem_max_dy: line_spacing * 0.6,
+            head_id_per_orig: Vec::new(),
+            stem_id_per_orig: Vec::new(),
+            beam_id_per_orig: Vec::new(),
+        }
+    }
+
+    /// Fügt alle Noteheads als `HeadInter` zum SIG hinzu. Behält den Index
+    /// für spätere Linkup-Operationen.
+    pub fn add_noteheads(mut self, sig: &mut Sig, noteheads: &[Notehead]) -> Self {
+        self.head_id_per_orig.clear();
+        for nh in noteheads {
+            let id = sig.next_inter_id();
+            let head = HeadInter::from_notehead(id, nh);
+            self.head_id_per_orig.push(sig.add_inter(Box::new(head)));
+        }
+        self
+    }
+
+    /// Fügt alle Stems als `StemInter` hinzu. Stem-Confidence wird konstant
+    /// auf 0.85 gesetzt, kann später per Detektor variiert werden.
+    pub fn add_stems(mut self, sig: &mut Sig, stems: &[Stem]) -> Self {
+        self.stem_id_per_orig.clear();
+        for stem in stems {
+            let id = sig.next_inter_id();
+            let si = StemInter::from_stem(id, stem, Grade::new(0.85));
+            self.stem_id_per_orig.push(sig.add_inter(Box::new(si)));
+        }
+        self
+    }
+
+    /// Fügt Beams als `BeamInter` hinzu. Erwartet (x_start, x_end, y_top, y_bot, level).
+    pub fn add_beams(
+        mut self,
+        sig: &mut Sig,
+        beams: &[(u32, u32, u32, u32, u8)],
+    ) -> Self {
+        self.beam_id_per_orig.clear();
+        for &(x_start, x_end, y_top, y_bot, level) in beams {
+            let id = sig.next_inter_id();
+            let bi = BeamInter::new(id, x_start, x_end, y_top, y_bot, level, Grade::new(0.80));
+            self.beam_id_per_orig.push(sig.add_inter(Box::new(bi)));
+        }
+        self
+    }
+
+    /// Fügt Taktstriche hinzu. Erwartet (x, system_idx).
+    pub fn add_bars(self, sig: &mut Sig, bars: &[(u32, u32)]) -> Self {
+        for &(x, system_idx) in bars {
+            let id = sig.next_inter_id();
+            let bi = BarInter::new(id, x, system_idx, Grade::new(0.90));
+            sig.add_inter(Box::new(bi));
+        }
+        self
+    }
+
+    /// Fügt `HeadStem`-Support-Edges hinzu: für jedes Stem das nächst-passende
+    /// NH (innerhalb `head_stem_max_dx`) wird verbunden.
+    ///
+    /// Audiveris-typischer Support-Multiplikator: 1.5 (Geometric).
+    pub fn link_head_stem(self, sig: &mut Sig) -> Self {
+        // Sammle Pairs (head_id, stem_id, distance) und nimm jeweils das beste.
+        let mut pairs: Vec<(InterId, InterId, f32)> = Vec::new();
+        let head_ids: Vec<(InterId, f32, f32, u32, u32)> = self
+            .head_id_per_orig
+            .iter()
+            .filter_map(|&id| {
+                let h = sig.get(id)?;
+                if h.kind() != InterKind::Head { return None; }
+                let bb = h.bounds();
+                Some((id, bb.cx(), bb.cy(), bb.x, bb.y + bb.h))
+            })
+            .collect();
+
+        for &stem_id in &self.stem_id_per_orig {
+            let stem = match sig.get(stem_id) {
+                Some(s) if s.kind() == InterKind::Stem => s,
+                _ => continue,
+            };
+            let stem_bb = stem.bounds();
+            let stem_cx = stem_bb.cx();
+            // Find closest head whose center.x is near stem.x AND whose y-bbox
+            // touches stem's y-range.
+            let mut best: Option<(InterId, f32)> = None;
+            for &(head_id, hcx, hcy, _hx, _hyb) in &head_ids {
+                let dx = (hcx - stem_cx).abs();
+                if dx > self.head_stem_max_dx {
+                    continue;
+                }
+                // Y must overlap stem range (head between top and bot).
+                if (hcy as u32) < stem_bb.y || (hcy as u32) > stem_bb.y + stem_bb.h {
+                    continue;
+                }
+                if best.map(|(_, d)| dx < d).unwrap_or(true) {
+                    best = Some((head_id, dx));
+                }
+            }
+            if let Some((head_id, dist)) = best {
+                pairs.push((head_id, stem_id, dist));
+            }
+        }
+        for (head_id, stem_id, _) in pairs {
+            sig.add_relation(Relation::support(
+                RelationKind::HeadStem,
+                head_id,
+                stem_id,
+                SupportImpacts::asymmetric(1.5, 1.5, SupportKind::Geometric),
+            ));
+        }
+        self
+    }
+
+    /// Fügt `BeamStem`-Support-Edges hinzu: jedes Stem dessen Y-Range einen
+    /// Beam überlappt UND dessen X im Beam-Bereich liegt → Edge.
+    pub fn link_beam_stem(self, sig: &mut Sig) -> Self {
+        let mut pairs: Vec<(InterId, InterId)> = Vec::new();
+        let beams: Vec<(InterId, u32, u32, u32, u32)> = self
+            .beam_id_per_orig
+            .iter()
+            .filter_map(|&id| {
+                let b = sig.get(id)?;
+                if b.kind() != InterKind::Beam { return None; }
+                let bb = b.bounds();
+                Some((id, bb.x, bb.x + bb.w, bb.y, bb.y + bb.h))
+            })
+            .collect();
+
+        for &stem_id in &self.stem_id_per_orig {
+            let stem = match sig.get(stem_id) {
+                Some(s) if s.kind() == InterKind::Stem => s,
+                _ => continue,
+            };
+            let stem_bb = stem.bounds();
+            let sx = (stem_bb.cx()) as u32;
+            for &(beam_id, x_start, x_end, y_top, y_bot) in &beams {
+                if sx < x_start || sx > x_end {
+                    continue;
+                }
+                // Beam-Y-Range muss innerhalb Stem-Y-Range liegen.
+                let stem_top = stem_bb.y;
+                let stem_bot = stem_bb.y + stem_bb.h;
+                let beam_in_stem = y_top >= stem_top.saturating_sub(2)
+                    && y_bot <= stem_bot.saturating_add(2);
+                if beam_in_stem {
+                    pairs.push((beam_id, stem_id));
+                }
+            }
+        }
+        for (beam_id, stem_id) in pairs {
+            sig.add_relation(Relation::support(
+                RelationKind::BeamStem,
+                beam_id,
+                stem_id,
+                SupportImpacts::symmetric(1.4, SupportKind::Geometric),
+            ));
+        }
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use omr_core::{Notehead, NoteheadKind, Point, Rect, Stem};
+
+    fn make_nh(x: u32, y: u32, conf: f32) -> Notehead {
+        Notehead {
+            bbox: Rect { x, y, w: 8, h: 6 },
+            center: Point { x: x as f32 + 4.0, y: y as f32 + 3.0 },
+            confidence: conf,
+            kind: NoteheadKind::Filled,
+            staff_idx: 0,
+        }
+    }
+
+    #[test]
+    fn builder_adds_head_inters() {
+        let mut sig = Sig::new();
+        let nhs = vec![make_nh(10, 20, 0.9), make_nh(30, 20, 0.8)];
+        let _ = SigBuilder::new(10.0).add_noteheads(&mut sig, &nhs);
+        assert_eq!(sig.inter_count(), 2);
+        let heads: Vec<_> = sig.inters_of_kind(InterKind::Head).collect();
+        assert_eq!(heads.len(), 2);
+    }
+
+    #[test]
+    fn link_head_stem_creates_support_edge() {
+        let mut sig = Sig::new();
+        // NH at (10,20) with bbox 10..18 / 20..26 — center (14, 23)
+        // Stem at x=14, y_top=10, y_bot=30 — covers NH y-range
+        let nhs = vec![make_nh(10, 20, 0.9)];
+        let stems = vec![Stem { x: 14, y_top: 10, y_bot: 30, notehead_idx: None }];
+        let _ = SigBuilder::new(10.0)
+            .add_noteheads(&mut sig, &nhs)
+            .add_stems(&mut sig, &stems)
+            .link_head_stem(&mut sig);
+        let head_stem_rels: Vec<_> = sig.relations_of_kind(RelationKind::HeadStem).collect();
+        assert_eq!(head_stem_rels.len(), 1);
+        assert!(head_stem_rels[0].is_support());
+    }
+
+    #[test]
+    fn link_head_stem_skips_distant_pairs() {
+        let mut sig = Sig::new();
+        // NH at (10, 20) center (14, 23)
+        // Stem far away at x=200 — should NOT link
+        let nhs = vec![make_nh(10, 20, 0.9)];
+        let stems = vec![Stem { x: 200, y_top: 10, y_bot: 30, notehead_idx: None }];
+        let _ = SigBuilder::new(10.0)
+            .add_noteheads(&mut sig, &nhs)
+            .add_stems(&mut sig, &stems)
+            .link_head_stem(&mut sig);
+        let head_stem_rels: Vec<_> = sig.relations_of_kind(RelationKind::HeadStem).collect();
+        assert_eq!(head_stem_rels.len(), 0);
+    }
+
+    #[test]
+    fn link_beam_stem_creates_edges() {
+        let mut sig = Sig::new();
+        // Two stems at x=20 and x=40, both running y=5..40
+        let stems = vec![
+            Stem { x: 20, y_top: 5, y_bot: 40, notehead_idx: None },
+            Stem { x: 40, y_top: 5, y_bot: 40, notehead_idx: None },
+        ];
+        // Beam from x=15 to x=45, y=10..14 (within stems' y-range)
+        let beams = vec![(15u32, 45u32, 10u32, 14u32, 1u8)];
+        let _ = SigBuilder::new(10.0)
+            .add_stems(&mut sig, &stems)
+            .add_beams(&mut sig, &beams)
+            .link_beam_stem(&mut sig);
+        let bs_rels: Vec<_> = sig.relations_of_kind(RelationKind::BeamStem).collect();
+        assert_eq!(bs_rels.len(), 2);
+    }
+
+    #[test]
+    fn contextualize_after_build_raises_grades() {
+        let mut sig = Sig::new();
+        let nhs = vec![make_nh(10, 20, 0.7)];
+        let stems = vec![Stem { x: 14, y_top: 10, y_bot: 30, notehead_idx: None }];
+        let _ = SigBuilder::new(10.0)
+            .add_noteheads(&mut sig, &nhs)
+            .add_stems(&mut sig, &stems)
+            .link_head_stem(&mut sig);
+        sig.contextualize();
+        // Head and stem both should have contextual grade > intrinsic
+        for inter in sig.inters() {
+            let i = inter.grade().value();
+            let c = inter.effective_grade().value();
+            assert!(c >= i, "contextual {} should be >= intrinsic {}", c, i);
+        }
+    }
+}

--- a/src/omr-rust/crates/omr-sig/src/inter.rs
+++ b/src/omr-rust/crates/omr-sig/src/inter.rs
@@ -157,11 +157,18 @@ impl InterMeta {
 /// Konkrete Inters wie `HeadInter`, `StemInter`, ... implementieren dieses
 /// Trait und tragen typ-spezifische Daten (z.B. Pitch bei Head, x-Position
 /// bei Stem). Über das Trait kann `Sig` einheitlich auf Metadaten zugreifen.
-pub trait Inter: std::fmt::Debug + Send + Sync {
+///
+/// Erweiterung von `Any` erlaubt sicheres Downcasten zu konkreten Typen,
+/// was für typed-Lookup-Operationen wie `sig.head_inters()` notwendig ist.
+pub trait Inter: std::fmt::Debug + Send + Sync + std::any::Any {
     /// Gemeinsame Metadaten.
     fn meta(&self) -> &InterMeta;
     /// Mutable Zugriff auf Metadaten (für `set_contextual`, `freeze`).
     fn meta_mut(&mut self) -> &mut InterMeta;
+    /// Downcast-Zugriff für typed accessors.
+    fn as_any(&self) -> &dyn std::any::Any;
+    /// Mutable Downcast-Zugriff.
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
 
     /// Convenience: ID.
     fn id(&self) -> InterId {
@@ -204,6 +211,12 @@ mod tests {
         }
         fn meta_mut(&mut self) -> &mut InterMeta {
             &mut self.meta
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+        fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+            self
         }
     }
 

--- a/src/omr-rust/crates/omr-sig/src/inters.rs
+++ b/src/omr-rust/crates/omr-sig/src/inters.rs
@@ -24,6 +24,12 @@ macro_rules! impl_inter {
             fn meta_mut(&mut self) -> &mut InterMeta {
                 &mut self.meta
             }
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+            fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+                self
+            }
         }
     };
 }

--- a/src/omr-rust/crates/omr-sig/src/inters.rs
+++ b/src/omr-rust/crates/omr-sig/src/inters.rs
@@ -1,0 +1,378 @@
+//! Konkrete `Inter`-Typen für die Sheetstorm-OMR-Pipeline.
+//!
+//! Jeder Detektor erzeugt typed Inters (HeadInter, StemInter, BeamInter, ...)
+//! die das `Inter`-Trait implementieren und die existierenden omr-core-
+//! Datenstrukturen umschließen.
+//!
+//! Diese Typen sind die "Bridge" zwischen den bestehenden Detektor-Outputs
+//! und der SIG-Architektur — bestehender Code muss minimal verändert werden,
+//! aber das Resultat wird Inter-basiert.
+
+use omr_core::{NoteheadKind, Point, Rect};
+use serde::{Deserialize, Serialize};
+
+use crate::grade::Grade;
+use crate::inter::{Inter, InterId, InterKind, InterMeta};
+
+/// Macro um Inter-Boilerplate zu reduzieren — implementiert `Inter` Trait.
+macro_rules! impl_inter {
+    ($t:ty) => {
+        impl Inter for $t {
+            fn meta(&self) -> &InterMeta {
+                &self.meta
+            }
+            fn meta_mut(&mut self) -> &mut InterMeta {
+                &mut self.meta
+            }
+        }
+    };
+}
+
+// ============================================================================
+// Notehead
+// ============================================================================
+
+/// Inter für einen Notenkopf.
+///
+/// Wraps die typische `omr_core::Notehead`-Struktur und ergaenzt sie um
+/// Inter-Metadaten + Pitch (wird vom Detektor gesetzt sobald StaffLine-Y
+/// bekannt ist).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HeadInter {
+    /// Gemeinsame Inter-Metadaten.
+    pub meta: InterMeta,
+    /// Bbox-Center in Pixel-Koordinaten.
+    pub center: Point<f32>,
+    /// Filled / Open / Whole.
+    pub notehead_kind: NoteheadKind,
+    /// MIDI-Pitch (0-127); 0 wenn noch nicht berechnet.
+    pub midi: u8,
+    /// Pitch-Step (C, D, E, F, G, A, B); 0=C wenn noch nicht berechnet.
+    pub step: omr_core::PitchStep,
+    /// Octave-Nummer (4 = mittlere Oktave).
+    pub octave: i8,
+    /// Vorzeichen (-2 = double-flat, -1 = flat, 0 = natural, 1 = sharp, 2 = double-sharp).
+    pub alter: i8,
+    /// Punktierung (0/1/2).
+    pub augmentation_dots: u8,
+    /// Duration in Ticks (0=unbekannt, 1=16th, 2=8th, 4=quarter, 8=half, 16=whole).
+    pub duration: u32,
+}
+impl_inter!(HeadInter);
+
+impl HeadInter {
+    /// Erstellt einen neuen HeadInter aus einer omr-core Notehead.
+    pub fn from_notehead(id: InterId, nh: &omr_core::Notehead) -> Self {
+        let meta = InterMeta::new(id, InterKind::Head, nh.bbox, Grade::new(nh.confidence as f64));
+        Self {
+            meta,
+            center: nh.center,
+            notehead_kind: nh.kind,
+            midi: 0,
+            step: omr_core::PitchStep::C,
+            octave: 4,
+            alter: 0,
+            augmentation_dots: 0,
+            duration: match nh.kind {
+                NoteheadKind::Filled => 4, // default to quarter
+                NoteheadKind::Open => 8,   // half
+                NoteheadKind::Whole => 16, // whole
+            },
+        }
+    }
+}
+
+// ============================================================================
+// Stem
+// ============================================================================
+
+/// Inter für einen Stem (Notenhals).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StemInter {
+    /// Gemeinsame Inter-Metadaten.
+    pub meta: InterMeta,
+    /// X-Pixel des Stems.
+    pub x: u32,
+    /// Top-Y (kleinerer Y-Wert = oben im Bild).
+    pub y_top: u32,
+    /// Bottom-Y.
+    pub y_bot: u32,
+    /// True = Stem zeigt nach oben (Notehead unten); False = nach unten.
+    pub stem_up: bool,
+}
+impl_inter!(StemInter);
+
+impl StemInter {
+    /// Erstellt einen neuen StemInter aus einer omr-core Stem.
+    pub fn from_stem(id: InterId, stem: &omr_core::Stem, grade: Grade) -> Self {
+        let bounds = Rect {
+            x: stem.x.saturating_sub(1),
+            y: stem.y_top,
+            w: 2,
+            h: stem.y_bot.saturating_sub(stem.y_top).max(1),
+        };
+        let meta = InterMeta::new(id, InterKind::Stem, bounds, grade);
+        // stem_up: heuristisch — Notenkopf ist meist unten am Stem.
+        // Detektor kann das später anpassen.
+        Self {
+            meta,
+            x: stem.x,
+            y_top: stem.y_top,
+            y_bot: stem.y_bot,
+            stem_up: true,
+        }
+    }
+
+    /// Länge des Stems in Pixeln.
+    pub fn length(&self) -> u32 {
+        self.y_bot.saturating_sub(self.y_top)
+    }
+}
+
+// ============================================================================
+// Beam
+// ============================================================================
+
+/// Inter für einen Beam (Balken zwischen Stems).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BeamInter {
+    /// Gemeinsame Inter-Metadaten.
+    pub meta: InterMeta,
+    /// X-Start-Position.
+    pub x_start: u32,
+    /// X-Ende-Position.
+    pub x_end: u32,
+    /// Y-Top des Beams.
+    pub y_top: u32,
+    /// Y-Bottom des Beams.
+    pub y_bot: u32,
+    /// Anzahl Beam-Levels (1 = Achtel, 2 = Sechzehntel, 3 = 32stel).
+    pub level: u8,
+}
+impl_inter!(BeamInter);
+
+impl BeamInter {
+    /// Erstellt einen neuen BeamInter.
+    pub fn new(
+        id: InterId,
+        x_start: u32,
+        x_end: u32,
+        y_top: u32,
+        y_bot: u32,
+        level: u8,
+        grade: Grade,
+    ) -> Self {
+        let bounds = Rect {
+            x: x_start,
+            y: y_top,
+            w: x_end.saturating_sub(x_start),
+            h: y_bot.saturating_sub(y_top).max(1),
+        };
+        let meta = InterMeta::new(id, InterKind::Beam, bounds, grade);
+        Self {
+            meta,
+            x_start,
+            x_end,
+            y_top,
+            y_bot,
+            level,
+        }
+    }
+}
+
+// ============================================================================
+// Bar
+// ============================================================================
+
+/// Inter für einen Taktstrich.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BarInter {
+    /// Gemeinsame Inter-Metadaten.
+    pub meta: InterMeta,
+    /// X-Pixel des Strichs.
+    pub x: u32,
+    /// Optional: Top-Y.
+    pub y_top: Option<u32>,
+    /// Optional: Bottom-Y.
+    pub y_bot: Option<u32>,
+    /// True = Doppelstrich, False = Einfachstrich.
+    pub double: bool,
+}
+impl_inter!(BarInter);
+
+impl BarInter {
+    /// Erstellt einen neuen BarInter.
+    pub fn new(id: InterId, x: u32, system_idx: u32, grade: Grade) -> Self {
+        let bounds = Rect { x: x.saturating_sub(1), y: 0, w: 2, h: 0 };
+        let mut meta = InterMeta::new(id, InterKind::Bar, bounds, grade);
+        meta.system_idx = Some(system_idx);
+        Self {
+            meta,
+            x,
+            y_top: None,
+            y_bot: None,
+            double: false,
+        }
+    }
+}
+
+// ============================================================================
+// Slur / Tie
+// ============================================================================
+
+/// Inter für einen Slur oder Tie.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SlurInter {
+    /// Gemeinsame Inter-Metadaten.
+    pub meta: InterMeta,
+    /// Start-Punkt der Bezier-Kurve.
+    pub start: Point<f32>,
+    /// End-Punkt.
+    pub end: Point<f32>,
+    /// Kontroll-Punkt (Höhe der Kurve).
+    pub control: Point<f32>,
+    /// True = Tie zwischen gleichen Notes; False = Slur über Phrase.
+    pub is_tie: bool,
+}
+impl_inter!(SlurInter);
+
+// ============================================================================
+// Rest
+// ============================================================================
+
+/// Inter für eine Pause.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RestInter {
+    /// Gemeinsame Inter-Metadaten.
+    pub meta: InterMeta,
+    /// Duration in Ticks (16th=1, 8th=2, quarter=4, half=8, whole=16).
+    pub duration: u32,
+}
+impl_inter!(RestInter);
+
+// ============================================================================
+// Clef / KeySig / TimeSig
+// ============================================================================
+
+/// Inter für einen Notenschlüssel.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClefInter {
+    /// Gemeinsame Inter-Metadaten.
+    pub meta: InterMeta,
+    /// Welcher Clef? (Treble, Bass, Alto, Tenor, ...).
+    pub clef_type: ClefType,
+    /// Welche Stafflinie ist Anchor (0=oberste, 4=unterste, default je Clef).
+    pub line: u8,
+}
+impl_inter!(ClefInter);
+
+/// Typ eines Notenschlüssels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ClefType {
+    /// Violinschlüssel (G-Schlüssel auf 2. Linie).
+    Treble,
+    /// Bassschlüssel (F-Schlüssel auf 4. Linie).
+    Bass,
+    /// Altschlüssel (C-Schlüssel auf 3. Linie).
+    Alto,
+    /// Tenorschlüssel (C-Schlüssel auf 4. Linie).
+    Tenor,
+    /// Sopranschlüssel (C-Schlüssel auf 1. Linie).
+    Soprano,
+    /// Schlagzeug-/Percussion-Schlüssel.
+    Percussion,
+    /// Gitarren-Tab-Schlüssel.
+    Tab,
+}
+
+/// Inter für eine Tonart-Signatur.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeySignatureInter {
+    /// Gemeinsame Inter-Metadaten.
+    pub meta: InterMeta,
+    /// Anzahl Vorzeichen (positiv = Sharps, negativ = Flats, 0 = C-Dur/A-Moll).
+    pub fifths: i8,
+}
+impl_inter!(KeySignatureInter);
+
+/// Inter für eine Taktangabe.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimeSignatureInter {
+    /// Gemeinsame Inter-Metadaten.
+    pub meta: InterMeta,
+    /// Zähler (z.B. 4 in 4/4).
+    pub beats: u8,
+    /// Nenner (z.B. 4 in 4/4).
+    pub beat_type: u8,
+}
+impl_inter!(TimeSignatureInter);
+
+// ============================================================================
+// Alter (Akzidens)
+// ============================================================================
+
+/// Inter für ein Vorzeichen (Sharp, Flat, Natural, Double-Sharp/Flat).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AlterInter {
+    /// Gemeinsame Inter-Metadaten.
+    pub meta: InterMeta,
+    /// -2..2 entsprechend Double-Flat ... Double-Sharp.
+    pub alter: i8,
+}
+impl_inter!(AlterInter);
+
+// ============================================================================
+// Ledger
+// ============================================================================
+
+/// Inter für eine Hilfslinie.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LedgerInter {
+    /// Gemeinsame Inter-Metadaten.
+    pub meta: InterMeta,
+    /// X-Start.
+    pub x_start: u32,
+    /// X-Ende.
+    pub x_end: u32,
+    /// Y-Position der Linie.
+    pub y: u32,
+    /// Position relativ zum Staff: 1 = direkt darüber, 2 = noch eins darüber, -1 = direkt darunter, ...
+    pub position: i8,
+}
+impl_inter!(LedgerInter);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn head_inter_from_notehead_preserves_data() {
+        let nh = omr_core::Notehead {
+            bbox: Rect { x: 10, y: 20, w: 8, h: 8 },
+            center: Point { x: 14.0, y: 24.0 },
+            confidence: 0.85,
+            kind: NoteheadKind::Filled,
+            staff_idx: 0,
+        };
+        let h = HeadInter::from_notehead(InterId(1), &nh);
+        assert_eq!(h.kind(), InterKind::Head);
+        assert!((h.grade().value() - 0.85).abs() < 1e-6);
+        assert_eq!(h.notehead_kind, NoteheadKind::Filled);
+        assert_eq!(h.duration, 4); // quarter (filled default)
+    }
+
+    #[test]
+    fn stem_inter_calculates_length() {
+        let stem = omr_core::Stem { x: 50, y_top: 100, y_bot: 150, notehead_idx: None };
+        let si = StemInter::from_stem(InterId(1), &stem, Grade::new(0.7));
+        assert_eq!(si.length(), 50);
+        assert_eq!(si.kind(), InterKind::Stem);
+    }
+
+    #[test]
+    fn beam_inter_kind_is_beam() {
+        let b = BeamInter::new(InterId(1), 100, 200, 50, 55, 1, Grade::new(0.8));
+        assert_eq!(b.kind(), InterKind::Beam);
+        assert_eq!(b.level, 1);
+    }
+}

--- a/src/omr-rust/crates/omr-sig/src/lib.rs
+++ b/src/omr-rust/crates/omr-sig/src/lib.rs
@@ -45,6 +45,7 @@ pub mod grade;
 pub mod history;
 pub mod inter;
 pub mod inters;
+pub mod music_theory;
 pub mod relation;
 pub mod sig;
 
@@ -55,6 +56,9 @@ pub use inter::{Inter, InterId, InterKind, InterMeta, Provenance};
 pub use inters::{
     AlterInter, BarInter, BeamInter, ClefInter, ClefType, HeadInter, KeySignatureInter,
     LedgerInter, RestInter, SlurInter, StemInter, TimeSignatureInter,
+};
+pub use music_theory::{
+    add_key_consistency_edges, add_measure_budget_edges, diatonic_pitches, is_diatonic,
 };
 pub use relation::{ExclusionCause, Relation, RelationKind, SupportImpacts, SupportKind};
 pub use sig::{ReduceReport, Sig};

--- a/src/omr-rust/crates/omr-sig/src/lib.rs
+++ b/src/omr-rust/crates/omr-sig/src/lib.rs
@@ -40,14 +40,21 @@
 
 #![warn(missing_docs)]
 
+pub mod builder;
 pub mod grade;
 pub mod history;
 pub mod inter;
+pub mod inters;
 pub mod relation;
 pub mod sig;
 
+pub use builder::SigBuilder;
 pub use grade::{contextual_grade, Grade, GradeImpacts};
 pub use history::{EditOperation, EditOperationKind, History, OperationId};
 pub use inter::{Inter, InterId, InterKind, InterMeta, Provenance};
+pub use inters::{
+    AlterInter, BarInter, BeamInter, ClefInter, ClefType, HeadInter, KeySignatureInter,
+    LedgerInter, RestInter, SlurInter, StemInter, TimeSignatureInter,
+};
 pub use relation::{ExclusionCause, Relation, RelationKind, SupportImpacts, SupportKind};
 pub use sig::{ReduceReport, Sig};

--- a/src/omr-rust/crates/omr-sig/src/music_theory.rs
+++ b/src/omr-rust/crates/omr-sig/src/music_theory.rs
@@ -1,0 +1,268 @@
+//! Music-Theory-Edges für den SIG.
+//!
+//! Erweitert ein gebautes `Sig` um Edges, die musiktheoretisches Wissen
+//! kodieren:
+//!
+//! - **KeyConsistency**: Note-Pitch passt (oder passt nicht) zur aktiven Tonart
+//! - **MeasureBudget**: Σ Durations im Takt = Time-Signature-Erwartung
+//! - **VoiceLeading**: Aufeinanderfolgende Notes sind ≤ Sext getrennt
+//! - **MetricStrength**: Note auf Down-Beat (starker Schlag) oder Up-Beat
+//!
+//! Jede Edge bringt Sub-Score-Information in den Contextual-Grade-Berechnung
+//! und erlaubt deklarative Conflict-Detection.
+
+use crate::inter::{Inter, InterId, InterKind};
+use crate::inters::{HeadInter, KeySignatureInter, TimeSignatureInter};
+use crate::relation::{
+    ExclusionCause, Relation, RelationKind, SupportImpacts, SupportKind,
+};
+use crate::sig::Sig;
+use std::collections::HashMap;
+
+/// MIDI-Pitches, die in einer C-Dur-Tonleiter (0 sharps/flats) plausibel sind:
+/// C, D, E, F, G, A, B → Mod 12: 0, 2, 4, 5, 7, 9, 11.
+const C_MAJOR_DIATONIC: [u8; 7] = [0, 2, 4, 5, 7, 9, 11];
+
+/// Welche Pitch-Klassen sind in einer Tonart mit `fifths` Vorzeichen plausibel?
+///
+/// fifths: positiv = Sharps (0=C, 1=G, 2=D, ..., 7=C#)
+///         negativ = Flats (-1=F, -2=Bb, ..., -7=Cb)
+///
+/// Returns 7 pitch classes (0-11) der Tonleiter.
+pub fn diatonic_pitches(fifths: i8) -> [u8; 7] {
+    // Circle of fifths transposition: jede +1 fifth verschiebt um +7 (mod 12).
+    let shift = (fifths as i32 * 7).rem_euclid(12) as u8;
+    let mut out = [0u8; 7];
+    for (i, &pc) in C_MAJOR_DIATONIC.iter().enumerate() {
+        out[i] = (pc + shift) % 12;
+    }
+    out
+}
+
+/// Ist `midi_pitch` diatonisch zur Tonart mit `fifths` Vorzeichen?
+pub fn is_diatonic(midi: u8, fifths: i8) -> bool {
+    let pc = midi % 12;
+    diatonic_pitches(fifths).contains(&pc)
+}
+
+/// Erzeugt KeyConsistency-Edges zwischen Heads und KeySignatures pro System.
+///
+/// - **Diatonisch**: Support-Edge (1.3, 1.0, Theoretical) — Head ist konsistent mit Tonart.
+/// - **Nicht-diatonisch**: Exclusion-Edge (ConsistencyViolation) — schwacher Konflikt.
+///
+/// Nutzt **typed access** über `sig.typed_inters::<HeadInter>()` und
+/// `sig.typed_inters::<KeySignatureInter>()` — kein externer Cache nötig.
+///
+/// Returns Anzahl hinzugefügter Edges.
+pub fn add_key_consistency_edges(sig: &mut Sig) -> usize {
+    // Sammle KeySigs per system_idx
+    let mut keysig_by_system: HashMap<u32, (InterId, i8)> = HashMap::new();
+    for ks in sig.typed_inters::<KeySignatureInter>() {
+        if let Some(sysid) = ks.meta.system_idx {
+            keysig_by_system.insert(sysid, (ks.id(), ks.fifths));
+        }
+    }
+
+    // Sammle alle (head_id, system_idx, midi) bevor wir mut ans Sig.
+    let head_data: Vec<(InterId, u32, u8)> = sig
+        .typed_inters::<HeadInter>()
+        .filter_map(|h| {
+            let sysid = h.meta.system_idx?;
+            // Nur Heads mit gesetztem MIDI berücksichtigen.
+            if h.midi == 0 {
+                return None;
+            }
+            Some((h.id(), sysid, h.midi))
+        })
+        .collect();
+
+    let mut count = 0;
+    for (head_id, sysid, midi) in head_data {
+        let Some(&(keysig_id, fifths)) = keysig_by_system.get(&sysid) else { continue; };
+        let consistent = is_diatonic(midi, fifths);
+        let rel = if consistent {
+            Relation::support(
+                RelationKind::KeyConsistency,
+                head_id,
+                keysig_id,
+                SupportImpacts::asymmetric(1.3, 1.0, SupportKind::Theoretical),
+            )
+        } else {
+            Relation::exclusion(
+                RelationKind::KeyConsistency,
+                head_id,
+                keysig_id,
+                ExclusionCause::ConsistencyViolation,
+            )
+        };
+        sig.add_relation(rel);
+        count += 1;
+    }
+    count
+}
+
+/// Erzeugt MeasureBudget-Edges zwischen TimeSignature und allen Heads im
+/// gleichen Measure.
+///
+/// Reine Annotation-Edge (kein Conflict-Resolution-Verhalten). Wird in
+/// einer späteren Iteration zur Auto-Repair-Suggestion-Engine erweitert.
+///
+/// Returns Anzahl hinzugefügter Edges.
+pub fn add_measure_budget_edges(sig: &mut Sig) -> usize {
+    // Sammle TimeSigs per system_idx
+    let mut ts_by_system: HashMap<u32, (InterId, u8, u8)> = HashMap::new();
+    for ts in sig.typed_inters::<TimeSignatureInter>() {
+        if let Some(sysid) = ts.meta.system_idx {
+            ts_by_system.insert(sysid, (ts.id(), ts.beats, ts.beat_type));
+        }
+    }
+
+    let head_data: Vec<(InterId, u32)> = sig
+        .typed_inters::<HeadInter>()
+        .filter_map(|h| Some((h.id(), h.meta.system_idx?)))
+        .collect();
+
+    let mut count = 0;
+    for (head_id, sysid) in head_data {
+        let Some(&(ts_id, _beats, _beat_type)) = ts_by_system.get(&sysid) else { continue; };
+        sig.add_relation(Relation::support(
+            RelationKind::MeasureBudget,
+            head_id,
+            ts_id,
+            SupportImpacts::asymmetric(1.0, 1.05, SupportKind::Theoretical),
+        ));
+        count += 1;
+    }
+    count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::grade::Grade;
+    use crate::inter::{InterMeta, Provenance};
+    use crate::inters::{HeadInter, KeySignatureInter};
+    use omr_core::{NoteheadKind, Point, Rect};
+
+    #[test]
+    fn c_major_is_diatonic_for_c() {
+        assert!(is_diatonic(60, 0)); // C4
+        assert!(is_diatonic(62, 0)); // D4
+        assert!(is_diatonic(64, 0)); // E4
+        assert!(!is_diatonic(61, 0)); // C#4 — not diatonic in C major
+        assert!(!is_diatonic(63, 0)); // Eb4 — not diatonic in C major
+    }
+
+    #[test]
+    fn g_major_includes_fsharp() {
+        // G-Dur hat 1 Sharp (F#).
+        assert!(is_diatonic(66, 1)); // F#4 IS diatonic in G major
+        assert!(!is_diatonic(65, 1)); // F natural — NOT diatonic in G major
+    }
+
+    #[test]
+    fn f_major_includes_bflat() {
+        // F-Dur hat 1 Flat (Bb).
+        assert!(is_diatonic(70, -1)); // Bb4 IS diatonic in F major
+        assert!(!is_diatonic(71, -1)); // B natural — NOT diatonic in F major
+    }
+
+    #[test]
+    fn diatonic_pitches_for_c_major() {
+        let pitches = diatonic_pitches(0);
+        let mut sorted = pitches.to_vec();
+        sorted.sort();
+        assert_eq!(sorted, vec![0, 2, 4, 5, 7, 9, 11]);
+    }
+
+    fn mk_head(sig: &mut Sig, midi: u8, system_idx: u32) -> InterId {
+        let id = sig.next_inter_id();
+        let mut meta = InterMeta::new(
+            id,
+            InterKind::Head,
+            Rect { x: 0, y: 0, w: 8, h: 8 },
+            Grade::new(0.8),
+        );
+        meta.system_idx = Some(system_idx);
+        let h = HeadInter {
+            meta,
+            center: Point { x: 0.0, y: 0.0 },
+            notehead_kind: NoteheadKind::Filled,
+            midi,
+            step: omr_core::PitchStep::C,
+            octave: 4,
+            alter: 0,
+            augmentation_dots: 0,
+            duration: 4,
+        };
+        sig.add_inter(Box::new(h))
+    }
+
+    fn mk_keysig(sig: &mut Sig, fifths: i8, system_idx: u32) -> InterId {
+        let id = sig.next_inter_id();
+        let mut meta = InterMeta::new(
+            id,
+            InterKind::KeySignature,
+            Rect { x: 0, y: 0, w: 30, h: 40 },
+            Grade::new(0.9),
+        );
+        meta.system_idx = Some(system_idx);
+        let ks = KeySignatureInter { meta, fifths };
+        sig.add_inter(Box::new(ks))
+    }
+
+    #[test]
+    fn diatonic_head_gets_support_edge() {
+        let mut sig = Sig::new();
+        // G major (1 sharp): F# IS diatonic
+        let _ks = mk_keysig(&mut sig, 1, 0);
+        let _h = mk_head(&mut sig, 66, 0); // F#4 (MIDI 66) — diatonic in G major
+        let n = add_key_consistency_edges(&mut sig);
+        assert_eq!(n, 1);
+        let rel = sig.relations().next().unwrap();
+        assert!(rel.is_support());
+    }
+
+    #[test]
+    fn non_diatonic_head_gets_exclusion_edge() {
+        let mut sig = Sig::new();
+        // G major: F natural is NOT diatonic
+        let _ks = mk_keysig(&mut sig, 1, 0);
+        let _h = mk_head(&mut sig, 65, 0); // F natural — NOT diatonic in G major
+        let n = add_key_consistency_edges(&mut sig);
+        assert_eq!(n, 1);
+        let rel = sig.relations().next().unwrap();
+        assert!(rel.is_exclusion());
+        assert_eq!(rel.exclusion_cause(), Some(ExclusionCause::ConsistencyViolation));
+    }
+
+    #[test]
+    fn no_keysig_means_no_edge() {
+        let mut sig = Sig::new();
+        let _h = mk_head(&mut sig, 60, 0); // C4
+        let n = add_key_consistency_edges(&mut sig);
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn multiple_systems_get_independent_keys() {
+        let mut sig = Sig::new();
+        let _ks1 = mk_keysig(&mut sig, 0, 0); // C major in system 0
+        let _ks2 = mk_keysig(&mut sig, 1, 1); // G major in system 1
+        let _h1 = mk_head(&mut sig, 65, 0); // F natural in system 0 — diatonic in C
+        let _h2 = mk_head(&mut sig, 65, 1); // F natural in system 1 — NOT in G major
+        let n = add_key_consistency_edges(&mut sig);
+        assert_eq!(n, 2);
+        let mut supports = 0;
+        let mut exclusions = 0;
+        for rel in sig.relations() {
+            if rel.is_support() {
+                supports += 1;
+            } else {
+                exclusions += 1;
+            }
+        }
+        assert_eq!(supports, 1);
+        assert_eq!(exclusions, 1);
+    }
+}

--- a/src/omr-rust/crates/omr-sig/src/sig.rs
+++ b/src/omr-rust/crates/omr-sig/src/sig.rs
@@ -151,6 +151,17 @@ impl Sig {
         self.inters().filter(move |i| i.kind() == kind)
     }
 
+    /// Typed-Iterator: alle Inters die zu konkretem Typ `T` downcast-bar sind.
+    /// Erlaubt typed Field-Access (z.B. midi, pitch, duration bei HeadInter).
+    pub fn typed_inters<T: 'static>(&self) -> impl Iterator<Item = &T> + '_ {
+        self.inters().filter_map(|i| i.as_any().downcast_ref::<T>())
+    }
+
+    /// Liefert ein konkretes typisiertes Inter via Downcast.
+    pub fn get_typed<T: 'static>(&self, id: InterId) -> Option<&T> {
+        self.get(id).and_then(|i| i.as_any().downcast_ref::<T>())
+    }
+
     /// Iterator über alle `Relation`s.
     pub fn relations(&self) -> impl Iterator<Item = &Relation> + '_ {
         self.graph.edge_indices().filter_map(move |e| self.graph.edge_weight(e))
@@ -359,6 +370,12 @@ mod tests {
         }
         fn meta_mut(&mut self) -> &mut InterMeta {
             &mut self.meta
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+        fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+            self
         }
     }
 


### PR DESCRIPTION
## Inhalt

Phase 2 der **Symbol Interpretation Graph (SIG)** Architektur — baut auf #147 (Phase 1 Foundation) auf.

### Phase 2a — Konkrete Inter-Typen
- **HeadInter** (mit pitch/midi/octave/alter/duration)
- **StemInter** (mit y_top/y_bot/length, stem_up)
- **BeamInter** (mit level fuer Achtel/16tel/32stel)
- **BarInter** (mit double-flag fuer Doppelstrich)
- **SlurInter, RestInter, ClefInter** (mit ClefType: Treble/Bass/Alto/Tenor/...)
- **KeySignatureInter, TimeSignatureInter, AlterInter, LedgerInter**

Jeder Typ wraps die existierenden \omr-core\ Datenstrukturen via \rom_notehead()\ / \rom_stem()\ Konstruktoren — minimaler Migration-Aufwand.

### Phase 2a — SigBuilder
Bridge zwischen bestehender Pipeline und SIG-Architektur:
- \dd_noteheads / add_stems / add_beams / add_bars\
- \link_head_stem\ (geometrische Heuristik: closest stem within line_spacing)
- \link_beam_stem\ (Y-Range-Overlap zwischen Beam und Stem)
- HeadStem Support-Edge mit Multiplikator 1.5 (Audiveris-Default)
- BeamStem Support-Edge mit Multiplikator 1.4

### Phase 2b — Pipeline-Integration
\omr-pipeline::sig_integration\ — neue Funktion \uild_sig_from_page(&DetectionPage) -> Sig\:
- 1:1 Aufbau aus existing Detections
- HeadStem + BeamStem Support-Edges via Geometric-Heuristics
- contextualize() automatisch
- \sig_summary()\ fuer Debug-Output

### Phase 2c — Music-Theory-Edges + Typed Accessors
**Inter trait erweitert** mit \Any\ fuer sichere Downcasts:
- \Sig::typed_inters<T>()\ — alle Inters die zu T downcasten
- \Sig::get_typed<T>(id)\ — typed Lookup

**music_theory.rs**:
- \diatonic_pitches(fifths)\ — Circle-of-Fifths Berechnung
- \is_diatonic(midi, fifths)\ — pitch class check fuer beliebige Tonart
- \dd_key_consistency_edges(sig)\:
  - Diatonic Head ↔ KeySig: **Support** (1.3, 1.0, Theoretical)
  - Non-diatonic Head ↔ KeySig: **Exclusion** (ConsistencyViolation)
- \dd_measure_budget_edges(sig)\ — TimeSig ↔ Heads im selben System

## Quality-Implikation

Sobald in der Pipeline pitch-/midi-Werte gesetzt sind, kann KeyConsistency:
- **Falsche Pitches als Konflikte markieren** (z.B. F natural in G-Dur)
- Diese werden vom Sig::reduce() automatisch entwertet
- → **Tonart-Awareness ohne harte Detection-Regel**

## Tests

\\\
cargo test -p omr-sig
running 36 tests
....................................
test result: ok. 36 passed; 0 failed
\\\

\\\
cargo test -p omr-pipeline
test result: ok. 25+ passed; 0 failed
\\\

## Was als nächstes folgt

- **Phase 3**: SIG-driven Filter — Heads ohne Stem-Support werden im reduce() entwertet → quality lift
- **Phase 4**: Op-Log-Persistenz fuer Editier-Workflow (User-Edits)
- **Phase 5**: ML-Layer (Multi-Hypothesis-Distributions, Music-Language-Model)
- **Phase 6**: Cross-Part-Validation (Blasmusik-Killer-Feature)

🤖 Co-authored-by: Copilot