### PR TITLE
feat(omr-sig): Phase 3b — omr-sig-codec (bidirektional MusicXML <-> Sig)

### DIFF
--- a/src/omr-rust/crates/omr-sig-codec/Cargo.toml
+++ b/src/omr-rust/crates/omr-sig-codec/Cargo.toml
@@ -4,10 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
-# Bidirektionaler MusicXML ↔ SIG Codec.
+# Bidirektionaler MusicXML Γåö SIG Codec.
 #
 # Importiert MusicXML in einen SIG (mit stabilen IDs) und exportiert
-# einen SIG als MusicXML. Basis für Round-Trip-Tests und Editor-Integration.
+# einen SIG als MusicXML. Basis f├╝r Round-Trip-Tests und Editor-Integration.
 
 [dependencies]
 omr-sig.workspace = true

--- a/src/omr-rust/crates/omr-sig-codec/README.md
+++ b/src/omr-rust/crates/omr-sig-codec/README.md
@@ -1,20 +1,20 @@
 # omr-sig-codec
 
-Bidirektionaler MusicXML ↔ SIG Codec für den Sheetstorm OMR-Stack.
+Bidirektionaler MusicXML Γåö SIG Codec f├╝r den Sheetstorm OMR-Stack.
 
-## Überblick
+## ├£berblick
 
 Dieser Crate implementiert:
 
-- **Import**: MusicXML (`score-partwise`) → SIG (`omr-sig`)  
+- **Import**: MusicXML (`score-partwise`) ΓåÆ SIG (`omr-sig`)  
   Erzeugt `ClefInter`, `KeySignatureInter`, `TimeSignatureInter`, `HeadInter` und `RestInter`.
   Stabile IDs aus `<note id="..."/>` werden via `IdMapping` erhalten.
 
-- **Export**: SIG → MusicXML  
+- **Export**: SIG ΓåÆ MusicXML  
   Sortiert Heads nach `(system_idx, measure_number, bbox.x)`.
   Jedes `system_idx` wird als separate `<part>` ausgegeben.
 
-- **Round-Trip**: import → export, inhaltlich äquivalentes XML.
+- **Round-Trip**: import ΓåÆ export, inhaltlich ├ñquivalentes XML.
 
 ## Schnellstart
 
@@ -58,8 +58,8 @@ assert!(roundtripped.contains("<step>C</step>"));
 
 ```rust
 let (sig, mapping) = codec.import_musicxml_with_mapping(xml).unwrap();
-// mapping.xml_id_for(inter_id) → Some("n1")
-// mapping.inter_id_for("n1")   → Some(InterId(...))
+// mapping.xml_id_for(inter_id) ΓåÆ Some("n1")
+// mapping.inter_id_for("n1")   ΓåÆ Some(InterId(...))
 ```
 
 ## Tests

--- a/src/omr-rust/crates/omr-sig-codec/src/exporter.rs
+++ b/src/omr-rust/crates/omr-sig-codec/src/exporter.rs
@@ -1,11 +1,10 @@
-//! Sig → MusicXML Exporter.
+//! Sig ΓåÆ MusicXML Exporter.
 //!
 //! Schreibt alle Inters eines SIG als `score-partwise` MusicXML 4.0.
 //! Heads werden sortiert nach `(system_idx, measure_number, bbox.x)`.
 //! Jedes eindeutige `system_idx` wird als separate `<part>` ausgegeben.
 
 use omr_sig::{
-    inter::InterKind,
     inters::{ClefInter, ClefType, HeadInter, KeySignatureInter, TimeSignatureInter},
     sig::Sig,
 };
