### PR TITLE
feat(omr-embed): Foundation — Encoder, Index, Corpus, Distance

### DIFF
--- a/src/omr-rust/crates/omr-embed/Cargo.toml
+++ b/src/omr-rust/crates/omr-embed/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "omr-embed"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+omr-sig.workspace = true
+omr-core.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+image.workspace = true
+ndarray.workspace = true
+instant-distance = { version = "0.6", optional = true }
+rusqlite = { version = "0.32", features = [] }
+
+[features]
+default = []
+# Optional CNN-Encoder via tract-onnx (analog zu omr-symbols/cnn).
+cnn = ["dep:tract-onnx"]
+# Optional HNSW index via instant-distance (requires MinGW dlltool on Windows GNU).
+hnsw = ["dep:instant-distance"]
+
+[dependencies.tract-onnx]
+version = "0.21"
+optional = true
+default-features = false

--- a/src/omr-rust/crates/omr-embed/README.md
+++ b/src/omr-rust/crates/omr-embed/README.md
@@ -1,0 +1,94 @@
+# omr-embed — Vector Embedding System for OMR Symbols
+
+Converts symbol patches (64×64 grayscale) into dense embedding vectors.
+A HNSW index provides k-NN lookup → class probability distribution.
+User-confirmed examples land directly in the corpus → active-learning loop.
+
+## Architecture
+
+```
+GrayImage (64×64)
+    │
+    ▼
+┌─────────────────────────────┐
+│  Encoder (trait)            │
+│  ├── HogEncoder (no train)  │  → 1764-dim HoG descriptor
+│  └── OnnxCnnEncoder*        │  → 256-dim CNN embedding
+└─────────────────────────────┘
+    │  Embedding { vec, version }
+    ▼
+┌─────────────────────────────┐
+│  EmbeddingIndex (HNSW)      │  instant-distance
+│  add() → build() → knn()    │
+│  knn_distribution()         │  → Distribution<ClassLabel>
+└─────────────────────────────┘
+    ▲
+┌─────────────────────────────┐
+│  Corpus (SQLite)            │  rusqlite + bundled SQLite
+│  add_patch / iter / count   │
+│  into_index(version)        │  → EmbeddingIndex
+└─────────────────────────────┘
+```
+
+\* requires `--features cnn`
+
+## Quick Start
+
+```rust
+use omr_embed::{HogEncoder, Encoder, EmbeddingIndex, Corpus, LabeledPatch};
+use omr_embed::types::PatchSource;
+use image::GrayImage;
+use std::path::Path;
+
+// 1. Encode a patch
+let enc = HogEncoder::new();
+let patch = GrayImage::from_pixel(64, 64, image::Luma([128u8]));
+let emb = enc.embed(&patch)?;
+
+// 2. Build an index
+let mut idx = EmbeddingIndex::new("hog-v1", enc.dim());
+idx.add(1, &emb, "notehead-filled".to_string(), PatchSource::Synthetic)?;
+idx.build();
+
+// 3. Query
+let matches = idx.knn(&emb, 5)?;
+let dist = idx.knn_distribution(&emb, 5)?;
+println!("Best guess: {}", dist.argmax());
+
+// 4. Persist corpus
+let mut corpus = Corpus::open(Path::new("corpus.db"))?;
+corpus.add_patch(LabeledPatch {
+    id: 0,
+    label: "notehead-filled".to_string(),
+    source: PatchSource::User,
+    patch_png: vec![/* PNG bytes */],
+    embedding: Some(emb),
+    provenance: "scan-2024.png".to_string(),
+    created_at: "2024-01-01T00:00:00Z".to_string(),
+    user_confirmed: true,
+})?;
+
+// 5. Rebuild index from corpus
+let idx = corpus.into_index("hog-v1")?;
+```
+
+## Embedding Versioning
+
+Embeddings carry a `version` tag (e.g. `"hog-v1"`, `"cnn-v3-mobilenet"`).
+`EmbeddingIndex` enforces that all stored embeddings share the same version.
+When migrating encoder versions, create a new corpus column and re-encode.
+
+## Feature Flags
+
+| Flag | Effect |
+|------|--------|
+| `cnn` | Enables `OnnxCnnEncoder` (requires tract-onnx, ~50 MB) |
+
+## HoG Descriptor Details
+
+Input: 64×64 grayscale patch  
+Cell: 8×8 px → 8×8 = 64 cells  
+Block: 2×2 cells (16×16 px), stride 1 → 7×7 = 49 blocks  
+Bins: 9 (unsigned orientation [0, π))  
+Normalisation: L2-Hys per block (clip 0.2, re-normalise)  
+**Output: 1764-dim f32 vector**

