### PR TITLE
feat(omr-sig): SIG-Summary in /detections + omr-sig-inspect CLI + collect_detections default

### DIFF
--- a/src/omr-rust/crates/omr-core/src/lib.rs
+++ b/src/omr-rust/crates/omr-core/src/lib.rs
@@ -438,7 +438,7 @@ mod timeline_tests {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct PipelineOptions {
     pub debug_dir: Option<PathBuf>,
     pub trace_only: bool,
@@ -448,6 +448,17 @@ pub struct PipelineOptions {
     pub unet_model_path: Option<PathBuf>,
     /// Wenn true, sammelt die Pipeline alle Detection-Bboxes (NHs, Stems,
     /// Beams, Bars) und gibt sie im `PipelineResult.detections` zurück.
-    /// Nötig für das Annotation-/Training-Tool. Default: false.
+    /// Nötig für das Annotation-/Training-Tool. Default: true.
     pub collect_detections: bool,
+}
+
+impl Default for PipelineOptions {
+    fn default() -> Self {
+        Self {
+            debug_dir: None,
+            trace_only: false,
+            unet_model_path: None,
+            collect_detections: true,
+        }
+    }
 }

--- a/src/omr-rust/crates/omr-pipeline/src/detections.rs
+++ b/src/omr-rust/crates/omr-pipeline/src/detections.rs
@@ -12,6 +12,40 @@ use omr_core::{Measure, Notehead, NoteheadKind, ScoreNote, StaffSystem, Stem};
 use omr_symbols::{Beam, MeasureBar};
 use serde::Serialize;
 
+/// Kompakte SIG-Statistik für eine DetectionPage.
+///
+/// Wird von `sig_integration::enrich_with_sig` befüllt und im JSON-Output
+/// des `/detections`-Endpoints unter dem Feld `sig` serialisiert.
+#[derive(Debug, Clone, Serialize)]
+pub struct SigSummary {
+    /// Gesamtzahl der Inters im SIG.
+    pub n_inters: u32,
+    /// Anzahl Noteheads.
+    pub n_heads: u32,
+    /// Anzahl Stems.
+    pub n_stems: u32,
+    /// Anzahl Beams.
+    pub n_beams: u32,
+    /// Anzahl Taktstriche.
+    pub n_bars: u32,
+    /// Anzahl Tonart-Vorzeichen.
+    pub n_keysigs: u32,
+    /// Anzahl Taktart-Angaben.
+    pub n_timesigs: u32,
+    /// Gesamtzahl der Relations (Edges).
+    pub n_relations: u32,
+    /// Anzahl KeyConsistency-Support-Edges (diatonische Noteheads).
+    pub n_keyconsistency_supports: u32,
+    /// Anzahl KeyConsistency-Exclusion-Edges (nicht-diatonische Noteheads).
+    pub n_keyconsistency_conflicts: u32,
+    /// Anzahl HeadStem-Support-Edges.
+    pub n_headstem_links: u32,
+    /// Anzahl BeamStem-Support-Edges.
+    pub n_beamstem_links: u32,
+    /// Anzahl MeasureBudget-Edges.
+    pub n_measurebudget_edges: u32,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct DetectionsResult {
     pub schema_version: u32,
@@ -48,6 +82,10 @@ pub struct DetectionPage {
     /// Wird über `read_page_sequentially` produziert.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reading_stream: Option<omr_symbols::PageReadingStream>,
+    /// Optionale SIG-Zusammenfassung — wird von `sig_integration::enrich_with_sig`
+    /// befüllt wenn `include_sig=true` beim Endpoint gesetzt ist.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sig: Option<SigSummary>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -522,5 +560,56 @@ pub fn build_detection_page(
         rests: rest_entries,
         slurs: slur_entries,
         reading_stream,
+        sig: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sig_summary_fields_default_zero() {
+        let summary = SigSummary {
+            n_inters: 0,
+            n_heads: 0,
+            n_stems: 0,
+            n_beams: 0,
+            n_bars: 0,
+            n_keysigs: 0,
+            n_timesigs: 0,
+            n_relations: 0,
+            n_keyconsistency_supports: 0,
+            n_keyconsistency_conflicts: 0,
+            n_headstem_links: 0,
+            n_beamstem_links: 0,
+            n_measurebudget_edges: 0,
+        };
+        assert_eq!(summary.n_inters, 0);
+        assert_eq!(summary.n_heads, 0);
+        assert_eq!(summary.n_relations, 0);
+    }
+
+    #[test]
+    fn sig_summary_serializes_with_all_fields() {
+        let summary = SigSummary {
+            n_inters: 10,
+            n_heads: 5,
+            n_stems: 3,
+            n_beams: 1,
+            n_bars: 2,
+            n_keysigs: 1,
+            n_timesigs: 1,
+            n_relations: 8,
+            n_keyconsistency_supports: 4,
+            n_keyconsistency_conflicts: 1,
+            n_headstem_links: 3,
+            n_beamstem_links: 1,
+            n_measurebudget_edges: 5,
+        };
+        let json = serde_json::to_string(&summary).expect("serialize ok");
+        assert!(json.contains("n_inters"));
+        assert!(json.contains("n_keyconsistency_conflicts"));
+        assert!(json.contains("n_measurebudget_edges"));
     }
 }

--- a/src/omr-rust/crates/omr-pipeline/src/sig_integration.rs
+++ b/src/omr-rust/crates/omr-pipeline/src/sig_integration.rs
@@ -215,6 +215,50 @@ pub fn sig_summary(sig: &Sig) -> String {
     )
 }
 
+/// Befüllt die `sig`-Summary eines `DetectionPage` durch Aufbau des SIG.
+///
+/// Baut den SIG aus der DetectionPage auf, zählt alle Inters und Relations
+/// nach Kind und schreibt das Ergebnis in `page.sig`.
+/// Idempotent — mehrfaches Aufrufen überschreibt den vorherigen Wert.
+pub fn enrich_with_sig(page: &mut crate::detections::DetectionPage) {
+    use crate::detections::SigSummary;
+    use omr_sig::{InterKind, RelationKind};
+
+    let sig = build_sig_from_page(page);
+
+    let summary = SigSummary {
+        n_inters: sig.inter_count() as u32,
+        n_heads: sig.inters_of_kind(InterKind::Head).count() as u32,
+        n_stems: sig.inters_of_kind(InterKind::Stem).count() as u32,
+        n_beams: sig.inters_of_kind(InterKind::Beam).count() as u32,
+        n_bars: sig.inters_of_kind(InterKind::Bar).count() as u32,
+        n_keysigs: sig.inters_of_kind(InterKind::KeySignature).count() as u32,
+        n_timesigs: sig.inters_of_kind(InterKind::TimeSignature).count() as u32,
+        n_relations: sig.relation_count() as u32,
+        n_keyconsistency_supports: sig
+            .relations()
+            .filter(|r| r.kind == RelationKind::KeyConsistency && r.is_support())
+            .count() as u32,
+        n_keyconsistency_conflicts: sig
+            .relations()
+            .filter(|r| r.kind == RelationKind::KeyConsistency && r.is_exclusion())
+            .count() as u32,
+        n_headstem_links: sig
+            .relations()
+            .filter(|r| r.kind == RelationKind::HeadStem && r.is_support())
+            .count() as u32,
+        n_beamstem_links: sig
+            .relations()
+            .filter(|r| r.kind == RelationKind::BeamStem && r.is_support())
+            .count() as u32,
+        n_measurebudget_edges: sig
+            .relations()
+            .filter(|r| r.kind == RelationKind::MeasureBudget)
+            .count() as u32,
+    };
+    page.sig = Some(summary);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -243,6 +287,7 @@ mod tests {
             rests: vec![],
             slurs: vec![],
             reading_stream: None,
+            sig: None,
         }
     }
 
@@ -375,5 +420,67 @@ mod tests {
             .find(|r| r.kind == omr_sig::RelationKind::KeyConsistency)
             .expect("KeyConsistency edge present");
         assert!(kc_edge.is_exclusion(), "F natural in G major should be Exclusion");
+    }
+
+    #[test]
+    fn enrich_with_sig_populates_summary() {
+        let mut page = empty_page();
+        // G-Dur Tonart
+        page.key_signatures.push(KeySignatureEntry {
+            system_idx: 0,
+            fifths: 1,
+            bbox: [50, 100, 30, 40],
+        });
+        // Diatonischer Head F#4 (MIDI 66)
+        page.noteheads.push(NoteheadEntry {
+            id: 0,
+            bbox: [100, 200, 8, 6],
+            center: [104.0, 203.0],
+            kind: "Filled",
+            system_idx: 0,
+            confidence: 0.9,
+            midi: Some(66),
+            step: Some("F"),
+            alter: Some(1),
+            octave: Some(4),
+            duration: Some(4),
+            augmentation_dots: Some(0),
+            measure_number: Some(1),
+            in_chord: None,
+            is_rest: None,
+            stem_id: None,
+        });
+        // Nicht-diatonischer Head F natural (MIDI 65)
+        page.noteheads.push(NoteheadEntry {
+            id: 1,
+            bbox: [200, 200, 8, 6],
+            center: [204.0, 203.0],
+            kind: "Filled",
+            system_idx: 0,
+            confidence: 0.85,
+            midi: Some(65),
+            step: Some("F"),
+            alter: Some(0),
+            octave: Some(4),
+            duration: Some(4),
+            augmentation_dots: Some(0),
+            measure_number: Some(1),
+            in_chord: None,
+            is_rest: None,
+            stem_id: None,
+        });
+
+        assert!(page.sig.is_none());
+        super::enrich_with_sig(&mut page);
+
+        let sig = page.sig.expect("sig populated after enrich_with_sig");
+        assert_eq!(sig.n_heads, 2);
+        assert_eq!(sig.n_keysigs, 1);
+        // 1 diatonic Head → 1 Support
+        assert_eq!(sig.n_keyconsistency_supports, 1);
+        // 1 non-diatonic Head → 1 Exclusion/Conflict
+        assert_eq!(sig.n_keyconsistency_conflicts, 1);
+        // Inters: 2 Heads + 1 KeySig = 3
+        assert_eq!(sig.n_inters, 3);
     }
 }

--- a/src/omr-rust/crates/omr-server/Cargo.toml
+++ b/src/omr-rust/crates/omr-server/Cargo.toml
@@ -16,11 +16,16 @@ path = "src/bin/omr-cli.rs"
 name = "omr-bench"
 path = "src/bin/omr-bench.rs"
 
+[[bin]]
+name = "omr-sig-inspect"
+path = "src/bin/omr-sig-inspect.rs"
+
 [dependencies]
 omr-pipeline.workspace = true
 omr-musicxml.workspace = true
 omr-core.workspace = true
 omr-symbols.workspace = true
+omr-sig.workspace = true
 axum.workspace = true
 tokio.workspace = true
 tower.workspace = true
@@ -30,6 +35,7 @@ tracing-subscriber.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 anyhow.workspace = true
+clap.workspace = true
 
 [features]
 default = []

--- a/src/omr-rust/crates/omr-server/src/bin/omr-sig-inspect.rs
+++ b/src/omr-rust/crates/omr-server/src/bin/omr-sig-inspect.rs
@@ -1,0 +1,394 @@
+// omr-sig-inspect — CLI zum Inspizieren von DetectionsResult-JSON-Dateien.
+//
+// Liest eine vom `/detections`-Endpoint erzeugte JSON-Datei und gibt eine
+// formatierte SIG-Zusammenfassung pro Seite im Terminal aus.
+//
+// Aufruf:
+//   cargo run --bin omr-sig-inspect -- detections.json
+//   cargo run --bin omr-sig-inspect -- detections.json --verbose
+
+use clap::Parser;
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "omr-sig-inspect",
+    about = "Sheetstorm SIG Inspector — zeigt SIG-Statistiken aus einer DetectionsResult-JSON-Datei"
+)]
+struct Args {
+    /// Pfad zur DetectionsResult-JSON-Datei.
+    file: PathBuf,
+
+    /// Zeigt auch Noteheads ohne Pitch und weitere Detail-Informationen.
+    #[arg(short, long)]
+    verbose: bool,
+}
+
+fn main() {
+    let args = Args::parse();
+
+    let content = match std::fs::read_to_string(&args.file) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Fehler beim Lesen von {}: {}", args.file.display(), e);
+            std::process::exit(1);
+        }
+    };
+
+    let data: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Ungültiges JSON: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let pages = match data["pages"].as_array() {
+        Some(p) => p,
+        None => {
+            eprintln!("JSON enthält kein 'pages'-Array — ist das eine gültige DetectionsResult-Datei?");
+            std::process::exit(1);
+        }
+    };
+
+    println!("=== Sheetstorm SIG Inspector ===");
+    println!("File: {}", args.file.display());
+    println!("Pages: {}\n", pages.len());
+
+    for (page_idx, page) in pages.iter().enumerate() {
+        print_page(page_idx, page, args.verbose);
+    }
+}
+
+fn print_page(page_idx: usize, page: &serde_json::Value, verbose: bool) {
+    let n_systems = page["staff_systems"].as_array().map(|a| a.len()).unwrap_or(0);
+    let noteheads = page["noteheads"].as_array();
+    let n_heads = noteheads.map(|a| a.len()).unwrap_or(0);
+    let n_stems = page["stems"].as_array().map(|a| a.len()).unwrap_or(0);
+    let n_beams = page["beams"].as_array().map(|a| a.len()).unwrap_or(0);
+    let n_bars = page["bars"].as_array().map(|a| a.len()).unwrap_or(0);
+
+    println!("Page {}:", page_idx + 1);
+    println!(
+        "  {} Systems, {} Noteheads, {} Stems, {} Beams, {} Bars",
+        n_systems, n_heads, n_stems, n_beams, n_bars
+    );
+
+    // Durchschnitts-Konfidenz der Noteheads berechnen.
+    let avg_conf_heads = noteheads
+        .map(|nhs| {
+            let sum: f64 = nhs.iter().filter_map(|n| n["confidence"].as_f64()).sum();
+            let count = nhs.len();
+            if count > 0 { sum / count as f64 } else { 0.0 }
+        })
+        .unwrap_or(0.0);
+    let avg_conf_stems = page["stems"]
+        .as_array()
+        .map(|stems| {
+            let sum: f64 = stems.iter().filter_map(|s| s["confidence"].as_f64()).sum();
+            let count = stems.len();
+            if count > 0 { sum / count as f64 } else { 0.0 }
+        })
+        .unwrap_or(0.0);
+
+    println!("  ┌─ SIG ─────────────────────────────");
+
+    // SIG-Summary aus dem JSON lesen (wenn vorhanden).
+    if let Some(sig) = page["sig"].as_object() {
+        let n_inters = sig.get("n_inters").and_then(|v| v.as_u64()).unwrap_or(0);
+        let n_sig_heads = sig.get("n_heads").and_then(|v| v.as_u64()).unwrap_or(0);
+        let n_sig_stems = sig.get("n_stems").and_then(|v| v.as_u64()).unwrap_or(0);
+        let n_sig_beams = sig.get("n_beams").and_then(|v| v.as_u64()).unwrap_or(0);
+        let n_sig_bars = sig.get("n_bars").and_then(|v| v.as_u64()).unwrap_or(0);
+        let n_keysigs = sig.get("n_keysigs").and_then(|v| v.as_u64()).unwrap_or(0);
+        let n_timesigs = sig.get("n_timesigs").and_then(|v| v.as_u64()).unwrap_or(0);
+        let n_relations = sig.get("n_relations").and_then(|v| v.as_u64()).unwrap_or(0);
+        let n_kc_supports = sig.get("n_keyconsistency_supports").and_then(|v| v.as_u64()).unwrap_or(0);
+        let n_kc_conflicts = sig.get("n_keyconsistency_conflicts").and_then(|v| v.as_u64()).unwrap_or(0);
+        let n_headstem = sig.get("n_headstem_links").and_then(|v| v.as_u64()).unwrap_or(0);
+        let n_beamstem = sig.get("n_beamstem_links").and_then(|v| v.as_u64()).unwrap_or(0);
+        let n_budget = sig.get("n_measurebudget_edges").and_then(|v| v.as_u64()).unwrap_or(0);
+
+        println!("  │ {} Inters total", n_inters);
+        println!("  │   Heads:     {:>5}  (avg conf {:.2})", n_sig_heads, avg_conf_heads);
+        println!("  │   Stems:     {:>5}  (avg conf {:.2})", n_sig_stems, avg_conf_stems);
+        println!("  │   Beams:     {:>5}", n_sig_beams);
+        println!("  │   Bars:      {:>5}", n_sig_bars);
+
+        // KeySig-Details aus den raw key_signatures
+        if let Some(keys) = page["key_signatures"].as_array() {
+            for k in keys {
+                let fifths = k["fifths"].as_i64().unwrap_or(0);
+                let key_name = key_name(fifths as i8);
+                println!("  │   KeySigs:  {:>5}  fifths={} ({})", n_keysigs, fifths, key_name);
+            }
+            if keys.is_empty() {
+                println!("  │   KeySigs:  {:>5}", n_keysigs);
+            }
+        }
+
+        // TimeSig-Details aus den raw time_signatures
+        if let Some(times) = page["time_signatures"].as_array() {
+            for t in times {
+                let beats = t["beats"].as_u64().unwrap_or(0);
+                let beat_type = t["beat_type"].as_u64().unwrap_or(4);
+                println!("  │   TimeSigs: {:>5}  {}/{}", n_timesigs, beats, beat_type);
+            }
+            if times.is_empty() {
+                println!("  │   TimeSigs: {:>5}", n_timesigs);
+            }
+        }
+
+        println!("  │ {} Relations total", n_relations);
+        println!("  │   HeadStem:        {} (Support)", n_headstem);
+        println!("  │   BeamStem:        {} (Support)", n_beamstem);
+        println!(
+            "  │   KeyConsistency: {} Support / {} Exclusion",
+            n_kc_supports, n_kc_conflicts
+        );
+        println!("  │   MeasureBudget:  {}", n_budget);
+
+        // Konflikte anzeigen
+        if n_kc_conflicts > 0 {
+            println!("  │");
+            println!("  │ ⚠ Conflicts: {} nicht-diatonische Pitches", n_kc_conflicts);
+            print_conflict_details(page, verbose);
+        }
+    } else {
+        // Kein vorberechnetes SIG — Basis-Info aus JSON
+        println!("  │ [kein SIG-Summary im JSON — erstelle mit aktuellem /detections-Endpoint]");
+        println!("  │ {} Noteheads  (avg conf {:.2})", n_heads, avg_conf_heads);
+        println!("  │ {} Stems", n_stems);
+        println!("  │ {} Beams", n_beams);
+        println!("  │ {} Bars", n_bars);
+
+        // Trotzdem Konflikte erkennen wenn KeySig und Noteheads vorhanden
+        let conflicts = find_conflicts_from_json(page);
+        if !conflicts.is_empty() {
+            println!("  │");
+            println!("  │ ⚠ Konflikte (geschätzt): {} nicht-diatonische Pitches", conflicts.len());
+            for c in conflicts.iter().take(5) {
+                println!("  │   - {}", c);
+            }
+            if conflicts.len() > 5 {
+                println!("  │   ... und {} weitere", conflicts.len() - 5);
+            }
+        }
+    }
+
+    println!("  └─────────────────────────────────────");
+    println!();
+}
+
+/// Gibt Konflikt-Details aus den Noteheads des JSON aus.
+fn print_conflict_details(page: &serde_json::Value, verbose: bool) {
+    let conflicts = find_conflicts_from_json(page);
+    let limit = if verbose { conflicts.len() } else { 5 };
+    for c in conflicts.iter().take(limit) {
+        println!("  │   - {}", c);
+    }
+    if !verbose && conflicts.len() > 5 {
+        println!("  │   ... und {} weitere (--verbose für alle)", conflicts.len() - 5);
+    }
+}
+
+/// Findet nicht-diatonische Noteheads durch Vergleich mit der Tonart.
+fn find_conflicts_from_json(page: &serde_json::Value) -> Vec<String> {
+    let mut conflicts = Vec::new();
+
+    let Some(noteheads) = page["noteheads"].as_array() else {
+        return conflicts;
+    };
+    let Some(key_sigs) = page["key_signatures"].as_array() else {
+        return conflicts;
+    };
+    if key_sigs.is_empty() {
+        return conflicts;
+    }
+
+    // Baue Map: system_idx → fifths
+    let mut sys_to_fifths: std::collections::HashMap<u32, i8> = std::collections::HashMap::new();
+    for k in key_sigs {
+        let sys = k["system_idx"].as_u64().unwrap_or(0) as u32;
+        let fifths = k["fifths"].as_i64().unwrap_or(0) as i8;
+        sys_to_fifths.insert(sys, fifths);
+    }
+
+    for (i, nh) in noteheads.iter().enumerate() {
+        let Some(midi) = nh["midi"].as_u64() else { continue };
+        let sys = nh["system_idx"].as_u64().unwrap_or(0) as u32;
+        let Some(&fifths) = sys_to_fifths.get(&sys) else { continue };
+
+        if !omr_sig::is_diatonic(midi as u8, fifths) {
+            let step = nh["step"].as_str().unwrap_or("?");
+            let alter = nh["alter"].as_i64().unwrap_or(0);
+            let octave = nh["octave"].as_i64().unwrap_or(4);
+            let cx = nh["center"][0].as_f64().unwrap_or(0.0) as u32;
+            let cy = nh["center"][1].as_f64().unwrap_or(0.0) as u32;
+            let alter_str = match alter {
+                1 => "#",
+                -1 => "b",
+                2 => "##",
+                -2 => "bb",
+                _ => "♮",
+            };
+            let expected = expected_alter_in_key(step, fifths);
+            conflicts.push(format!(
+                "Head#{} {}{}{} at ({}, {}) — erwartet {} in {}",
+                i,
+                step,
+                alter_str,
+                octave,
+                cx,
+                cy,
+                expected,
+                key_name(fifths),
+            ));
+        }
+    }
+    conflicts
+}
+
+/// Gibt den erwarteten Alterations-String für einen Schritt in einer Tonart zurück.
+fn expected_alter_in_key(step: &str, fifths: i8) -> String {
+    // Circle of fifths: Sharps sind F,C,G,D,A,E,B; Flats sind B,E,A,D,G,C,F
+    let sharp_order = ["F", "C", "G", "D", "A", "E", "B"];
+    let flat_order = ["B", "E", "A", "D", "G", "C", "F"];
+
+    if fifths > 0 {
+        let n = fifths as usize;
+        if sharp_order[..n.min(7)].contains(&step) {
+            return format!("{}#", step);
+        }
+    } else if fifths < 0 {
+        let n = (-fifths) as usize;
+        if flat_order[..n.min(7)].contains(&step) {
+            return format!("{}b", step);
+        }
+    }
+    step.to_string()
+}
+
+/// Gibt den Tonart-Namen für `fifths` zurück (z.B. 1 → "G major").
+fn key_name(fifths: i8) -> &'static str {
+    match fifths {
+        0 => "C major",
+        1 => "G major",
+        2 => "D major",
+        3 => "A major",
+        4 => "E major",
+        5 => "B major",
+        6 => "F# major",
+        7 => "C# major",
+        -1 => "F major",
+        -2 => "Bb major",
+        -3 => "Eb major",
+        -4 => "Ab major",
+        -5 => "Db major",
+        -6 => "Gb major",
+        -7 => "Cb major",
+        _ => "unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_detection_json(n_heads: usize, n_stems: usize, fifths: i8, include_sig: bool) -> serde_json::Value {
+        let noteheads: Vec<serde_json::Value> = (0..n_heads)
+            .map(|i| {
+                serde_json::json!({
+                    "id": i,
+                    "bbox": [100, 200, 8, 6],
+                    "center": [104.0, 203.0],
+                    "kind": "Filled",
+                    "system_idx": 0,
+                    "confidence": 0.85,
+                    "midi": if i % 2 == 0 { 66 } else { 65 },  // F# (diatonic) / F natural (conflict)
+                    "step": "F",
+                    "alter": if i % 2 == 0 { 1 } else { 0 },
+                    "octave": 4
+                })
+            })
+            .collect();
+
+        let stems: Vec<serde_json::Value> = (0..n_stems)
+            .map(|i| serde_json::json!({"id": i, "x": 104, "y_top": 180, "y_bot": 230}))
+            .collect();
+
+        let key_sigs = vec![serde_json::json!({"system_idx": 0, "fifths": fifths, "bbox": [50, 100, 30, 40]})];
+        let time_sigs = vec![serde_json::json!({"system_idx": 0, "beats": 4, "beat_type": 4, "bbox": [80, 100, 20, 40]})];
+
+        let mut page = serde_json::json!({
+            "page_index": 0,
+            "width": 1000,
+            "height": 1000,
+            "staff_systems": [{"system_idx": 0, "top_y": 100.0, "bot_y": 140.0, "line_spacing": 10.0}],
+            "noteheads": noteheads,
+            "stems": stems,
+            "beams": [],
+            "bars": [],
+            "key_signatures": key_sigs,
+            "time_signatures": time_sigs,
+        });
+
+        if include_sig {
+            page["sig"] = serde_json::json!({
+                "n_inters": n_heads + n_stems + 1,
+                "n_heads": n_heads,
+                "n_stems": n_stems,
+                "n_beams": 0,
+                "n_bars": 0,
+                "n_keysigs": 1,
+                "n_timesigs": 1,
+                "n_relations": n_heads,
+                "n_keyconsistency_supports": n_heads / 2,
+                "n_keyconsistency_conflicts": (n_heads + 1) / 2,
+                "n_headstem_links": n_stems,
+                "n_beamstem_links": 0,
+                "n_measurebudget_edges": n_heads
+            });
+        }
+
+        serde_json::json!({"schema_version": 1, "pages": [page]})
+    }
+
+    #[test]
+    fn smoke_inspect_with_sig() {
+        let json = make_detection_json(4, 2, 1, true);
+        let pages = json["pages"].as_array().unwrap();
+        assert_eq!(pages.len(), 1);
+        let page = &pages[0];
+        assert!(page["sig"].is_object(), "sig field present");
+        assert_eq!(page["sig"]["n_heads"].as_u64().unwrap(), 4);
+        assert_eq!(page["sig"]["n_keyconsistency_conflicts"].as_u64().unwrap(), 2);
+    }
+
+    #[test]
+    fn smoke_inspect_without_sig() {
+        let json = make_detection_json(4, 2, 1, false);
+        let pages = json["pages"].as_array().unwrap();
+        let page = &pages[0];
+        assert!(page["sig"].is_null(), "no sig field when not included");
+    }
+
+    #[test]
+    fn find_conflicts_detects_non_diatonic() {
+        let json = make_detection_json(2, 0, 1, false);
+        let pages = json["pages"].as_array().unwrap();
+        let conflicts = find_conflicts_from_json(&pages[0]);
+        // Head#0: F#4 MIDI 66 → diatonic in G (fifths=1)
+        // Head#1: F♮4 MIDI 65 → NOT diatonic in G (fifths=1)
+        assert_eq!(conflicts.len(), 1, "exactly 1 non-diatonic head");
+        assert!(conflicts[0].contains("Head#1"), "conflict is Head#1");
+    }
+
+    #[test]
+    fn key_name_roundtrip() {
+        assert_eq!(key_name(0), "C major");
+        assert_eq!(key_name(1), "G major");
+        assert_eq!(key_name(-1), "F major");
+        assert_eq!(key_name(2), "D major");
+    }
+}

