### PR TITLE
feat(omr): Audiveris als Vergleichs-Engine wieder aktiviert

### DIFF
--- a/docs/06-omr-engine-comparison.md
+++ b/docs/06-omr-engine-comparison.md
@@ -1,0 +1,123 @@
+# OMR-Engine-Vergleich: Sheetstorm-OMR vs Audiveris
+
+Sheetstorm hat **zwei OMR-Engines** die parallel laufen koennen:
+
+| Engine | Sprache | Speed | Output | Wann nutzen? |
+|--------|---------|-------|--------|--------------|
+| **Sheetstorm-OMR** | Rust | ~1s/Seite | MusicXML + Detections-JSON + SIG | Default; schnell, mit Bbox-Daten |
+| **Audiveris** | Java (5.10) | 5-60s/Seite | MusicXML | Vergleich; ausgereift, vollständige Texte/Lyrics |
+
+## Schnellstart
+
+### Nur Sheetstorm-OMR (Default, schnell)
+```powershell
+.\scripts\start-with-sheetstorm-omr.ps1
+```
+
+### Nur Audiveris (Vergleichs-Engine)
+```powershell
+.\scripts\start-with-audiveris.ps1
+```
+> Erster Start dauert 5-10 min wegen Docker-Image-Build (Java + Audiveris + Tesseract = ~1 GB).
+
+### Beide parallel (Comparison-Mode)
+```powershell
+# Sheetstorm-OMR ist Default-Engine, Audiveris parallel verfuegbar
+.\scripts\start-comparison.ps1
+
+# Audiveris ist Default-Engine
+.\scripts\start-comparison.ps1 -Engine audiveris
+```
+
+## Manuell via AppHost
+
+```powershell
+dotnet run --project src/Sheetstorm.AppHost -- \
+    --enable-audiveris \         # startet Audiveris-Container
+    --enable-omr \               # startet Sheetstorm-OMR-Container
+    --use-engine=audiveris       # waehlt Audiveris als Active fuer Web-UI
+```
+
+Auswahl-Logik:
+- Wenn `--use-engine` gesetzt: genau diese Engine
+- Sonst: Sheetstorm-OMR wenn beide laufen, sonst die einzig laufende
+
+Env-Vars (alternativ zu CLI-Flags):
+- `SHEETSTORM_ENABLE_AUDIVERIS=true`
+- `SHEETSTORM_ENABLE_OMR=true`
+- `SHEETSTORM_USE_ENGINE=audiveris|sheetstorm|stub`
+
+## API-Vergleich
+
+Beide Engines exponieren dieselbe HTTP-API:
+- `GET /health`
+- `POST /recognize` — multipart `pdf` field, returns plain MusicXML
+
+Sheetstorm-OMR zusaetzlich:
+- `POST /detections` — Detections-JSON mit Bboxes + SIG-Summary
+- `POST /omr` — SIG als JSON-Object
+
+## Direkter Vergleich auf einem PDF
+
+Mit beiden Engines parallel:
+```powershell
+# Audiveris
+curl -X POST -F "pdf=@./mein-stueck.pdf" http://localhost:8081/recognize -o audiveris.mxml
+
+# Sheetstorm-OMR
+curl -X POST -F "file=@./mein-stueck.pdf" http://localhost:8091/recognize -o sheetstorm.mxml
+
+# Vergleich
+diff audiveris.mxml sheetstorm.mxml
+```
+
+## Web-UI
+
+Im Web-UI (https://localhost:7070) wird die OMR-Engine via `Omr:Provider`
+ausgewählt. Dieser Wert wird vom AppHost basierend auf den Flags gesetzt:
+- `--use-engine=sheetstorm` → `Omr__Provider=sheetstorm`
+- `--use-engine=audiveris` → `Omr__Provider=audiveris`
+- ohne Wahl → automatisch nach laufenden Containern
+
+Der Wechsel erfordert einen Web-Restart (oder Aspire Restart-Command auf dem Web-Container).
+
+## Architektur
+
+```
+                         ┌──────────────────────┐
+                         │  Sheetstorm.Web      │
+                         │  (Blazor)            │
+                         └────────┬─────────────┘
+                                  │ IOmrEngine (DI)
+                                  ▼
+                ┌─────────────────┴─────────────────┐
+                ▼                                   ▼
+      ┌──────────────────┐              ┌────────────────────┐
+      │ AudiverisOmr     │              │ SheetstormOmr      │
+      │ Engine           │              │ Engine             │
+      └────────┬─────────┘              └────────┬───────────┘
+               │ http://audiveris:8080            │ http://sheetstorm-omr:8091
+               ▼                                  ▼
+      ┌──────────────────┐              ┌────────────────────┐
+      │ Audiveris        │              │ omr-server (Rust)  │
+      │ Container        │              │ Container          │
+      │ (Java 21 + 5.10) │              │ (omr-rust crates)  │
+      └──────────────────┘              └────────────────────┘
+```
+
+## Bekannte Limitationen
+
+### Audiveris
+- Liefert **nur MusicXML**, keine Bbox-Daten / Detections-JSON
+- Annotation-Tool kann Audiveris-Output **nicht editieren** (keine Bboxes)
+- Lizenz: AGPL-3.0 (deshalb separate Container, kein Linking)
+
+### Sheetstorm-OMR
+- Pitch-/Duration-Erkennung noch nicht so robust wie Audiveris
+- Texte/Lyrics werden noch nicht via OCR detected (Audiveris nutzt Tesseract)
+
+## Wann was?
+
+- **Production**: Sheetstorm-OMR (schnell, mit Annotation-Workflow)
+- **Vergleichs-Tests**: Audiveris als Ground-Truth-Annaeherung
+- **Entwicklung**: Stub (kein Container, schnell)

--- a/scripts/start-comparison.ps1
+++ b/scripts/start-comparison.ps1
@@ -1,0 +1,34 @@
+# Startet Sheetstorm mit BEIDEN OMR-Engines parallel + UI nutzt die explizit
+# gewaehlte. Erlaubt:
+# - Engine via UI/API zu vergleichen (beide Endpoints sind erreichbar)
+# - Schnellen Wechsel via Env: SHEETSTORM_USE_ENGINE=audiveris|sheetstorm
+#
+# Default-Engine: sheetstorm (Rust), faster.
+
+param(
+    [ValidateSet("sheetstorm", "audiveris", "stub")]
+    [string]$Engine = "sheetstorm"
+)
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Push-Location $repoRoot
+
+try {
+    Write-Host "🎼🚀 Sheetstorm mit BEIDEN OMR-Engines starten..."
+    Write-Host "   Aktive Engine fuer Web-UI: $Engine"
+    Write-Host ""
+    Write-Host "   Audiveris      → http://localhost:8081"
+    Write-Host "   Sheetstorm-OMR → http://localhost:8091"
+    Write-Host ""
+    Write-Host "   Beide HTTP-APIs sind kompatibel (POST /recognize multipart)."
+    Write-Host "   Vergleichs-Calls direkt via curl moeglich."
+    Write-Host ""
+
+    dotnet run --project src/Sheetstorm.AppHost -- `
+        --enable-audiveris `
+        --enable-omr `
+        --use-engine=$Engine
+}
+finally {
+    Pop-Location
+}

--- a/scripts/start-with-audiveris.ps1
+++ b/scripts/start-with-audiveris.ps1
@@ -1,0 +1,41 @@
+# Startet Sheetstorm mit AUDIVERIS als aktiver OMR-Engine.
+#
+# Audiveris ist die ältere, langsamere aber etablierte Java-OMR-Engine
+# (https://github.com/Audiveris/audiveris). Wir nutzen sie zum
+# Vergleichen mit unserer eigenen Sheetstorm-OMR (Rust).
+#
+# Beim ersten Start wird das Audiveris-Docker-Image gebaut (~5-10 Minuten).
+# Danach geht der Start schnell.
+#
+# Optionen:
+#   -BothEngines: laesst auch die Sheetstorm-OMR (Rust) parallel laufen,
+#                 sodass Vergleichs-Calls moeglich sind.
+
+param(
+    [switch]$BothEngines
+)
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Push-Location $repoRoot
+
+try {
+    $appHostArgs = @("--enable-audiveris", "--use-engine=audiveris")
+    if ($BothEngines) {
+        $appHostArgs += "--enable-omr"
+    }
+
+    Write-Host "🎼 Sheetstorm mit Audiveris als OMR-Engine starten..."
+    Write-Host "   AppHost-Args: $($appHostArgs -join ' ')"
+    Write-Host ""
+    Write-Host "   Wenn das Docker-Image fehlt, dauert der erste Start ~5-10 min."
+    Write-Host "   Audiveris läuft auf http://localhost:8081 (POST /recognize)."
+    if ($BothEngines) {
+        Write-Host "   Sheetstorm-OMR (Rust) läuft auf http://localhost:8091 (parallel)."
+    }
+    Write-Host ""
+
+    dotnet run --project src/Sheetstorm.AppHost -- @appHostArgs
+}
+finally {
+    Pop-Location
+}

--- a/scripts/start-with-sheetstorm-omr.ps1
+++ b/scripts/start-with-sheetstorm-omr.ps1
@@ -1,0 +1,36 @@
+# Startet Sheetstorm mit der EIGENEN Sheetstorm-OMR (Rust) als aktiver Engine.
+#
+# Sheetstorm-OMR ist unsere eigene Rust-basierte OMR-Engine
+# (siehe src/omr-rust/). Schnell (~1s/Seite), produziert Detections-JSON
+# mit Bbox-Daten + SIG (Symbol Interpretation Graph).
+#
+# Optionen:
+#   -BothEngines: laesst Audiveris parallel mitlaufen fuer Vergleich.
+
+param(
+    [switch]$BothEngines
+)
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Push-Location $repoRoot
+
+try {
+    $appHostArgs = @("--enable-omr", "--use-engine=sheetstorm")
+    if ($BothEngines) {
+        $appHostArgs += "--enable-audiveris"
+    }
+
+    Write-Host "🚀 Sheetstorm mit Sheetstorm-OMR (Rust) als Engine starten..."
+    Write-Host "   AppHost-Args: $($appHostArgs -join ' ')"
+    Write-Host ""
+    Write-Host "   Sheetstorm-OMR läuft auf http://localhost:8091."
+    if ($BothEngines) {
+        Write-Host "   Audiveris läuft auf http://localhost:8081 (parallel)."
+    }
+    Write-Host ""
+
+    dotnet run --project src/Sheetstorm.AppHost -- @appHostArgs
+}
+finally {
+    Pop-Location
+}

--- a/src/Sheetstorm.AppHost/AppHost.cs
+++ b/src/Sheetstorm.AppHost/AppHost.cs
@@ -10,19 +10,48 @@ var mailhog = builder.AddContainer("mailhog", "mailhog/mailhog")
     .WithEndpoint(port: 1025, targetPort: 1025, name: "smtp")
     .WithEndpoint(port: 8025, targetPort: 8025, name: "ui", scheme: "http");
 
-// Audiveris-Sidecar.
+// ─── OMR-Engine-Auswahl ───────────────────────────────────────────────────
 //
-// Strategie: Wir bauen das Image NUR EINMAL ueber `scripts/build-audiveris.ps1`
-// (oder beim ersten AppHost-Start, wenn nicht vorhanden). Aspire startet hier
-// nur den fertigen Container ueber `AddContainer(name, image)` — kein Build,
-// kein Wartezeit-Verlust. Aenderungen am Dockerfile/server.py erkennt das
-// Build-Skript ueber einen SHA256-Hash der Quellen unter docker/audiveris/.
-// Wenn der Hash sich geaendert hat, wird neu gebaut.
+// Sheetstorm hat **zwei** OMR-Engines, die parallel laufen koennen:
 //
-// Aktivieren: dotnet run --project src/Sheetstorm.AppHost -- --enable-audiveris
+// 1. **Sheetstorm-OMR** (Rust, eigene Engine, in src/omr-rust/)
+//    Schnell (~1s/Seite), produziert Detections-JSON mit Bbox-Daten und SIG.
+//    Aktivieren: `--enable-omr` ODER env SHEETSTORM_ENABLE_OMR=true
+//
+// 2. **Audiveris** (Java, https://github.com/Audiveris/audiveris)
+//    Langsamer (5-60s/Seite), produziert komplettes MusicXML (inkl. Texte).
+//    Aktivieren: `--enable-audiveris` ODER env SHEETSTORM_ENABLE_AUDIVERIS=true
+//
+// **Welcher wird vom Web-UI verwendet?** Steuerbar via:
+//
+// - `--use-engine=sheetstorm` → Sheetstorm-OMR ist aktiv (Default wenn beide laufen)
+// - `--use-engine=audiveris`  → Audiveris ist aktiv
+// - `--use-engine=stub`       → Stub-Engine (Demo-Daten)
+// - keine Angabe              → automatisch: Audiveris wenn nur Audiveris laeuft,
+//                               sonst Sheetstorm-OMR
+//
+// Beispiele:
+//   dotnet run --project src/Sheetstorm.AppHost -- --enable-omr
+//   dotnet run --project src/Sheetstorm.AppHost -- --enable-audiveris
+//   dotnet run --project src/Sheetstorm.AppHost -- --enable-omr --enable-audiveris --use-engine=audiveris
+//
+// Die Container-Images werden bei Bedarf automatisch via docker build erstellt
+// (siehe EnsureContainerImageBuilt unten).
 
 var enableAudiveris = args.Contains("--enable-audiveris")
     || string.Equals(Environment.GetEnvironmentVariable("SHEETSTORM_ENABLE_AUDIVERIS"), "true", StringComparison.OrdinalIgnoreCase);
+
+var enableOmr = args.Contains("--enable-omr")
+    || string.Equals(Environment.GetEnvironmentVariable("SHEETSTORM_ENABLE_OMR"), "true", StringComparison.OrdinalIgnoreCase);
+
+// Gewuenschte Engine ableiten.
+string? requestedEngine = null;
+foreach (var a in args)
+{
+    if (a.StartsWith("--use-engine=", StringComparison.OrdinalIgnoreCase))
+        requestedEngine = a.Substring("--use-engine=".Length).ToLowerInvariant();
+}
+requestedEngine ??= Environment.GetEnvironmentVariable("SHEETSTORM_USE_ENGINE")?.ToLowerInvariant();
 
 IResourceBuilder<ContainerResource>? audiveris = null;
 if (enableAudiveris)
@@ -32,19 +61,6 @@ if (enableAudiveris)
         .WithEndpoint(port: 8081, targetPort: 8080, name: "http", scheme: "http")
         .WithHttpHealthCheck("/health");
 }
-
-// Sheetstorm-OMR-Engine (Rust).
-//
-// Drop-in-Replacement fuer Audiveris mit gleicher HTTP-API. Aktivieren:
-//   dotnet run --project src/Sheetstorm.AppHost -- --enable-omr
-// oder Env: SHEETSTORM_ENABLE_OMR=true.
-//
-// Wenn beide enableAudiveris UND enableOmr aktiv sind, wird OMR als
-// Sheetstorm.Web-Provider verwendet (Audiveris bleibt erreichbar fuer
-// vergleichende Tests).
-
-var enableOmr = args.Contains("--enable-omr")
-    || string.Equals(Environment.GetEnvironmentVariable("SHEETSTORM_ENABLE_OMR"), "true", StringComparison.OrdinalIgnoreCase);
 
 IResourceBuilder<ContainerResource>? omr = null;
 if (enableOmr)
@@ -70,19 +86,48 @@ var web = builder.AddProject<Projects.Sheetstorm_Web>("webfrontend")
     .WaitFor(apiService)
     .WaitFor(sheetstormDb);
 
+// Engine-URLs verfuegbar machen — egal welche aktiv ist, beide URLs werden
+// gesetzt damit das Web-Projekt notfalls beide ansprechen kann (z.B. fuer
+// Comparison-View in der UI).
 if (audiveris is not null)
 {
     web = web
         .WithEnvironment("Audiveris__BaseUrl", audiveris.GetEndpoint("http"))
         .WaitFor(audiveris);
 }
-
 if (omr is not null)
 {
     web = web
-        .WithEnvironment("Omr__Provider", "sheetstorm")
         .WithEnvironment("Omr__BaseUrl", omr.GetEndpoint("http"))
         .WaitFor(omr);
+}
+
+// Active-Provider explizit setzen.
+// Logik:
+//   1. Wenn requestedEngine gesetzt → genau diese Engine aktivieren (sofern URL da)
+//   2. Sonst: Wenn beide laufen → Sheetstorm-OMR (schneller, neuere Engine)
+//   3. Sonst: nur die laufende Engine
+//   4. Sonst: Stub (kein Provider gesetzt)
+string? activeProvider = (requestedEngine, omr is not null, audiveris is not null) switch
+{
+    ("audiveris", _, true) => "audiveris",
+    ("audiveris", _, false) => null, // gewuenscht aber nicht da → fallback Stub
+    ("sheetstorm", true, _) => "sheetstorm",
+    ("sheetstorm", false, _) => null,
+    ("stub", _, _) => null,
+    (null, true, _) => "sheetstorm",
+    (null, false, true) => "audiveris",
+    _ => null,
+};
+
+if (activeProvider is not null)
+{
+    web = web.WithEnvironment("Omr__Provider", activeProvider);
+    Console.WriteLine($"⚡ Web-Frontend nutzt OMR-Engine: {activeProvider.ToUpperInvariant()}");
+}
+else if (enableOmr || enableAudiveris)
+{
+    Console.WriteLine("⚠ OMR-Engine erwuenscht aber nicht verfuegbar — Web faellt auf Stub zurueck.");
 }
 
 builder.Build().Run();


### PR DESCRIPTION
## Audiveris zurueck als Comparison-Engine

User-Anforderung: *Ich möchte noch mal audiveris als vergleich haben. Schmeiß aber nichts weg.*

### Was geaendert
- AppHost.cs: neue --use-engine=audiveris|sheetstorm|stub Flag fuer explizite Engine-Auswahl. Beide Engines parallel moeglich.
- scripts/start-with-audiveris.ps1, start-with-sheetstorm-omr.ps1, start-comparison.ps1
- docs/06-omr-engine-comparison.md mit Architektur, API-Vergleich, curl-Beispielen

### Was NICHT geaendert
- Sheetstorm-OMR (Rust) bleibt unveraendert
- omr-sig + Phase 1/2/3/5 Architektur unangetastet
- Annotation-Tool unveraendert

### Quickstart
\\\powershell
.\\scripts\\start-with-audiveris.ps1     # Nur Audiveris
.\\scripts\\start-comparison.ps1         # Beide parallel, Sheetstorm-OMR Default
.\\scripts\\start-comparison.ps1 -Engine audiveris   # Audiveris Default
\\\

### Engine-Auswahl-Logik (AppHost)

| Flag-Kombination | Aktive Engine |
|---|---|
| --enable-audiveris | audiveris (auto) |
| --enable-omr | sheetstorm (auto) |
| --enable-audiveris --enable-omr | sheetstorm (Default) |
| --enable-audiveris --enable-omr --use-engine=audiveris | audiveris (explizit) |

Audiveris-Docker-Image wurde gebaut (607MB), ready-to-run.

🤖 Co-authored-by: Copilot