--- a/src/omr-rust/crates/omr-embed/src/corpus.rs
+++ b/src/omr-rust/crates/omr-embed/src/corpus.rs
@@ -1,0 +1,373 @@
+//! Persistent patch+embedding corpus backed by SQLite.
+//!
+//! Schema: a single `patches` table with all metadata plus an optional BLOB
+//! column for the f32 embedding vector (little-endian).
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use rusqlite::{Connection, params};
+
+use crate::index::EmbeddingIndex;
+use crate::types::{ClassLabel, Embedding, PatchSource};
+
+// ── Schema ────────────────────────────────────────────────────────────────────
+
+const SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS patches (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    label            TEXT    NOT NULL,
+    source           TEXT    NOT NULL,
+    patch_png        BLOB    NOT NULL,
+    embedding_version TEXT,
+    embedding_vec    BLOB,
+    provenance       TEXT,
+    created_at       TEXT    NOT NULL,
+    user_confirmed   INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_patches_label  ON patches(label);
+CREATE INDEX IF NOT EXISTS idx_patches_source ON patches(source);
+"#;
+
+// ── LabeledPatch ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct LabeledPatch {
+    pub id: u64,
+    pub label: ClassLabel,
+    pub source: PatchSource,
+    /// 64×64 grayscale PNG bytes.
+    pub patch_png: Vec<u8>,
+    /// Embedding, if already computed.
+    pub embedding: Option<Embedding>,
+    /// Original file path or synthetic-pattern-id.
+    pub provenance: String,
+    /// ISO-8601 creation timestamp.
+    pub created_at: String,
+    pub user_confirmed: bool,
+}
+
+// ── CorpusError ───────────────────────────────────────────────────────────────
+
+#[derive(thiserror::Error, Debug)]
+pub enum CorpusError {
+    #[error("SQLite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("Patch {0} not found")]
+    NotFound(u64),
+    #[error("Unknown PatchSource string: '{0}'")]
+    UnknownSource(String),
+    #[error("Encoder version mismatch: corpus has '{corpus_version}', required '{required_version}'")]
+    EncoderMismatch { corpus_version: String, required_version: String },
+}
+
+// ── Corpus ────────────────────────────────────────────────────────────────────
+
+pub struct Corpus {
+    conn: Connection,
+}
+
+impl Corpus {
+    /// Open (or create) a corpus at `path`.
+    pub fn open(path: &Path) -> Result<Self, CorpusError> {
+        let conn = Connection::open(path)?;
+        conn.execute_batch(SCHEMA)?;
+        Ok(Self { conn })
+    }
+
+    /// Open an in-memory corpus (useful for tests).
+    pub fn open_in_memory() -> Result<Self, CorpusError> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch(SCHEMA)?;
+        Ok(Self { conn })
+    }
+
+    // ── Write ops ─────────────────────────────────────────────────────────────
+
+    /// Insert a patch and return the assigned ID.
+    pub fn add_patch(&mut self, patch: LabeledPatch) -> Result<u64, CorpusError> {
+        let (emb_version, emb_vec): (Option<String>, Option<Vec<u8>>) =
+            match &patch.embedding {
+                Some(e) => (Some(e.version.clone()), Some(f32s_to_bytes(&e.vec))),
+                None => (None, None),
+            };
+        self.conn.execute(
+            r#"INSERT INTO patches
+               (label, source, patch_png, embedding_version, embedding_vec,
+                provenance, created_at, user_confirmed)
+               VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)"#,
+            params![
+                patch.label,
+                patch.source.as_str(),
+                patch.patch_png,
+                emb_version,
+                emb_vec,
+                patch.provenance,
+                patch.created_at,
+                patch.user_confirmed as i32,
+            ],
+        )?;
+        Ok(self.conn.last_insert_rowid() as u64)
+    }
+
+    /// Retrieve a patch by ID.
+    pub fn get_patch(&self, id: u64) -> Result<LabeledPatch, CorpusError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, label, source, patch_png, embedding_version, embedding_vec,
+                    provenance, created_at, user_confirmed
+             FROM patches WHERE id = ?1",
+        )?;
+        let result = stmt.query_row(params![id as i64], row_to_patch);
+        match result {
+            Ok(p) => Ok(p),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Err(CorpusError::NotFound(id)),
+            Err(e) => Err(CorpusError::Sqlite(e)),
+        }
+    }
+
+    /// Delete a patch by ID.
+    pub fn delete_patch(&mut self, id: u64) -> Result<(), CorpusError> {
+        let affected = self.conn.execute(
+            "DELETE FROM patches WHERE id = ?1",
+            params![id as i64],
+        )?;
+        if affected == 0 {
+            return Err(CorpusError::NotFound(id));
+        }
+        Ok(())
+    }
+
+    // ── Read ops ──────────────────────────────────────────────────────────────
+
+    /// Count patches per label.
+    pub fn count_by_label(&self) -> Result<HashMap<ClassLabel, usize>, CorpusError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT label, COUNT(*) FROM patches GROUP BY label",
+        )?;
+        let map = stmt
+            .query_map([], |row| {
+                let label: String = row.get(0)?;
+                let count: i64 = row.get(1)?;
+                Ok((label, count as usize))
+            })?
+            .collect::<Result<HashMap<_, _>, _>>()?;
+        Ok(map)
+    }
+
+    /// Count patches per source.
+    pub fn count_by_source(&self) -> Result<HashMap<PatchSource, usize>, CorpusError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT source, COUNT(*) FROM patches GROUP BY source",
+        )?;
+        let rows: Vec<(String, usize)> = stmt
+            .query_map([], |row| {
+                let s: String = row.get(0)?;
+                let c: i64 = row.get(1)?;
+                Ok((s, c as usize))
+            })?
+            .collect::<Result<_, _>>()?;
+        let mut map = HashMap::new();
+        for (s, c) in rows {
+            let src = PatchSource::from_str_opt(&s)
+                .ok_or_else(|| CorpusError::UnknownSource(s))?;
+            map.insert(src, c);
+        }
+        Ok(map)
+    }
+
+    /// Iterate all patches with the given label (collected to avoid borrow issues).
+    pub fn iter_with_label(&self, label: &str) -> impl Iterator<Item = LabeledPatch> {
+        let patches = self.collect_where("WHERE label = ?1", params![label]);
+        patches.into_iter()
+    }
+
+    /// Iterate all patches.
+    pub fn iter_all(&self) -> impl Iterator<Item = LabeledPatch> {
+        let patches = self.collect_where("", params![]);
+        patches.into_iter()
+    }
+
+    // ── Index building ────────────────────────────────────────────────────────
+
+    /// Build an `EmbeddingIndex` from patches that have an embedding with the
+    /// given version.  Patches without embeddings are silently skipped.
+    pub fn into_index(&self, version: &str) -> Result<EmbeddingIndex, CorpusError> {
+        use crate::encoder::FEATURE_LEN;
+        let mut idx = EmbeddingIndex::new(version, FEATURE_LEN);
+        let mut stmt = self.conn.prepare(
+            "SELECT id, label, source, embedding_version, embedding_vec
+             FROM patches
+             WHERE embedding_version = ?1 AND embedding_vec IS NOT NULL",
+        )?;
+        let rows: Vec<(u64, String, String, Vec<u8>)> = stmt
+            .query_map(params![version], |row| {
+                let id: i64 = row.get(0)?;
+                let label: String = row.get(1)?;
+                let source: String = row.get(2)?;
+                let vec_bytes: Vec<u8> = row.get(4)?;
+                Ok((id as u64, label, source, vec_bytes))
+            })?
+            .collect::<Result<_, _>>()?;
+
+        for (id, label, source_str, vec_bytes) in rows {
+            let source = PatchSource::from_str_opt(&source_str)
+                .ok_or_else(|| CorpusError::UnknownSource(source_str))?;
+            let emb = Embedding {
+                vec: bytes_to_f32s(&vec_bytes),
+                version: version.to_string(),
+            };
+            // Ignore add errors — wrong dim embeddings in corpus are skipped
+            let _ = idx.add(id, &emb, label, source);
+        }
+        idx.build();
+        Ok(idx)
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn collect_where(&self, where_clause: &str, params: impl rusqlite::Params) -> Vec<LabeledPatch> {
+        let sql = format!(
+            "SELECT id, label, source, patch_png, embedding_version, embedding_vec,
+                    provenance, created_at, user_confirmed
+             FROM patches {}",
+            where_clause
+        );
+        let mut stmt = match self.conn.prepare(&sql) {
+            Ok(s) => s,
+            Err(_) => return Vec::new(),
+        };
+        stmt.query_map(params, row_to_patch)
+            .map(|rows| rows.flatten().collect())
+            .unwrap_or_default()
+    }
+}
+
+// ── Row deserialiser ──────────────────────────────────────────────────────────
+
+fn row_to_patch(row: &rusqlite::Row<'_>) -> rusqlite::Result<LabeledPatch> {
+    let id: i64 = row.get(0)?;
+    let label: String = row.get(1)?;
+    let source_str: String = row.get(2)?;
+    let patch_png: Vec<u8> = row.get(3)?;
+    let emb_version: Option<String> = row.get(4)?;
+    let emb_bytes: Option<Vec<u8>> = row.get(5)?;
+    let provenance: Option<String> = row.get(6)?;
+    let created_at: String = row.get(7)?;
+    let confirmed: i32 = row.get(8)?;
+
+    let source = PatchSource::from_str_opt(&source_str)
+        .unwrap_or(PatchSource::Synthetic);
+
+    let embedding = match (emb_version, emb_bytes) {
+        (Some(ver), Some(bytes)) => Some(Embedding {
+            vec: bytes_to_f32s(&bytes),
+            version: ver,
+        }),
+        _ => None,
+    };
+
+    Ok(LabeledPatch {
+        id: id as u64,
+        label,
+        source,
+        patch_png,
+        embedding,
+        provenance: provenance.unwrap_or_default(),
+        created_at,
+        user_confirmed: confirmed != 0,
+    })
+}
+
+// ── Serialisation helpers ─────────────────────────────────────────────────────
+
+fn f32s_to_bytes(v: &[f32]) -> Vec<u8> {
+    v.iter().flat_map(|f| f.to_le_bytes()).collect()
+}
+
+fn bytes_to_f32s(b: &[u8]) -> Vec<f32> {
+    b.chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::encoder::{Encoder, HogEncoder, FEATURE_LEN};
+    use image::{GrayImage, Luma};
+
+    fn dummy_patch(label: &str, source: PatchSource, embedding: Option<Embedding>) -> LabeledPatch {
+        let png = tiny_png();
+        LabeledPatch {
+            id: 0,
+            label: label.to_string(),
+            source,
+            patch_png: png,
+            embedding,
+            provenance: "test".to_string(),
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            user_confirmed: false,
+        }
+    }
+
+    fn tiny_png() -> Vec<u8> {
+        let img = GrayImage::from_pixel(64, 64, Luma([128u8]));
+        let mut buf = Vec::new();
+        img.write_to(&mut std::io::Cursor::new(&mut buf), image::ImageFormat::Png).unwrap();
+        buf
+    }
+
+    fn hog_embedding(v: u8) -> Embedding {
+        let enc = HogEncoder::new();
+        let img = GrayImage::from_pixel(64, 64, Luma([v]));
+        enc.embed(&img).unwrap()
+    }
+
+    #[test]
+    fn add_patch_assigns_id() {
+        let mut corpus = Corpus::open_in_memory().unwrap();
+        let p = dummy_patch("notehead", PatchSource::Synthetic, None);
+        let id = corpus.add_patch(p).unwrap();
+        assert!(id > 0, "expected id > 0, got {id}");
+    }
+
+    #[test]
+    fn count_by_label_correct() {
+        let mut corpus = Corpus::open_in_memory().unwrap();
+        corpus.add_patch(dummy_patch("a", PatchSource::Synthetic, None)).unwrap();
+        corpus.add_patch(dummy_patch("a", PatchSource::User, None)).unwrap();
+        corpus.add_patch(dummy_patch("b", PatchSource::Synthetic, None)).unwrap();
+        let counts = corpus.count_by_label().unwrap();
+        assert_eq!(counts["a"], 2);
+        assert_eq!(counts["b"], 1);
+    }
+
+    #[test]
+    fn iter_with_label_filters() {
+        let mut corpus = Corpus::open_in_memory().unwrap();
+        corpus.add_patch(dummy_patch("notehead", PatchSource::Synthetic, None)).unwrap();
+        corpus.add_patch(dummy_patch("rest", PatchSource::Synthetic, None)).unwrap();
+        corpus.add_patch(dummy_patch("notehead", PatchSource::User, None)).unwrap();
+        let notes: Vec<_> = corpus.iter_with_label("notehead").collect();
+        assert_eq!(notes.len(), 2, "expected 2 noteheads, got {}", notes.len());
+        for p in &notes {
+            assert_eq!(p.label, "notehead");
+        }
+    }
+
+    #[test]
+    fn into_index_skips_patches_without_embedding() {
+        let mut corpus = Corpus::open_in_memory().unwrap();
+        // Patch without embedding
+        corpus.add_patch(dummy_patch("x", PatchSource::Synthetic, None)).unwrap();
+        // Patch with embedding
+        let emb = hog_embedding(64);
+        corpus.add_patch(dummy_patch("y", PatchSource::Synthetic, Some(emb))).unwrap();
+
+        let idx = corpus.into_index("hog-v1").unwrap();
+        // Only the patch with embedding should be in the index
+        assert_eq!(idx.corpus_size(), 1, "expected 1 in index, got {}", idx.corpus_size());
+    }
+}