--- a/src/omr-rust/crates/omr-server/src/main.rs
+++ b/src/omr-rust/crates/omr-server/src/main.rs
@@ -263,7 +263,7 @@ async fn detections(mut multipart: Multipart) -> Response {
 
     match result {
         Ok(Ok(res)) => {
-            let dump = match res.detections {
+            let mut dump = match res.detections {
                 Some(d) => d,
                 None => {
                     return error_resp(
@@ -273,6 +273,10 @@ async fn detections(mut multipart: Multipart) -> Response {
                     );
                 }
             };
+            // SIG-Summary für jede Seite berechnen.
+            for page in &mut dump.pages {
+                omr_pipeline::sig_integration::enrich_with_sig(page);
+            }
             info!(
                 elapsed_ms = started.elapsed().as_millis() as u64,
                 n_pages = dump.pages.len(),


### PR DESCRIPTION
## Was wurde gebaut

### 1. SIG-Summary in `/detections`-API

Die `DetectionPage`-Struktur enthält jetzt ein optionales `sig: Option<SigSummary>`-Feld:

```rust
pub struct SigSummary {
    pub n_inters: u32,
    pub n_heads: u32,
    pub n_stems: u32,
    pub n_beams: u32,
    pub n_bars: u32,
    pub n_keysigs: u32,
    pub n_timesigs: u32,
    pub n_relations: u32,
    pub n_keyconsistency_supports: u32,   // diatonische NHs
    pub n_keyconsistency_conflicts: u32,  // nicht-diatonische NHs
    pub n_headstem_links: u32,
    pub n_beamstem_links: u32,
    pub n_measurebudget_edges: u32,
}
```

Die neue Funktion `omr_pipeline::sig_integration::enrich_with_sig(&mut page)` baut den SIG aus einer `DetectionPage` auf und befüllt das `sig`-Feld. Der `/detections`-Endpoint ruft diese Funktion automatisch für jede Seite auf.

### 2. CLI Binary `omr-sig-inspect`

Neues Binary `omr-sig-inspect` im `omr-server`-Crate:

```
$ cargo run --bin omr-sig-inspect -- detections.json
=== Sheetstorm SIG Inspector ===
File: detections.json
Pages: 1

Page 1:
  1 Systems, 2 Noteheads, 0 Stems, 0 Beams, 0 Bars
  ┌─ SIG ─────────────────────────────
  │ 3 Inters total
  │   Heads:         2  (avg conf 0.88)
  │   Stems:         0  (avg conf 0.00)
  │   Beams:         0
  │   Bars:          0
  │   KeySigs:       1  fifths=1 (G major)
  │   TimeSigs:      1  4/4
  │ 3 Relations total
  │   HeadStem:        0 (Support)
  │   BeamStem:        0 (Support)
  │   KeyConsistency: 1 Support / 1 Exclusion
  │   MeasureBudget:  2
  │
  │ ⚠ Conflicts: 1 nicht-diatonische Pitches
  │   - Head#1 F♮4 at (204, 203) — erwartet F# in G major
  └─────────────────────────────────────
```

Features:
- Nutzt `clap` für Argument-Parsing (`--verbose` Flag)
- Zeigt SIG-Summary wenn im JSON vorhanden
- Erkennt und zeigt nicht-diatonische Pitches als Konflikte
- Funktioniert auch mit alten JSON-Dateien ohne `sig`-Feld (zeigt Basis-Stats)

### 3. `collect_detections=true` Default

`PipelineOptions.collect_detections` hat jetzt `true` als Default-Wert — über ein manuelles `Default`-Impl statt `#[derive(Default)]`. Damit liefern `/detections` und `/recognize` immer Detection-JSON ohne dass `collect_detections: true` explizit gesetzt werden muss.

## Tests

Alle vorhandenen Tests grün (mit `--workspace --exclude omr-sig-store`):

- `omr-pipeline`: 15 unit-tests + 4 integration-tests — alle grün
- `omr-sig`: 9 unit-tests — alle grün  
- `omr-server`: 4 neue unit-tests in `omr-sig-inspect.rs` — alle grün
  - `smoke_inspect_with_sig`
  - `smoke_inspect_without_sig`
  - `find_conflicts_detects_non_diatonic`
  - `key_name_roundtrip`
- `sig_integration.rs`: neuer Test `enrich_with_sig_populates_summary` — grün

**Hinweis:** `cargo test -p omr-sig` direkt schlägt mit einem pre-existing `rusqlite/winsqlite3`-Feature-Konflikt in `omr-sig-store` fehl. Tests laufen mit `--workspace --exclude omr-sig-store`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>