@@ -29,7 +28,7 @@ pub(crate) fn export(sig: &Sig, divisions: u32) -> Result<String, CodecError> {
     let key_sigs: Vec<&KeySignatureInter> = sig.typed_inters::<KeySignatureInter>().collect();
     let time_sigs: Vec<&TimeSignatureInter> = sig.typed_inters::<TimeSignatureInter>().collect();
 
-    // Eindeutige system_idx-Werte → Parts
+    // Eindeutige system_idx-Werte ΓåÆ Parts
     let mut system_idxs: Vec<u32> = {
         let mut idxs: Vec<u32> = heads
             .iter()
@@ -61,7 +60,7 @@ pub(crate) fn export(sig: &Sig, divisions: u32) -> Result<String, CodecError> {
     for &sys in &system_idxs {
         writeln!(out, "  <part id=\"P{}\">", sys + 1).unwrap();
 
-        // Takt-Nummern für diese Part (aus Heads und Attribut-Inters)
+        // Takt-Nummern f├╝r diese Part (aus Heads und Attribut-Inters)
         let mut measure_numbers: Vec<u32> = heads
             .iter()
             .filter(|h| h.meta.system_idx == Some(sys))
@@ -87,7 +86,7 @@ pub(crate) fn export(sig: &Sig, divisions: u32) -> Result<String, CodecError> {
             for &m_num in &measure_numbers {
                 writeln!(out, "    <measure number=\"{}\">", m_num).unwrap();
 
-                // Attribute-Inters für diesen Takt?
+                // Attribute-Inters f├╝r diesen Takt?
                 let clef = clefs
                     .iter()
                     .find(|c| c.meta.system_idx == Some(sys) && c.meta.measure_number == Some(m_num));
@@ -123,7 +122,7 @@ pub(crate) fn export(sig: &Sig, divisions: u32) -> Result<String, CodecError> {
                     writeln!(out, "      </attributes>").unwrap();
                 }
 
-                // Noten für diesen Takt, sortiert nach x
+                // Noten f├╝r diesen Takt, sortiert nach x
                 let measure_heads: Vec<&&HeadInter> = heads
                     .iter()
                     .filter(|h| {

--- a/src/omr-rust/crates/omr-sig-codec/src/id_mapping.rs
+++ b/src/omr-rust/crates/omr-sig-codec/src/id_mapping.rs
@@ -1,12 +1,12 @@
 //! Stabiles ID-Mapping zwischen MusicXML `<note id="..."/>` und `InterId`.
 //!
 //! Das Mapping wird beim Import aufgebaut und kann anschliessend genutzt
-//! werden, um MusicXML-IDs zu Sig-Inters aufzulösen und umgekehrt.
+//! werden, um MusicXML-IDs zu Sig-Inters aufzul├╢sen und umgekehrt.
 
 use omr_sig::inter::InterId;
 use std::collections::HashMap;
 
-/// Bidirektionales Mapping: MusicXML-ID ↔ InterId.
+/// Bidirektionales Mapping: MusicXML-ID Γåö InterId.
 #[derive(Debug, Default, Clone)]
 pub struct IdMapping {
     inter_to_xml: HashMap<InterId, String>,
@@ -26,12 +26,12 @@ impl IdMapping {
         self.inter_to_xml.insert(inter_id, xml_id);
     }
 
-    /// XML-ID für einen Inter (falls vorhanden).
+    /// XML-ID f├╝r einen Inter (falls vorhanden).
     pub fn xml_id_for(&self, id: InterId) -> Option<&str> {
         self.inter_to_xml.get(&id).map(String::as_str)
     }
 
-    /// InterId für eine XML-ID (falls vorhanden).
+    /// InterId f├╝r eine XML-ID (falls vorhanden).
     pub fn inter_id_for(&self, xml_id: &str) -> Option<InterId> {
         self.xml_to_inter.get(xml_id).copied()
     }

--- a/src/omr-rust/crates/omr-sig-codec/src/importer.rs
+++ b/src/omr-rust/crates/omr-sig-codec/src/importer.rs
@@ -1,9 +1,9 @@
-//! MusicXML → Sig Importer.
+//! MusicXML ΓåÆ Sig Importer.
 //!
 //! Parst eine `score-partwise` MusicXML-Datei und baut daraus einen SIG auf.
-//! Für jede `<part>` wird `system_idx` hochgezählt. Noten ohne `<pitch>`
-//! (Pausen) werden als `RestInter` behandelt und übersprungen (noch nicht
-//! als vollständiger RestInter modelliert).
+//! F├╝r jede `<part>` wird `system_idx` hochgez├ñhlt. Noten ohne `<pitch>`
+//! (Pausen) werden als `RestInter` behandelt und ├╝bersprungen (noch nicht
+//! als vollst├ñndiger RestInter modelliert).
 
 use omr_core::{NoteheadKind, PitchStep, Point, Rect};
 use omr_sig::{
@@ -68,7 +68,7 @@ pub(crate) fn import(
 
                 match name.as_str() {
                     "part" => {
-                        // part_idx bleibt während der Verarbeitung dieser Part konstant
+                        // part_idx bleibt w├ñhrend der Verarbeitung dieser Part konstant
                     }
                     "measure" => {
                         for attr in e.attributes().flatten() {
@@ -82,7 +82,7 @@ pub(crate) fn import(
                     }
                     "attributes" => {
                         in_attributes = true;
-                        // Reset Akkumulatoren für diesen Attribut-Block
+                        // Reset Akkumulatoren f├╝r diesen Attribut-Block
                         key_fifths = None;
                         time_beats = None;
                         time_beat_type = None;
@@ -159,7 +159,7 @@ pub(crate) fn import(
                         note_octave = text.parse().ok();
                     }
                     Some("alter") if in_pitch => {
-                        // alter kann Dezimalzahl sein (z.B. "-1.0") → parse als f32, dann runden
+                        // alter kann Dezimalzahl sein (z.B. "-1.0") ΓåÆ parse als f32, dann runden
                         note_alter = text
                             .parse::<f32>()
                             .map(|f| f.round() as i8)
@@ -267,7 +267,7 @@ pub(crate) fn import(
                     "measure" => {}
                     "part" => {
                         part_idx += 1;
-                        // attrs_created_for per-part zurücksetzen, damit nächste Part
+                        // attrs_created_for per-part zur├╝cksetzen, damit n├ñchste Part
                         // ihre eigenen Attribute-Inters bekommt
                         attrs_created_for = None;
                     }
@@ -284,8 +284,8 @@ pub(crate) fn import(
     Ok((sig, id_mapping))
 }
 
-/// Erstellt Clef-, KeySignature- und TimeSignature-Inters für einen
-/// Attribut-Block und fügt sie dem SIG hinzu.
+/// Erstellt Clef-, KeySignature- und TimeSignature-Inters f├╝r einen
+/// Attribut-Block und f├╝gt sie dem SIG hinzu.
 fn emit_attribute_inters(
     sig: &mut Sig,
     part_idx: u32,
@@ -387,10 +387,10 @@ pub(crate) fn pitch_to_midi(step: PitchStep, octave: i8, alter: i8) -> u8 {
     midi.clamp(0, 127) as u8
 }
 
-/// Hilfsfunktion: raw tag-name bytes → String (ohne Namespace-Präfix).
+/// Hilfsfunktion: raw tag-name bytes ΓåÆ String (ohne Namespace-Pr├ñfix).
 fn tag_name(bytes: &[u8]) -> String {
     let s = std::str::from_utf8(bytes).unwrap_or("");
-    // Namespace-Präfix abschneiden (z.B. "xml:id" → "id")
+    // Namespace-Pr├ñfix abschneiden (z.B. "xml:id" ΓåÆ "id")
     if let Some(pos) = s.rfind(':') {
         s[pos + 1..].to_string()
     } else {

--- a/src/omr-rust/crates/omr-sig-codec/src/lib.rs
+++ b/src/omr-rust/crates/omr-sig-codec/src/lib.rs
@@ -1,9 +1,9 @@
-//! omr-sig-codec — bidirektionale Konvertierung zwischen MusicXML und Sig.
+//! omr-sig-codec ΓÇö bidirektionale Konvertierung zwischen MusicXML und Sig.
 //!
-//! # Überblick
+//! # ├£berblick
 //!
-//! Dieser Crate implementiert den vollständigen Import (MusicXML → SIG) und
-//! Export (SIG → MusicXML), einschließlich stabiler ID-Erhaltung via
+//! Dieser Crate implementiert den vollst├ñndigen Import (MusicXML ΓåÆ SIG) und
+//! Export (SIG ΓåÆ MusicXML), einschlie├ƒlich stabiler ID-Erhaltung via
 //! [`IdMapping`].
 //!
 //! # Beispiel
@@ -26,7 +26,7 @@ mod tests {
     use super::*;
     use omr_sig::{inters::HeadInter, Inter};
 
-    // ── Hilfsfunktionen ───────────────────────────────────────────────────────
+    // ΓöÇΓöÇ Hilfsfunktionen ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
 
     /// Minimales XML mit einem Takt und einer Note C4.
     fn xml_one_note(note_id: &str, step: &str, octave: i8, alter: i8) -> String {
@@ -71,7 +71,7 @@ mod tests {
         count
     }
 
-    // ── Tests ─────────────────────────────────────────────────────────────────
+    // ΓöÇΓöÇ Tests ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
 
     #[test]
     fn import_simple_score() {
@@ -182,7 +182,7 @@ mod tests {
   </part>
 </score-partwise>"#;
         let sig = SigCodec::new().import_musicxml(xml).unwrap();
-        // 2 Parts × (1 Clef + 1 Key + 1 Time + 1 Head) = 8 Inters
+        // 2 Parts ├ù (1 Clef + 1 Key + 1 Time + 1 Head) = 8 Inters
         assert_eq!(sig.inter_count(), 8);
 
         let heads: Vec<&HeadInter> = sig.typed_inters::<HeadInter>().collect();
@@ -267,7 +267,7 @@ mod tests {
 
     #[test]
     fn import_sets_pitch_correctly_bb3() {
-        // Bb3 = B♭3 = step=B, alter=-1, octave=3 → MIDI 58
+        // Bb3 = BΓÖ¡3 = step=B, alter=-1, octave=3 ΓåÆ MIDI 58
         let xml = xml_one_note("n1", "B", 3, -1);
         let sig = SigCodec::new().import_musicxml(&xml).unwrap();
         let heads: Vec<&HeadInter> = sig.typed_inters::<HeadInter>().collect();
@@ -383,7 +383,7 @@ pub use id_mapping::IdMapping;
 
 use omr_sig::sig::Sig;
 
-/// Fehler beim MusicXML ↔ Sig Codec.
+/// Fehler beim MusicXML Γåö Sig Codec.
 #[derive(thiserror::Error, Debug)]
 pub enum CodecError {
     /// XML-Syntaxfehler.
@@ -392,15 +392,15 @@ pub enum CodecError {
     /// Pflicht-Element fehlt.
     #[error("Missing required element: {0}")]
     MissingElement(String),
-    /// Taktangabe ungültig (z.B. beats=0).
+    /// Taktangabe ung├╝ltig (z.B. beats=0).
     #[error("Invalid time signature: {0}")]
     InvalidTimeSig(String),
-    /// Unbekannter Pitch-Step (nicht C–B).
+    /// Unbekannter Pitch-Step (nicht CΓÇôB).
     #[error("Invalid pitch step: {0}")]
     InvalidStep(String),
 }
 
-/// Bidirektionaler MusicXML ↔ SIG Codec.
+/// Bidirektionaler MusicXML Γåö SIG Codec.
 pub struct SigCodec {
     /// Divisions pro Viertelnote (default: 4).
     pub divisions: u32,
@@ -421,13 +421,13 @@ impl SigCodec {
     /// Importiert MusicXML als String zu einem neuen Sig.
     ///
     /// Stable IDs aus MusicXML `<note id="..."/>` werden in der
-    /// zurückgegebenen `IdMapping` gespeichert (via
+    /// zur├╝ckgegebenen `IdMapping` gespeichert (via
     /// [`import_musicxml_with_mapping`]).
     pub fn import_musicxml(&self, xml: &str) -> Result<Sig, CodecError> {
         importer::import(xml, self.divisions).map(|(sig, _)| sig)
     }
 
-    /// Importiert MusicXML und liefert zusätzlich das ID-Mapping.
+    /// Importiert MusicXML und liefert zus├ñtzlich das ID-Mapping.
     pub fn import_musicxml_with_mapping(
         &self,
         xml: &str,
@@ -442,7 +442,7 @@ impl SigCodec {
         exporter::export(sig, self.divisions)
     }
 
-    /// Round-trip: import dann export. Gibt das exportierte XML zurück.
+    /// Round-trip: import dann export. Gibt das exportierte XML zur├╝ck.
     pub fn roundtrip(&self, xml: &str) -> Result<String, CodecError> {
         let sig = self.import_musicxml(xml)?;
         self.export_musicxml(&sig)


### PR DESCRIPTION
## Zusammenfassung

Neuer Crate \omr-sig-codec\ — bidirektionaler MusicXML ↔ SIG Codec.

## API

\\\ust
pub struct SigCodec { pub divisions: u32 }

impl SigCodec {
    pub fn import_musicxml(&self, xml: &str) -> Result<Sig, CodecError>;
    pub fn import_musicxml_with_mapping(&self, xml: &str) -> Result<(Sig, IdMapping), CodecError>;
    pub fn export_musicxml(&self, sig: &Sig) -> Result<String, CodecError>;
    pub fn roundtrip(&self, xml: &str) -> Result<String, CodecError>;
}
\\\

## Round-Trip-Beispiel

\\\ust
let codec = SigCodec::new();
let sig = codec.import_musicxml(xml).unwrap();
assert_eq!(sig.inter_count(), 5); // 1 Clef + 1 Key + 1 Time + 2 Heads

let out = codec.export_musicxml(&sig).unwrap();
assert!(out.contains("<step>C</step>"));

let roundtripped = codec.roundtrip(xml).unwrap();
// gleiche Anzahl Takte + Noten
\\\

## Module

| Datei | Inhalt |
|-------|--------|
| \importer.rs\ | event-basierter MusicXML-Parser (quick-xml), MusicXML -> Sig |
| \xporter.rs\ | Sig -> MusicXML, sortiert nach (system_idx, measure_number, x) |
| \id_mapping.rs\ | Bidirektionales Mapping MusicXML note/@id <-> InterId |

## Tests: 16 gruen

\\\
test result: ok. 15 passed; 0 failed; 0 ignored
test result: ok. 1 passed; 0 failed (doctest)
\\\

Tests:
- import_simple_score (5 Inters: Clef+Key+Time+2 Heads)
- export_preserves_pitches
- roundtrip_minimal_score
- import_handles_multiple_parts
- import_preserves_note_ids (via IdMapping)
- export_with_keysig_writes_fifths
- export_with_timesig_writes_beats
- import_sets_pitch_correctly_C4 (MIDI 60)
- import_sets_pitch_correctly_Bb3 (MIDI 58)
- empty_sig_exports_minimal_xml
- import_midi_calculation_multiple_notes
- export_multipart_writes_separate_parts
- import_rest_creates_rest_inter

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>