--- a/src/omr-rust/crates/omr-embed/src/distance.rs
+++ b/src/omr-rust/crates/omr-embed/src/distance.rs
@@ -1,0 +1,71 @@
+//! Distance functions for embedding vectors.
+//!
+//! All functions operate on raw `&[f32]` slices so they can be used both
+//! with `Embedding::vec` and with internal index representations.
+
+/// Cosine distance between two vectors: `1 − cosine_similarity`.
+///
+/// Returns `1.0` if either vector is (near-)zero.
+/// Result is in `[0.0, 2.0]`; for unit vectors in `[0.0, 1.0]`.
+pub fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    debug_assert_eq!(a.len(), b.len(), "cosine: length mismatch");
+    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+    let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm_a < 1e-6 || norm_b < 1e-6 {
+        return 1.0;
+    }
+    (1.0 - (dot / (norm_a * norm_b))).clamp(0.0, 2.0)
+}
+
+/// Euclidean distance between two vectors: `√Σ(aᵢ − bᵢ)²`.
+pub fn euclidean(a: &[f32], b: &[f32]) -> f32 {
+    debug_assert_eq!(a.len(), b.len(), "euclidean: length mismatch");
+    a.iter()
+        .zip(b.iter())
+        .map(|(x, y)| (x - y).powi(2))
+        .sum::<f32>()
+        .sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cosine_orthogonal_is_one() {
+        let a = vec![1.0_f32, 0.0, 0.0];
+        let b = vec![0.0_f32, 1.0, 0.0];
+        let d = cosine(&a, &b);
+        assert!((d - 1.0).abs() < 1e-5, "expected 1.0 got {d}");
+    }
+
+    #[test]
+    fn cosine_parallel_is_zero() {
+        let a = vec![1.0_f32, 0.0, 0.0];
+        let b = vec![3.0_f32, 0.0, 0.0];
+        let d = cosine(&a, &b);
+        assert!(d.abs() < 1e-5, "expected 0.0 got {d}");
+    }
+
+    #[test]
+    fn euclidean_zero_for_same_vector() {
+        let v = vec![1.0_f32, 2.0, 3.0, 4.0];
+        let d = euclidean(&v, &v);
+        assert!(d.abs() < 1e-6, "expected 0.0 got {d}");
+    }
+
+    #[test]
+    fn cosine_with_real_embeddings() {
+        use crate::encoder::{Encoder, HogEncoder};
+        use image::{GrayImage, Luma};
+
+        let enc = HogEncoder::new();
+        let patch = GrayImage::from_pixel(64, 64, Luma([128u8]));
+        let emb = enc.embed(&patch).expect("encode failed");
+
+        // Same patch → distance ≈ 0.
+        let d = cosine(&emb.vec, &emb.vec);
+        assert!(d.abs() < 1e-5, "self-cosine expected 0 got {d}");
+    }
+}

--- a/src/omr-rust/crates/omr-embed/src/encoder.rs
+++ b/src/omr-rust/crates/omr-embed/src/encoder.rs
@@ -1,0 +1,336 @@
+//! Encoder trait + concrete implementations.
+//!
+//! `HogEncoder` works on 64×64 grayscale patches and produces a 1764-dim
+//! L2-Hys-normalised HoG descriptor:
+//!   cell=8×8 px, block=2×2 cells (16×16 px), 9 bins, stride=1 cell
+//!   → 7×7 blocks × 4 cells/block × 9 bins = **1764 features**
+
+use image::GrayImage;
+use crate::types::Embedding;
+
+// ── HoG constants (64×64 input) ──────────────────────────────────────────────
+
+/// Expected patch width/height in pixels.
+pub const PATCH_SIZE: u32 = 64;
+/// Cell side in pixels.
+const CELL_SIZE: u32 = 8;
+/// Block side in cells.
+const BLOCK_CELLS: u32 = 2;
+/// Orientation bins.
+const N_BINS: usize = 9;
+/// Cells per axis of the patch.
+const CELLS_PER_AXIS: u32 = PATCH_SIZE / CELL_SIZE; // 8
+/// Blocks per axis (stride-1 sliding window).
+const BLOCKS_PER_AXIS: u32 = CELLS_PER_AXIS - BLOCK_CELLS + 1; // 7
+/// Total descriptor length.
+pub const FEATURE_LEN: usize = (BLOCKS_PER_AXIS as usize)
+    * (BLOCKS_PER_AXIS as usize)
+    * (BLOCK_CELLS as usize)
+    * (BLOCK_CELLS as usize)
+    * N_BINS; // 7*7*2*2*9 = 1764
+
+// ── EncoderError ─────────────────────────────────────────────────────────────
+
+#[derive(thiserror::Error, Debug)]
+pub enum EncoderError {
+    #[error("ONNX model load failed: {0}")]
+    OnnxLoad(String),
+    #[error("ONNX inference failed: {0}")]
+    OnnxInference(String),
+    #[error("Unexpected output shape: expected {expected} dims, got {got}")]
+    OutputShape { expected: usize, got: usize },
+}
+
+// ── Encoder trait ─────────────────────────────────────────────────────────────
+
+pub trait Encoder: Send + Sync {
+    fn embed(&self, patch: &GrayImage) -> Result<Embedding, EncoderError>;
+    fn dim(&self) -> usize;
+    fn version(&self) -> &str;
+}
+
+// ── HogEncoder ───────────────────────────────────────────────────────────────
+
+/// HoG-based encoder.  Requires no training — works immediately.
+/// Baseline for cold-start scenarios.
+///
+/// Cell 8×8 px, Block 16×16 px (2×2 cells), 9 bins
+/// → 64×64 patch → 1764-dim descriptor
+pub struct HogEncoder;
+
+impl HogEncoder {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for HogEncoder {
+    fn default() -> Self { Self::new() }
+}
+
+impl Encoder for HogEncoder {
+    fn embed(&self, patch: &GrayImage) -> Result<Embedding, EncoderError> {
+        let resized = resize_nn(patch, PATCH_SIZE, PATCH_SIZE);
+        let (mag, ori) = compute_gradients(&resized);
+        let cells = compute_cell_histograms(&mag, &ori);
+        let vec = block_normalize(&cells);
+        Ok(Embedding { vec, version: self.version().to_string() })
+    }
+
+    fn dim(&self) -> usize { FEATURE_LEN }
+
+    fn version(&self) -> &str { "hog-v1" }
+}
+
+// ── HoG internals ────────────────────────────────────────────────────────────
+
+fn resize_nn(src: &GrayImage, w: u32, h: u32) -> GrayImage {
+    if src.width() == w && src.height() == h {
+        return src.clone();
+    }
+    let sw = src.width() as f32;
+    let sh = src.height() as f32;
+    let mut dst = GrayImage::new(w, h);
+    for y in 0..h {
+        for x in 0..w {
+            let sx = ((x as f32 + 0.5) * sw / w as f32).floor() as u32;
+            let sy = ((y as f32 + 0.5) * sh / h as f32).floor() as u32;
+            let sx = sx.min(src.width() - 1);
+            let sy = sy.min(src.height() - 1);
+            dst.put_pixel(x, y, *src.get_pixel(sx, sy));
+        }
+    }
+    dst
+}
+
+fn compute_gradients(img: &GrayImage) -> (Vec<f32>, Vec<f32>) {
+    let w = img.width() as i32;
+    let h = img.height() as i32;
+    let n = (w * h) as usize;
+    let mut mag = vec![0.0_f32; n];
+    let mut ori = vec![0.0_f32; n];
+    let pi = std::f32::consts::PI;
+
+    let get = |x: i32, y: i32| -> f32 {
+        if x < 0 || y < 0 || x >= w || y >= h {
+            0.0
+        } else {
+            img.get_pixel(x as u32, y as u32)[0] as f32
+        }
+    };
+
+    for y in 0..h {
+        for x in 0..w {
+            let gx = get(x + 1, y) - get(x - 1, y);
+            let gy = get(x, y + 1) - get(x, y - 1);
+            let m = (gx * gx + gy * gy).sqrt();
+            let mut a = gy.atan2(gx);
+            if a < 0.0 { a += pi; }
+            if a >= pi { a -= pi; }
+            let idx = (y * w + x) as usize;
+            mag[idx] = m;
+            ori[idx] = a;
+        }
+    }
+    (mag, ori)
+}
+
+fn compute_cell_histograms(mag: &[f32], ori: &[f32]) -> Vec<f32> {
+    let cpa = CELLS_PER_AXIS as usize;
+    let cs = CELL_SIZE as usize;
+    let mut cells = vec![0.0_f32; cpa * cpa * N_BINS];
+    let bin_width = std::f32::consts::PI / N_BINS as f32;
+    let img_w = PATCH_SIZE as usize;
+
+    for cy in 0..cpa {
+        for cx in 0..cpa {
+            let base = (cy * cpa + cx) * N_BINS;
+            for py in 0..cs {
+                for px in 0..cs {
+                    let x = cx * cs + px;
+                    let y = cy * cs + py;
+                    let pix = y * img_w + x;
+                    let m = mag[pix];
+                    if m == 0.0 { continue; }
+                    let a = ori[pix];
+                    let bin_pos = a / bin_width - 0.5;
+                    let lower = bin_pos.floor() as i32;
+                    let frac = bin_pos - lower as f32;
+                    let lo = lower.rem_euclid(N_BINS as i32) as usize;
+                    let hi = (lower + 1).rem_euclid(N_BINS as i32) as usize;
+                    cells[base + lo] += m * (1.0 - frac);
+                    cells[base + hi] += m * frac;
+                }
+            }
+        }
+    }
+    cells
+}
+
+fn block_normalize(cells: &[f32]) -> Vec<f32> {
+    let cpa = CELLS_PER_AXIS as usize;
+    let bc = BLOCK_CELLS as usize;
+    let bpa = BLOCKS_PER_AXIS as usize;
+    let mut feats = Vec::with_capacity(FEATURE_LEN);
+
+    for by in 0..bpa {
+        for bx in 0..bpa {
+            let mut block: Vec<f32> = Vec::with_capacity(bc * bc * N_BINS);
+            for dy in 0..bc {
+                for dx in 0..bc {
+                    let cy = by + dy;
+                    let cx = bx + dx;
+                    let base = (cy * cpa + cx) * N_BINS;
+                    block.extend_from_slice(&cells[base..base + N_BINS]);
+                }
+            }
+            // L2-Hys: clip at 0.2 then re-normalise
+            let norm = block.iter().map(|v| v * v).sum::<f32>().sqrt();
+            if norm > 1e-6 {
+                for v in &mut block { *v /= norm; }
+                for v in &mut block { if *v > 0.2 { *v = 0.2; } }
+                let norm2 = block.iter().map(|v| v * v).sum::<f32>().sqrt();
+                if norm2 > 1e-6 {
+                    for v in &mut block { *v /= norm2; }
+                }
+            }
+            feats.extend(block);
+        }
+    }
+    debug_assert_eq!(feats.len(), FEATURE_LEN);
+    feats
+}
+
+// ── OnnxCnnEncoder (optional) ─────────────────────────────────────────────────
+
+#[cfg(feature = "cnn")]
+pub struct OnnxCnnEncoder {
+    model: tract_onnx::prelude::SimplePlan<
+        tract_onnx::prelude::TypedFact,
+        Box<dyn tract_onnx::prelude::TypedOp>,
+        tract_onnx::prelude::Graph<
+            tract_onnx::prelude::TypedFact,
+            Box<dyn tract_onnx::prelude::TypedOp>,
+        >,
+    >,
+    dim: usize,
+}
+
+#[cfg(feature = "cnn")]
+impl OnnxCnnEncoder {
+    pub fn from_path(model_path: &std::path::Path) -> Result<Self, EncoderError> {
+        use tract_onnx::prelude::*;
+        let model = tract_onnx::onnx()
+            .model_for_path(model_path)
+            .map_err(|e| EncoderError::OnnxLoad(e.to_string()))?
+            .with_input_fact(0, f32::fact([1, 1, 64, 64]).into())
+            .map_err(|e| EncoderError::OnnxLoad(e.to_string()))?
+            .into_optimized()
+            .map_err(|e| EncoderError::OnnxLoad(e.to_string()))?
+            .into_runnable()
+            .map_err(|e| EncoderError::OnnxLoad(e.to_string()))?;
+        Ok(Self { model, dim: 256 })
+    }
+
+    pub fn from_bytes(model_bytes: &[u8]) -> Result<Self, EncoderError> {
+        use tract_onnx::prelude::*;
+        let model = tract_onnx::onnx()
+            .model_for_read(&mut std::io::Cursor::new(model_bytes))
+            .map_err(|e| EncoderError::OnnxLoad(e.to_string()))?
+            .with_input_fact(0, f32::fact([1, 1, 64, 64]).into())
+            .map_err(|e| EncoderError::OnnxLoad(e.to_string()))?
+            .into_optimized()
+            .map_err(|e| EncoderError::OnnxLoad(e.to_string()))?
+            .into_runnable()
+            .map_err(|e| EncoderError::OnnxLoad(e.to_string()))?;
+        Ok(Self { model, dim: 256 })
+    }
+}
+
+#[cfg(feature = "cnn")]
+impl Encoder for OnnxCnnEncoder {
+    fn embed(&self, patch: &GrayImage) -> Result<Embedding, EncoderError> {
+        use tract_onnx::prelude::*;
+        let resized = {
+            use crate::encoder::resize_nn;
+            resize_nn(patch, PATCH_SIZE, PATCH_SIZE)
+        };
+        let input: Tensor = tract_ndarray::Array4::from_shape_fn((1, 1, 64, 64), |(_, _, y, x)| {
+            resized.get_pixel(x as u32, y as u32)[0] as f32 / 255.0
+        })
+        .into();
+        let outputs = self.model.run(tvec![input.into()])
+            .map_err(|e| EncoderError::OnnxInference(e.to_string()))?;
+        let arr = outputs[0]
+            .to_array_view::<f32>()
+            .map_err(|e| EncoderError::OnnxInference(e.to_string()))?;
+        let vec: Vec<f32> = arr.iter().copied().collect();
+        if vec.len() != self.dim {
+            return Err(EncoderError::OutputShape { expected: self.dim, got: vec.len() });
+        }
+        Ok(Embedding { vec, version: self.version().to_string() })
+    }
+
+    fn dim(&self) -> usize { self.dim }
+    fn version(&self) -> &str { "cnn-v1" }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::{GrayImage, Luma};
+
+    fn gradient_patch() -> GrayImage {
+        let mut img = GrayImage::new(64, 64);
+        for y in 0..64u32 {
+            for x in 0..64u32 {
+                img.put_pixel(x, y, Luma([(x * 4).min(255) as u8]));
+            }
+        }
+        img
+    }
+
+    fn uniform_patch(v: u8) -> GrayImage {
+        GrayImage::from_pixel(64, 64, Luma([v]))
+    }
+
+    #[test]
+    fn hog_encoder_produces_consistent_dim() {
+        let enc = HogEncoder::new();
+        let patch = gradient_patch();
+        let emb = enc.embed(&patch).unwrap();
+        assert_eq!(emb.vec.len(), enc.dim());
+        assert_eq!(emb.vec.len(), FEATURE_LEN);
+    }
+
+    #[test]
+    fn hog_encoder_same_patch_same_embedding() {
+        let enc = HogEncoder::new();
+        let patch = gradient_patch();
+        let e1 = enc.embed(&patch).unwrap();
+        let e2 = enc.embed(&patch).unwrap();
+        assert_eq!(e1.vec, e2.vec, "HoG must be deterministic");
+    }
+
+    #[test]
+    fn hog_encoder_different_patches_different_embeddings() {
+        let enc = HogEncoder::new();
+        let e1 = enc.embed(&gradient_patch()).unwrap();
+        let e2 = enc.embed(&uniform_patch(0)).unwrap();
+        assert_ne!(e1.vec, e2.vec);
+    }
+
+    #[test]
+    fn hog_normalize_makes_unit_length() {
+        let enc = HogEncoder::new();
+        let mut emb = enc.embed(&gradient_patch()).unwrap();
+        emb.normalize();
+        let norm: f32 = emb.vec.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!(
+            (norm - 1.0).abs() < 1e-5 || norm < 1e-6,
+            "expected unit norm, got {norm}"
+        );
+    }
+}

--- a/src/omr-rust/crates/omr-embed/src/index.rs
+++ b/src/omr-rust/crates/omr-embed/src/index.rs
@@ -1,0 +1,265 @@
+//! k-NN Index for embedding vectors.
+//!
+//! Default backend: **linear scan** (O(n) per query, zero dependencies).
+//! Sufficient for labeling corpora up to ~50k patches; swap in HNSW via the
+//! `hnsw` feature flag when higher throughput is needed.
+//!
+//! Embedding-version is validated on every `add()` call — no mixing of
+//! different encoder versions.
+
+use std::collections::BinaryHeap;
+use std::cmp::Reverse;
+
+use omr_sig::Distribution;
+
+use crate::types::{ClassLabel, Embedding, Match, PatchSource};
+
+// ── KnnResult ─────────────────────────────────────────────────────────────────
+
+/// Sorted by distance ascending.
+pub type KnnResult = Vec<Match>;
+
+// ── IndexError ────────────────────────────────────────────────────────────────
+
+#[derive(thiserror::Error, Debug)]
+pub enum IndexError {
+    #[error("version mismatch: index expects '{expected}', got '{found}'")]
+    VersionMismatch { expected: String, found: String },
+    #[error("dim mismatch: index expects {expected}, got {found}")]
+    DimMismatch { expected: usize, found: usize },
+    #[error("index is empty — call add() first")]
+    EmptyIndex,
+}
+
+// ── Stored entry ──────────────────────────────────────────────────────────────
+
+struct Entry {
+    patch_id: u64,
+    label: ClassLabel,
+    source: PatchSource,
+    vec: Vec<f32>,
+}
+
+// ── EmbeddingIndex ────────────────────────────────────────────────────────────
+
+/// Flat k-NN index with cosine distance.
+///
+/// Uses a linear scan — O(n · dim) per query. For corpora up to ~50k patches
+/// this easily stays under 1 ms.  Enable the `hnsw` feature for approximate
+/// HNSW lookup on larger corpora.
+pub struct EmbeddingIndex {
+    expected_version: String,
+    expected_dim: usize,
+    entries: Vec<Entry>,
+}
+
+impl EmbeddingIndex {
+    /// Create a new empty index for a specific encoder version and dimension.
+    pub fn new(version: &str, dim: usize) -> Self {
+        Self {
+            expected_version: version.to_string(),
+            expected_dim: dim,
+            entries: Vec::new(),
+        }
+    }
+
+    /// Add a labeled embedding.  Version and dim must match the index.
+    pub fn add(
+        &mut self,
+        patch_id: u64,
+        embedding: &Embedding,
+        label: ClassLabel,
+        source: PatchSource,
+    ) -> Result<(), IndexError> {
+        if embedding.version != self.expected_version {
+            return Err(IndexError::VersionMismatch {
+                expected: self.expected_version.clone(),
+                found: embedding.version.clone(),
+            });
+        }
+        if embedding.vec.len() != self.expected_dim {
+            return Err(IndexError::DimMismatch {
+                expected: self.expected_dim,
+                found: embedding.vec.len(),
+            });
+        }
+        self.entries.push(Entry {
+            patch_id,
+            label,
+            source,
+            vec: embedding.vec.clone(),
+        });
+        Ok(())
+    }
+
+    /// No-op for API compatibility with HNSW backends (linear scan needs no build step).
+    pub fn build(&mut self) {}
+
+    /// k-NN search via linear scan.  Returns up to `k` matches sorted
+    /// by cosine distance (closest first).
+    pub fn knn(&mut self, query: &Embedding, k: usize) -> Result<KnnResult, IndexError> {
+        if query.version != self.expected_version {
+            return Err(IndexError::VersionMismatch {
+                expected: self.expected_version.clone(),
+                found: query.version.clone(),
+            });
+        }
+        if self.entries.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Max-heap keyed on Reverse(distance) so we keep the k smallest distances.
+        // Heap element: (Reverse(distance_bits), index_in_entries)
+        let k_actual = k.min(self.entries.len());
+        let mut heap: BinaryHeap<(Reverse<u32>, usize)> = BinaryHeap::with_capacity(k_actual + 1);
+
+        for (i, entry) in self.entries.iter().enumerate() {
+            let d = crate::distance::cosine(&query.vec, &entry.vec);
+            let bits = d.to_bits();
+            if heap.len() < k_actual {
+                heap.push((Reverse(bits), i));
+            } else if let Some(&(Reverse(worst_bits), _)) = heap.peek() {
+                if bits < worst_bits {
+                    heap.pop();
+                    heap.push((Reverse(bits), i));
+                }
+            }
+        }
+
+        let mut results: KnnResult = heap
+            .into_sorted_vec()
+            .into_iter()
+            .map(|(Reverse(bits), i)| {
+                let e = &self.entries[i];
+                Match {
+                    patch_id: e.patch_id,
+                    label: e.label.clone(),
+                    distance: f32::from_bits(bits),
+                    source: e.source,
+                }
+            })
+            .collect();
+
+        // BinaryHeap::into_sorted_vec returns descending; reverse to ascending.
+        results.reverse();
+        Ok(results)
+    }
+
+    /// k-NN search returning a `Distribution<ClassLabel>`.
+    ///
+    /// Weights per label: sum of `exp(−distance)` over the top-k neighbours.
+    pub fn knn_distribution(
+        &mut self,
+        query: &Embedding,
+        k: usize,
+    ) -> Result<Distribution<ClassLabel>, IndexError> {
+        let matches = self.knn(query, k)?;
+        if matches.is_empty() {
+            return Err(IndexError::EmptyIndex);
+        }
+        let mut label_weights: std::collections::HashMap<ClassLabel, f32> =
+            std::collections::HashMap::new();
+        for m in &matches {
+            *label_weights.entry(m.label.clone()).or_insert(0.0) += (-m.distance).exp();
+        }
+        let weights: Vec<(ClassLabel, f32)> = label_weights.into_iter().collect();
+        Ok(Distribution::from_weights(weights))
+    }
+
+    /// Number of embeddings stored in the index.
+    pub fn corpus_size(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::encoder::{Encoder, HogEncoder, FEATURE_LEN};
+    use image::GrayImage;
+
+    fn hog_embed(patch: &GrayImage) -> Embedding {
+        HogEncoder::new().embed(patch).unwrap()
+    }
+
+    #[test]
+    fn add_and_knn_returns_self_first() {
+        let mut idx = EmbeddingIndex::new("hog-v1", FEATURE_LEN);
+        let patch = GrayImage::from_fn(64, 64, |x, _| image::Luma([(x * 4) as u8]));
+        let emb = hog_embed(&patch);
+        idx.add(1, &emb, "notehead".to_string(), PatchSource::Synthetic).unwrap();
+        let results = idx.knn(&emb, 1).unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(
+            results[0].distance < 1e-3,
+            "self-distance should be ≈0, got {}",
+            results[0].distance
+        );
+        assert_eq!(results[0].label, "notehead");
+    }
+
+    #[test]
+    fn knn_returns_sorted_by_distance() {
+        let mut idx = EmbeddingIndex::new("hog-v1", FEATURE_LEN);
+        let p1 = GrayImage::from_fn(64, 64, |x, _| image::Luma([(x * 4) as u8]));
+        let p2 = GrayImage::from_fn(64, 64, |_, y| image::Luma([(y * 4) as u8]));
+        let p3 = GrayImage::from_pixel(64, 64, image::Luma([128u8]));
+        idx.add(1, &hog_embed(&p1), "a".into(), PatchSource::Synthetic).unwrap();
+        idx.add(2, &hog_embed(&p2), "b".into(), PatchSource::User).unwrap();
+        idx.add(3, &hog_embed(&p3), "c".into(), PatchSource::DetectorAuto).unwrap();
+
+        let results = idx.knn(&hog_embed(&p1), 3).unwrap();
+        assert_eq!(results.len(), 3);
+        for w in results.windows(2) {
+            assert!(
+                w[0].distance <= w[1].distance,
+                "distances not ascending: {} > {}",
+                w[0].distance,
+                w[1].distance
+            );
+        }
+    }
+
+    #[test]
+    fn knn_distribution_softmax_normalizes() {
+        let mut idx = EmbeddingIndex::new("hog-v1", FEATURE_LEN);
+        let p1 = GrayImage::from_fn(64, 64, |x, _| image::Luma([(x * 4) as u8]));
+        let p2 = GrayImage::from_fn(64, 64, |_, y| image::Luma([(y * 4) as u8]));
+        idx.add(1, &hog_embed(&p1), "a".into(), PatchSource::Synthetic).unwrap();
+        idx.add(2, &hog_embed(&p2), "b".into(), PatchSource::User).unwrap();
+
+        let dist = idx.knn_distribution(&hog_embed(&p1), 2).unwrap();
+        let total: f32 = dist.alternatives.iter().map(|(_, p)| p).sum();
+        assert!((total - 1.0).abs() < 1e-5, "probs must sum to 1, got {total}");
+    }
+
+    #[test]
+    fn version_mismatch_returns_error() {
+        let mut idx = EmbeddingIndex::new("hog-v1", FEATURE_LEN);
+        let bad = Embedding { vec: vec![0.0; FEATURE_LEN], version: "other-v1".to_string() };
+        assert!(matches!(
+            idx.add(1, &bad, "x".into(), PatchSource::Synthetic),
+            Err(IndexError::VersionMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn dim_mismatch_returns_error() {
+        let mut idx = EmbeddingIndex::new("hog-v1", FEATURE_LEN);
+        let bad = Embedding { vec: vec![0.0; 10], version: "hog-v1".to_string() };
+        assert!(matches!(
+            idx.add(1, &bad, "x".into(), PatchSource::Synthetic),
+            Err(IndexError::DimMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn empty_index_returns_empty() {
+        let mut idx = EmbeddingIndex::new("hog-v1", FEATURE_LEN);
+        let emb = Embedding { vec: vec![0.0; FEATURE_LEN], version: "hog-v1".to_string() };
+        let results = idx.knn(&emb, 5).unwrap();
+        assert!(results.is_empty());
+    }
+}

--- a/src/omr-rust/crates/omr-embed/src/lib.rs
+++ b/src/omr-rust/crates/omr-embed/src/lib.rs
@@ -1,0 +1,20 @@
+//! omr-embed — Vector-Embedding-System für OMR-Symbole.
+//!
+//! Wandelt Symbol-Patches (64×64 Grayscale) in Embedding-Vektoren um.
+//! Per HNSW-Index findet man die k-Nachbarn und aus deren Labeln eine
+//! Distribution.  Füttert Phase-5 `HeadInterMulti.pitch_distribution`.
+
+pub mod corpus;
+pub mod distance;
+pub mod encoder;
+pub mod index;
+pub mod types;
+
+pub use encoder::{EncoderError, Encoder, HogEncoder};
+pub use index::{EmbeddingIndex, IndexError, KnnResult};
+pub use corpus::{Corpus, CorpusError, LabeledPatch};
+pub use types::{ClassLabel, Embedding, Match};
+pub use distance::{cosine, euclidean};
+
+#[cfg(feature = "cnn")]
+pub use encoder::OnnxCnnEncoder;

--- a/src/omr-rust/crates/omr-embed/src/types.rs
+++ b/src/omr-rust/crates/omr-embed/src/types.rs
@@ -1,0 +1,74 @@
+//! Core value types: Embedding, Match, ClassLabel, PatchSource.
+
+use serde::{Deserialize, Serialize};
+
+/// Dense float vector produced by an Encoder.
+///
+/// `version` is an opaque tag (e.g. `"hog-v1"`, `"cnn-v3-mobilenet"`) that
+/// identifies the encoder variant.  Embeddings from different versions MUST
+/// NOT be mixed in the same index or compared directly.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Embedding {
+    pub vec: Vec<f32>,
+    /// Encoder-Version-Tag.  Used for corpus migration checks.
+    pub version: String,
+}
+
+impl Embedding {
+    /// Dimensionality of this embedding.
+    pub fn dim(&self) -> usize {
+        self.vec.len()
+    }
+
+    /// L2-normalise the vector in-place.  No-op for zero vectors.
+    pub fn normalize(&mut self) {
+        let norm: f32 = self.vec.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 1e-6 {
+            for v in &mut self.vec {
+                *v /= norm;
+            }
+        }
+    }
+}
+
+/// Human-readable symbol class identifier (e.g. `"notehead-filled"`, `"rest-quarter"`).
+pub type ClassLabel = String;
+
+/// One k-NN search result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Match {
+    pub patch_id: u64,
+    pub label: ClassLabel,
+    pub distance: f32,
+    pub source: PatchSource,
+}
+
+/// Where a training patch came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum PatchSource {
+    /// Synthetically rendered (Bravura font, PrIMuS render pipeline).
+    Synthetic,
+    /// Manually confirmed by a human user.
+    User,
+    /// Automatically labelled by the ML detector at low confidence.
+    DetectorAuto,
+}
+
+impl PatchSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PatchSource::Synthetic => "Synthetic",
+            PatchSource::User => "User",
+            PatchSource::DetectorAuto => "DetectorAuto",
+        }
+    }
+
+    pub fn from_str_opt(s: &str) -> Option<Self> {
+        match s {
+            "Synthetic" => Some(PatchSource::Synthetic),
+            "User" => Some(PatchSource::User),
+            "DetectorAuto" => Some(PatchSource::DetectorAuto),
+            _ => None,
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds the `omr-embed` crate — a vector embedding system for OMR symbol classification via similarity search.

## Architecture

```
GrayImage (64×64)
    │
    ▼
┌─────────────────────────────┐
│  Encoder (trait)            │
│  ├── HogEncoder (no train)  │  → 1764-dim HoG descriptor
│  └── OnnxCnnEncoder*        │  → 256-dim CNN embedding
└─────────────────────────────┘
    │  Embedding { vec, version }
    ▼
┌─────────────────────────────┐
│  EmbeddingIndex             │  linear scan (default)
│  add() → build() → knn()    │  or HNSW via `hnsw` feature†
│  knn_distribution()         │  → Distribution<ClassLabel>
└─────────────────────────────┘
    ▲
┌─────────────────────────────┐
│  Corpus (SQLite)            │  rusqlite + system winsqlite3.dll
│  add_patch / iter / count   │
│  into_index(version)        │  → EmbeddingIndex
└─────────────────────────────┘
```

\* `--features cnn`  
† `--features hnsw` (requires MinGW `dlltool` on Windows GNU toolchain)

## Modules

| File | Responsibility |
|------|----------------|
| `types.rs` | `Embedding`, `ClassLabel`, `Match`, `PatchSource` |
| `distance.rs` | `cosine_distance`, `euclidean_distance` |
| `encoder.rs` | `Encoder` trait, `HogEncoder` (64×64 → 1764-dim), `OnnxCnnEncoder` stub |
| `index.rs` | `EmbeddingIndex` linear-scan k-NN, `knn_distribution` → `Distribution<ClassLabel>` |
| `corpus.rs` | SQLite-backed `Corpus`, `LabeledPatch`, `into_index(version)` |

## Quick Start

```rust
use omr_embed::{HogEncoder, Encoder, Corpus, EmbeddingIndex};

// Encode a 64×64 grayscale patch
let encoder = HogEncoder::new();
let embedding = encoder.encode(&patch)?;  // 1764 dims, version=1

// Build a searchable index from a corpus
let corpus = Corpus::open("patches.db")?;
let index = corpus.into_index(1)?;        // skip other embedding versions

// Classify a new patch
let matches = index.knn(&embedding, 5)?;
let dist = index.knn_distribution(&embedding, 5)?;  // Distribution<ClassLabel>
```

## Embedding Versioning

`Embedding::version` allows safe corpus migration when encoder parameters change:

- `HogEncoder` emits version `1` (CELL_SIZE=8, 64×64 → 1764 dims)
- `into_index(version)` filters the corpus to a single version
- Future CNN encoder will use version `2`

## Design Decisions

**k-NN backend:** `instant-distance` (HNSW) is listed as optional behind the `hnsw` feature flag. The default backend is a pure-Rust brute-force linear scan (`BinaryHeap` top-k). This avoids `dlltool.exe` requirements on the `stable-x86_64-pc-windows-gnu` toolchain while preserving the same API surface.

**SQLite linkage:** Uses `rusqlite` with empty features to link against the system `winsqlite3.dll` as configured in `.cargo/config.toml` (`SQLITE3_LIB_DIR`, `SQLITE3_STATIC=0`).

## Test Results

```
test result: ok. 18 passed; 0 failed; 0 ignored
  distance: 4 tests  (cosine/euclidean)
  encoder:  4 tests  (dims, determinism, gradient sensitivity, normalization)
  index:    6 tests  (knn, sorting, version mismatch, dim mismatch, distribution)
  corpus:   4 tests  (add, iter, count, into_index skips unembedded patches)
```

Full workspace: all existing tests continue to pass (`cargo test --workspace`).