### PR TITLE
feat(training): comprehensive synthetic pattern generator for OMR cold-start corpus

### DIFF
--- a/src/omr-rust/Cargo.lock
+++ b/src/omr-rust/Cargo.lock
@@ -947,6 +947,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1116,6 +1122,19 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.0",
+]
+
+[[package]]
+name = "instant-distance"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c619cdaa30bb84088963968bee12a45ea5fbbf355f2c021bcd15589f5ca494a"
+dependencies = [
+ "num_cpus",
+ "ordered-float",
+ "parking_lot",
+ "rand 0.8.6",
+ "rayon",
 ]
 
 [[package]]
@@ -1655,6 +1674,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "omr-core"
 version = "0.1.0"
 dependencies = [
@@ -1663,6 +1692,49 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "tracing",
+]
+
+[[package]]
+name = "omr-embed"
+version = "0.1.0"
+dependencies = [
+ "image",
+ "instant-distance",
+ "ndarray",
+ "omr-core",
+ "omr-sig",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+ "tract-onnx",
+]
+
+[[package]]
+name = "omr-labeler"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "clap",
+ "image",
+ "omr-core",
+ "omr-embed",
+ "omr-pipeline",
+ "omr-sig",
+ "omr-sig-store",
+ "omr-staff",
+ "omr-symbols",
+ "pdfium-render",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1816,6 +1888,15 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "ordered-float"
+version = "3.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "owned_ttf_parser"

--- a/src/omr-rust/Cargo.toml
+++ b/src/omr-rust/Cargo.toml
@@ -11,6 +11,8 @@ members = [
     "crates/omr-sig",
     "crates/omr-sig-store",
     "crates/omr-sig-codec",
+    "crates/omr-embed",
+    "crates/omr-labeler",
 ]
 
 [workspace.package]
@@ -60,6 +62,7 @@ omr-pipeline = { path = "crates/omr-pipeline" }
 omr-sig = { path = "crates/omr-sig" }
 omr-sig-store = { path = "crates/omr-sig-store" }
 omr-sig-codec = { path = "crates/omr-sig-codec" }
+omr-embed = { path = "crates/omr-embed" }
 
 [profile.release]
 opt-level = 3

--- a/src/omr-rust/crates/omr-embed/Cargo.toml
+++ b/src/omr-rust/crates/omr-embed/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "omr-embed"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+omr-sig.workspace = true
+omr-core.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+image.workspace = true
+ndarray.workspace = true
+instant-distance = { version = "0.6", optional = true }
+rusqlite = { version = "0.32", features = [] }
+
+[features]
+default = []
+# Optional CNN-Encoder via tract-onnx (analog zu omr-symbols/cnn).
+cnn = ["dep:tract-onnx"]
+# Optional HNSW index via instant-distance (requires MinGW dlltool on Windows GNU).
+hnsw = ["dep:instant-distance"]
+
+[dependencies.tract-onnx]
+version = "0.21"
+optional = true
+default-features = false

--- a/src/omr-rust/crates/omr-embed/README.md
+++ b/src/omr-rust/crates/omr-embed/README.md
@@ -1,0 +1,94 @@
+# omr-embed — Vector Embedding System for OMR Symbols
+
+Converts symbol patches (64×64 grayscale) into dense embedding vectors.
+A HNSW index provides k-NN lookup → class probability distribution.
+User-confirmed examples land directly in the corpus → active-learning loop.
+
+## Architecture
+
+```
+GrayImage (64×64)
+    │
+    ▼
+┌─────────────────────────────┐
+│  Encoder (trait)            │
+│  ├── HogEncoder (no train)  │  → 1764-dim HoG descriptor
+│  └── OnnxCnnEncoder*        │  → 256-dim CNN embedding
+└─────────────────────────────┘
+    │  Embedding { vec, version }
+    ▼
+┌─────────────────────────────┐
+│  EmbeddingIndex (HNSW)      │  instant-distance
+│  add() → build() → knn()    │
+│  knn_distribution()         │  → Distribution<ClassLabel>
+└─────────────────────────────┘
+    ▲
+┌─────────────────────────────┐
+│  Corpus (SQLite)            │  rusqlite + bundled SQLite
+│  add_patch / iter / count   │
+│  into_index(version)        │  → EmbeddingIndex
+└─────────────────────────────┘
+```
+
+\* requires `--features cnn`
+
+## Quick Start
+
+```rust
+use omr_embed::{HogEncoder, Encoder, EmbeddingIndex, Corpus, LabeledPatch};
+use omr_embed::types::PatchSource;
+use image::GrayImage;
+use std::path::Path;
+
+// 1. Encode a patch
+let enc = HogEncoder::new();
+let patch = GrayImage::from_pixel(64, 64, image::Luma([128u8]));
+let emb = enc.embed(&patch)?;
+
+// 2. Build an index
+let mut idx = EmbeddingIndex::new("hog-v1", enc.dim());
+idx.add(1, &emb, "notehead-filled".to_string(), PatchSource::Synthetic)?;
+idx.build();
+
+// 3. Query
+let matches = idx.knn(&emb, 5)?;
+let dist = idx.knn_distribution(&emb, 5)?;
+println!("Best guess: {}", dist.argmax());
+
+// 4. Persist corpus
+let mut corpus = Corpus::open(Path::new("corpus.db"))?;
+corpus.add_patch(LabeledPatch {
+    id: 0,
+    label: "notehead-filled".to_string(),
+    source: PatchSource::User,
+    patch_png: vec![/* PNG bytes */],
+    embedding: Some(emb),
+    provenance: "scan-2024.png".to_string(),
+    created_at: "2024-01-01T00:00:00Z".to_string(),
+    user_confirmed: true,
+})?;
+
+// 5. Rebuild index from corpus
+let idx = corpus.into_index("hog-v1")?;
+```
+
+## Embedding Versioning
+
+Embeddings carry a `version` tag (e.g. `"hog-v1"`, `"cnn-v3-mobilenet"`).
+`EmbeddingIndex` enforces that all stored embeddings share the same version.
+When migrating encoder versions, create a new corpus column and re-encode.
+
+## Feature Flags
+
+| Flag | Effect |
+|------|--------|
+| `cnn` | Enables `OnnxCnnEncoder` (requires tract-onnx, ~50 MB) |
+
+## HoG Descriptor Details
+
+Input: 64×64 grayscale patch  
+Cell: 8×8 px → 8×8 = 64 cells  
+Block: 2×2 cells (16×16 px), stride 1 → 7×7 = 49 blocks  
+Bins: 9 (unsigned orientation [0, π))  
+Normalisation: L2-Hys per block (clip 0.2, re-normalise)  
+**Output: 1764-dim f32 vector**

--- a/src/omr-rust/crates/omr-embed/src/corpus.rs
+++ b/src/omr-rust/crates/omr-embed/src/corpus.rs
@@ -1,0 +1,373 @@
+//! Persistent patch+embedding corpus backed by SQLite.
+//!
+//! Schema: a single `patches` table with all metadata plus an optional BLOB
+//! column for the f32 embedding vector (little-endian).
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use rusqlite::{Connection, params};
+
+use crate::index::EmbeddingIndex;
+use crate::types::{ClassLabel, Embedding, PatchSource};
+
+// ── Schema ────────────────────────────────────────────────────────────────────
+
+const SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS patches (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    label            TEXT    NOT NULL,
+    source           TEXT    NOT NULL,
+    patch_png        BLOB    NOT NULL,
+    embedding_version TEXT,
+    embedding_vec    BLOB,
+    provenance       TEXT,
+    created_at       TEXT    NOT NULL,
+    user_confirmed   INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_patches_label  ON patches(label);
+CREATE INDEX IF NOT EXISTS idx_patches_source ON patches(source);
+"#;
+
+// ── LabeledPatch ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct LabeledPatch {
+    pub id: u64,
+    pub label: ClassLabel,
+    pub source: PatchSource,
+    /// 64×64 grayscale PNG bytes.
+    pub patch_png: Vec<u8>,
+    /// Embedding, if already computed.
+    pub embedding: Option<Embedding>,
+    /// Original file path or synthetic-pattern-id.
+    pub provenance: String,
+    /// ISO-8601 creation timestamp.
+    pub created_at: String,
+    pub user_confirmed: bool,
+}
+
+// ── CorpusError ───────────────────────────────────────────────────────────────
+
+#[derive(thiserror::Error, Debug)]
+pub enum CorpusError {
+    #[error("SQLite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("Patch {0} not found")]
+    NotFound(u64),
+    #[error("Unknown PatchSource string: '{0}'")]
+    UnknownSource(String),
+    #[error("Encoder version mismatch: corpus has '{corpus_version}', required '{required_version}'")]
+    EncoderMismatch { corpus_version: String, required_version: String },
+}
+
+// ── Corpus ────────────────────────────────────────────────────────────────────
+
+pub struct Corpus {
+    conn: Connection,
+}
+
+impl Corpus {
+    /// Open (or create) a corpus at `path`.
+    pub fn open(path: &Path) -> Result<Self, CorpusError> {
+        let conn = Connection::open(path)?;
+        conn.execute_batch(SCHEMA)?;
+        Ok(Self { conn })
+    }
+
+    /// Open an in-memory corpus (useful for tests).
+    pub fn open_in_memory() -> Result<Self, CorpusError> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch(SCHEMA)?;
+        Ok(Self { conn })
+    }
+
+    // ── Write ops ─────────────────────────────────────────────────────────────
+
+    /// Insert a patch and return the assigned ID.
+    pub fn add_patch(&mut self, patch: LabeledPatch) -> Result<u64, CorpusError> {
+        let (emb_version, emb_vec): (Option<String>, Option<Vec<u8>>) =
+            match &patch.embedding {
+                Some(e) => (Some(e.version.clone()), Some(f32s_to_bytes(&e.vec))),
+                None => (None, None),
+            };
+        self.conn.execute(
+            r#"INSERT INTO patches
+               (label, source, patch_png, embedding_version, embedding_vec,
+                provenance, created_at, user_confirmed)
+               VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)"#,
+            params![
+                patch.label,
+                patch.source.as_str(),
+                patch.patch_png,
+                emb_version,
+                emb_vec,
+                patch.provenance,
+                patch.created_at,
+                patch.user_confirmed as i32,
+            ],
+        )?;
+        Ok(self.conn.last_insert_rowid() as u64)
+    }
+
+    /// Retrieve a patch by ID.
+    pub fn get_patch(&self, id: u64) -> Result<LabeledPatch, CorpusError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, label, source, patch_png, embedding_version, embedding_vec,
+                    provenance, created_at, user_confirmed
+             FROM patches WHERE id = ?1",
+        )?;
+        let result = stmt.query_row(params![id as i64], row_to_patch);
+        match result {
+            Ok(p) => Ok(p),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Err(CorpusError::NotFound(id)),
+            Err(e) => Err(CorpusError::Sqlite(e)),
+        }
+    }
+
+    /// Delete a patch by ID.
+    pub fn delete_patch(&mut self, id: u64) -> Result<(), CorpusError> {
+        let affected = self.conn.execute(
+            "DELETE FROM patches WHERE id = ?1",
+            params![id as i64],
+        )?;
+        if affected == 0 {
+            return Err(CorpusError::NotFound(id));
+        }
+        Ok(())
+    }
+
+    // ── Read ops ──────────────────────────────────────────────────────────────
+
+    /// Count patches per label.
+    pub fn count_by_label(&self) -> Result<HashMap<ClassLabel, usize>, CorpusError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT label, COUNT(*) FROM patches GROUP BY label",
+        )?;
+        let map = stmt
+            .query_map([], |row| {
+                let label: String = row.get(0)?;
+                let count: i64 = row.get(1)?;
+                Ok((label, count as usize))
+            })?
+            .collect::<Result<HashMap<_, _>, _>>()?;
+        Ok(map)
+    }
+
+    /// Count patches per source.
+    pub fn count_by_source(&self) -> Result<HashMap<PatchSource, usize>, CorpusError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT source, COUNT(*) FROM patches GROUP BY source",
+        )?;
+        let rows: Vec<(String, usize)> = stmt
+            .query_map([], |row| {
+                let s: String = row.get(0)?;
+                let c: i64 = row.get(1)?;
+                Ok((s, c as usize))
+            })?
+            .collect::<Result<_, _>>()?;
+        let mut map = HashMap::new();
+        for (s, c) in rows {
+            let src = PatchSource::from_str_opt(&s)
+                .ok_or_else(|| CorpusError::UnknownSource(s))?;
+            map.insert(src, c);
+        }
+        Ok(map)
+    }
+
+    /// Iterate all patches with the given label (collected to avoid borrow issues).
+    pub fn iter_with_label(&self, label: &str) -> impl Iterator<Item = LabeledPatch> {
+        let patches = self.collect_where("WHERE label = ?1", params![label]);
+        patches.into_iter()
+    }
+
+    /// Iterate all patches.
+    pub fn iter_all(&self) -> impl Iterator<Item = LabeledPatch> {
+        let patches = self.collect_where("", params![]);
+        patches.into_iter()
+    }
+
+    // ── Index building ────────────────────────────────────────────────────────
+
+    /// Build an `EmbeddingIndex` from patches that have an embedding with the
+    /// given version.  Patches without embeddings are silently skipped.
+    pub fn into_index(&self, version: &str) -> Result<EmbeddingIndex, CorpusError> {
+        use crate::encoder::FEATURE_LEN;
+        let mut idx = EmbeddingIndex::new(version, FEATURE_LEN);
+        let mut stmt = self.conn.prepare(
+            "SELECT id, label, source, embedding_version, embedding_vec
+             FROM patches
+             WHERE embedding_version = ?1 AND embedding_vec IS NOT NULL",
+        )?;
+        let rows: Vec<(u64, String, String, Vec<u8>)> = stmt
+            .query_map(params![version], |row| {
+                let id: i64 = row.get(0)?;
+                let label: String = row.get(1)?;
+                let source: String = row.get(2)?;
+                let vec_bytes: Vec<u8> = row.get(4)?;
+                Ok((id as u64, label, source, vec_bytes))
+            })?
+            .collect::<Result<_, _>>()?;
+
+        for (id, label, source_str, vec_bytes) in rows {
+            let source = PatchSource::from_str_opt(&source_str)
+                .ok_or_else(|| CorpusError::UnknownSource(source_str))?;
+            let emb = Embedding {
+                vec: bytes_to_f32s(&vec_bytes),
+                version: version.to_string(),
+            };
+            // Ignore add errors — wrong dim embeddings in corpus are skipped
+            let _ = idx.add(id, &emb, label, source);
+        }
+        idx.build();
+        Ok(idx)
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn collect_where(&self, where_clause: &str, params: impl rusqlite::Params) -> Vec<LabeledPatch> {
+        let sql = format!(
+            "SELECT id, label, source, patch_png, embedding_version, embedding_vec,
+                    provenance, created_at, user_confirmed
+             FROM patches {}",
+            where_clause
+        );
+        let mut stmt = match self.conn.prepare(&sql) {
+            Ok(s) => s,
+            Err(_) => return Vec::new(),
+        };
+        stmt.query_map(params, row_to_patch)
+            .map(|rows| rows.flatten().collect())
+            .unwrap_or_default()
+    }
+}
+
+// ── Row deserialiser ──────────────────────────────────────────────────────────
+
+fn row_to_patch(row: &rusqlite::Row<'_>) -> rusqlite::Result<LabeledPatch> {
+    let id: i64 = row.get(0)?;
+    let label: String = row.get(1)?;
+    let source_str: String = row.get(2)?;
+    let patch_png: Vec<u8> = row.get(3)?;
+    let emb_version: Option<String> = row.get(4)?;
+    let emb_bytes: Option<Vec<u8>> = row.get(5)?;
+    let provenance: Option<String> = row.get(6)?;
+    let created_at: String = row.get(7)?;
+    let confirmed: i32 = row.get(8)?;
+
+    let source = PatchSource::from_str_opt(&source_str)
+        .unwrap_or(PatchSource::Synthetic);
+
+    let embedding = match (emb_version, emb_bytes) {
+        (Some(ver), Some(bytes)) => Some(Embedding {
+            vec: bytes_to_f32s(&bytes),
+            version: ver,
+        }),
+        _ => None,
+    };
+
+    Ok(LabeledPatch {
+        id: id as u64,
+        label,
+        source,
+        patch_png,
+        embedding,
+        provenance: provenance.unwrap_or_default(),
+        created_at,
+        user_confirmed: confirmed != 0,
+    })
+}
+
+// ── Serialisation helpers ─────────────────────────────────────────────────────
+
+fn f32s_to_bytes(v: &[f32]) -> Vec<u8> {
+    v.iter().flat_map(|f| f.to_le_bytes()).collect()
+}
+
+fn bytes_to_f32s(b: &[u8]) -> Vec<f32> {
+    b.chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::encoder::{Encoder, HogEncoder, FEATURE_LEN};
+    use image::{GrayImage, Luma};
+
+    fn dummy_patch(label: &str, source: PatchSource, embedding: Option<Embedding>) -> LabeledPatch {
+        let png = tiny_png();
+        LabeledPatch {
+            id: 0,
+            label: label.to_string(),
+            source,
+            patch_png: png,
+            embedding,
+            provenance: "test".to_string(),
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            user_confirmed: false,
+        }
+    }
+
+    fn tiny_png() -> Vec<u8> {
+        let img = GrayImage::from_pixel(64, 64, Luma([128u8]));
+        let mut buf = Vec::new();
+        img.write_to(&mut std::io::Cursor::new(&mut buf), image::ImageFormat::Png).unwrap();
+        buf
+    }
+
+    fn hog_embedding(v: u8) -> Embedding {
+        let enc = HogEncoder::new();
+        let img = GrayImage::from_pixel(64, 64, Luma([v]));
+        enc.embed(&img).unwrap()
+    }
+
+    #[test]
+    fn add_patch_assigns_id() {
+        let mut corpus = Corpus::open_in_memory().unwrap();
+        let p = dummy_patch("notehead", PatchSource::Synthetic, None);
+        let id = corpus.add_patch(p).unwrap();
+        assert!(id > 0, "expected id > 0, got {id}");
+    }
+
+    #[test]
+    fn count_by_label_correct() {
+        let mut corpus = Corpus::open_in_memory().unwrap();
+        corpus.add_patch(dummy_patch("a", PatchSource::Synthetic, None)).unwrap();
+        corpus.add_patch(dummy_patch("a", PatchSource::User, None)).unwrap();
+        corpus.add_patch(dummy_patch("b", PatchSource::Synthetic, None)).unwrap();
+        let counts = corpus.count_by_label().unwrap();
+        assert_eq!(counts["a"], 2);
+        assert_eq!(counts["b"], 1);
+    }
+
+    #[test]
+    fn iter_with_label_filters() {
+        let mut corpus = Corpus::open_in_memory().unwrap();
+        corpus.add_patch(dummy_patch("notehead", PatchSource::Synthetic, None)).unwrap();
+        corpus.add_patch(dummy_patch("rest", PatchSource::Synthetic, None)).unwrap();
+        corpus.add_patch(dummy_patch("notehead", PatchSource::User, None)).unwrap();
+        let notes: Vec<_> = corpus.iter_with_label("notehead").collect();
+        assert_eq!(notes.len(), 2, "expected 2 noteheads, got {}", notes.len());
+        for p in &notes {
+            assert_eq!(p.label, "notehead");
+        }
+    }
+
+    #[test]
+    fn into_index_skips_patches_without_embedding() {
+        let mut corpus = Corpus::open_in_memory().unwrap();
+        // Patch without embedding
+        corpus.add_patch(dummy_patch("x", PatchSource::Synthetic, None)).unwrap();
+        // Patch with embedding
+        let emb = hog_embedding(64);
+        corpus.add_patch(dummy_patch("y", PatchSource::Synthetic, Some(emb))).unwrap();
+
+        let idx = corpus.into_index("hog-v1").unwrap();
+        // Only the patch with embedding should be in the index
+        assert_eq!(idx.corpus_size(), 1, "expected 1 in index, got {}", idx.corpus_size());
+    }
+}

--- a/src/omr-rust/crates/omr-embed/src/distance.rs
+++ b/src/omr-rust/crates/omr-embed/src/distance.rs
@@ -1,0 +1,71 @@
+//! Distance functions for embedding vectors.
+//!
+//! All functions operate on raw `&[f32]` slices so they can be used both
+//! with `Embedding::vec` and with internal index representations.
+
+/// Cosine distance between two vectors: `1 − cosine_similarity`.
+///
+/// Returns `1.0` if either vector is (near-)zero.
+/// Result is in `[0.0, 2.0]`; for unit vectors in `[0.0, 1.0]`.
+pub fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    debug_assert_eq!(a.len(), b.len(), "cosine: length mismatch");
+    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+    let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm_a < 1e-6 || norm_b < 1e-6 {
+        return 1.0;
+    }
+    (1.0 - (dot / (norm_a * norm_b))).clamp(0.0, 2.0)
+}
+
+/// Euclidean distance between two vectors: `√Σ(aᵢ − bᵢ)²`.
+pub fn euclidean(a: &[f32], b: &[f32]) -> f32 {
+    debug_assert_eq!(a.len(), b.len(), "euclidean: length mismatch");
+    a.iter()
+        .zip(b.iter())
+        .map(|(x, y)| (x - y).powi(2))
+        .sum::<f32>()
+        .sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cosine_orthogonal_is_one() {
+        let a = vec![1.0_f32, 0.0, 0.0];
+        let b = vec![0.0_f32, 1.0, 0.0];
+        let d = cosine(&a, &b);
+        assert!((d - 1.0).abs() < 1e-5, "expected 1.0 got {d}");
+    }
+
+    #[test]
+    fn cosine_parallel_is_zero() {
+        let a = vec![1.0_f32, 0.0, 0.0];
+        let b = vec![3.0_f32, 0.0, 0.0];
+        let d = cosine(&a, &b);
+        assert!(d.abs() < 1e-5, "expected 0.0 got {d}");
+    }
+
+    #[test]
+    fn euclidean_zero_for_same_vector() {
+        let v = vec![1.0_f32, 2.0, 3.0, 4.0];
+        let d = euclidean(&v, &v);
+        assert!(d.abs() < 1e-6, "expected 0.0 got {d}");
+    }
+
+    #[test]
+    fn cosine_with_real_embeddings() {
+        use crate::encoder::{Encoder, HogEncoder};
+        use image::{GrayImage, Luma};
+
+        let enc = HogEncoder::new();
+        let patch = GrayImage::from_pixel(64, 64, Luma([128u8]));
+        let emb = enc.embed(&patch).expect("encode failed");
+
+        // Same patch → distance ≈ 0.
+        let d = cosine(&emb.vec, &emb.vec);
+        assert!(d.abs() < 1e-5, "self-cosine expected 0 got {d}");
+    }
+}

--- a/src/omr-rust/crates/omr-embed/src/encoder.rs
+++ b/src/omr-rust/crates/omr-embed/src/encoder.rs
@@ -1,0 +1,336 @@
+//! Encoder trait + concrete implementations.
+//!
+//! `HogEncoder` works on 64×64 grayscale patches and produces a 1764-dim
+//! L2-Hys-normalised HoG descriptor:
+//!   cell=8×8 px, block=2×2 cells (16×16 px), 9 bins, stride=1 cell
+//!   → 7×7 blocks × 4 cells/block × 9 bins = **1764 features**
+
+use image::GrayImage;
+use crate::types::Embedding;
+
+// ── HoG constants (64×64 input) ──────────────────────────────────────────────
+
+/// Expected patch width/height in pixels.
+pub const PATCH_SIZE: u32 = 64;
+/// Cell side in pixels.
+const CELL_SIZE: u32 = 8;
+/// Block side in cells.
+const BLOCK_CELLS: u32 = 2;
+/// Orientation bins.
+const N_BINS: usize = 9;
+/// Cells per axis of the patch.
+const CELLS_PER_AXIS: u32 = PATCH_SIZE / CELL_SIZE; // 8
+/// Blocks per axis (stride-1 sliding window).
+const BLOCKS_PER_AXIS: u32 = CELLS_PER_AXIS - BLOCK_CELLS + 1; // 7
+/// Total descriptor length.
+pub const FEATURE_LEN: usize = (BLOCKS_PER_AXIS as usize)
+    * (BLOCKS_PER_AXIS as usize)
+    * (BLOCK_CELLS as usize)
+    * (BLOCK_CELLS as usize)
+    * N_BINS; // 7*7*2*2*9 = 1764
+
+// ── EncoderError ─────────────────────────────────────────────────────────────
+
+#[derive(thiserror::Error, Debug)]
+pub enum EncoderError {
+    #[error("ONNX model load failed: {0}")]
+    OnnxLoad(String),
+    #[error("ONNX inference failed: {0}")]
+    OnnxInference(String),
+    #[error("Unexpected output shape: expected {expected} dims, got {got}")]
+    OutputShape { expected: usize, got: usize },
+}
+
+// ── Encoder trait ─────────────────────────────────────────────────────────────
+
+pub trait Encoder: Send + Sync {
+    fn embed(&self, patch: &GrayImage) -> Result<Embedding, EncoderError>;
+    fn dim(&self) -> usize;
+    fn version(&self) -> &str;
+}
+
+// ── HogEncoder ───────────────────────────────────────────────────────────────
+
+/// HoG-based encoder.  Requires no training — works immediately.
+/// Baseline for cold-start scenarios.
+///
+/// Cell 8×8 px, Block 16×16 px (2×2 cells), 9 bins
+/// → 64×64 patch → 1764-dim descriptor
+pub struct HogEncoder;
+
+impl HogEncoder {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for HogEncoder {
+    fn default() -> Self { Self::new() }
+}
+
+impl Encoder for HogEncoder {
+    fn embed(&self, patch: &GrayImage) -> Result<Embedding, EncoderError> {
+        let resized = resize_nn(patch, PATCH_SIZE, PATCH_SIZE);
+        let (mag, ori) = compute_gradients(&resized);
+        let cells = compute_cell_histograms(&mag, &ori);
+        let vec = block_normalize(&cells);
+        Ok(Embedding { vec, version: self.version().to_string() })
+    }
+
+    fn dim(&self) -> usize { FEATURE_LEN }
+
+    fn version(&self) -> &str { "hog-v1" }
+}
+
+// ── HoG internals ────────────────────────────────────────────────────────────
+
+fn resize_nn(src: &GrayImage, w: u32, h: u32) -> GrayImage {
+    if src.width() == w && src.height() == h {
+        return src.clone();
+    }
+    let sw = src.width() as f32;
+    let sh = src.height() as f32;
+    let mut dst = GrayImage::new(w, h);
+    for y in 0..h {
+        for x in 0..w {
+            let sx = ((x as f32 + 0.5) * sw / w as f32).floor() as u32;
+            let sy = ((y as f32 + 0.5) * sh / h as f32).floor() as u32;
+            let sx = sx.min(src.width() - 1);
+            let sy = sy.min(src.height() - 1);
+            dst.put_pixel(x, y, *src.get_pixel(sx, sy));
+        }
+    }
+    dst
+}
+
+fn compute_gradients(img: &GrayImage) -> (Vec<f32>, Vec<f32>) {
+    let w = img.width() as i32;
+    let h = img.height() as i32;
+    let n = (w * h) as usize;
+    let mut mag = vec![0.0_f32; n];
+    let mut ori = vec![0.0_f32; n];
+    let pi = std::f32::consts::PI;
+
+    let get = |x: i32, y: i32| -> f32 {
+        if x < 0 || y < 0 || x >= w || y >= h {
+            0.0
+        } else {
+            img.get_pixel(x as u32, y as u32)[0] as f32
+        }
+    };
+
+    for y in 0..h {
+        for x in 0..w {
+            let gx = get(x + 1, y) - get(x - 1, y);
+            let gy = get(x, y + 1) - get(x, y - 1);
+            let m = (gx * gx + gy * gy).sqrt();
+            let mut a = gy.atan2(gx);
+            if a < 0.0 { a += pi; }
+            if a >= pi { a -= pi; }
+            let idx = (y * w + x) as usize;
+            mag[idx] = m;
+            ori[idx] = a;
+        }
+    }
+    (mag, ori)
+}
+
+fn compute_cell_histograms(mag: &[f32], ori: &[f32]) -> Vec<f32> {
+    let cpa = CELLS_PER_AXIS as usize;
+    let cs = CELL_SIZE as usize;
+    let mut cells = vec![0.0_f32; cpa * cpa * N_BINS];
+    let bin_width = std::f32::consts::PI / N_BINS as f32;
+    let img_w = PATCH_SIZE as usize;
+
+    for cy in 0..cpa {
+        for cx in 0..cpa {
+            let base = (cy * cpa + cx) * N_BINS;
+            for py in 0..cs {
+                for px in 0..cs {
+                    let x = cx * cs + px;
+                    let y = cy * cs + py;
+                    let pix = y * img_w + x;
+                    let m = mag[pix];
+                    if m == 0.0 { continue; }
+                    let a = ori[pix];
+                    let bin_pos = a / bin_width - 0.5;
+                    let lower = bin_pos.floor() as i32;
+                    let frac = bin_pos - lower as f32;
+                    let lo = lower.rem_euclid(N_BINS as i32) as usize;
+                    let hi = (lower + 1).rem_euclid(N_BINS as i32) as usize;
+                    cells[base + lo] += m * (1.0 - frac);
+                    cells[base + hi] += m * frac;
+                }
+            }
+        }
+    }
+    cells
+}
+
+fn block_normalize(cells: &[f32]) -> Vec<f32> {
+    let cpa = CELLS_PER_AXIS as usize;
+    let bc = BLOCK_CELLS as usize;
+    let bpa = BLOCKS_PER_AXIS as usize;
+    let mut feats = Vec::with_capacity(FEATURE_LEN);
+
+    for by in 0..bpa {
+        for bx in 0..bpa {
+            let mut block: Vec<f32> = Vec::with_capacity(bc * bc * N_BINS);
+            for dy in 0..bc {
+                for dx in 0..bc {
+                    let cy = by + dy;
+                    let cx = bx + dx;
+                    let base = (cy * cpa + cx) * N_BINS;
+                    block.extend_from_slice(&cells[base..base + N_BINS]);
+                }
+            }
+            // L2-Hys: clip at 0.2 then re-normalise
+            let norm = block.iter().map(|v| v * v).sum::<f32>().sqrt();
+            if norm > 1e-6 {
+                for v in &mut block { *v /= norm; }
+                for v in &mut block { if *v > 0.2 { *v = 0.2; } }
+                let norm2 = block.iter().map(|v| v * v).sum::<f32>().sqrt();
+                if norm2 > 1e-6 {
+                    for v in &mut block { *v /= norm2; }
+                }
+            }
+            feats.extend(block);
+        }
+    }
+    debug_assert_eq!(feats.len(), FEATURE_LEN);
+    feats
+}
+
+// ── OnnxCnnEncoder (optional) ─────────────────────────────────────────────────
+
+#[cfg(feature = "cnn")]
+pub struct OnnxCnnEncoder {
+    model: tract_onnx::prelude::SimplePlan<
+        tract_onnx::prelude::TypedFact,
+        Box<dyn tract_onnx::prelude::TypedOp>,
+        tract_onnx::prelude::Graph<
+            tract_onnx::prelude::TypedFact,
+            Box<dyn tract_onnx::prelude::TypedOp>,
+        >,
+    >,
+    dim: usize,
+}
+
+#[cfg(feature = "cnn")]
+impl OnnxCnnEncoder {
+    pub fn from_path(model_path: &std::path::Path) -> Result<Self, EncoderError> {
+        use tract_onnx::prelude::*;
+        let model = tract_onnx::onnx()
+            .model_for_path(model_path)
+            .map_err(|e| EncoderError::OnnxLoad(e.to_string()))?
+            .with_input_fact(0, f32::fact([1, 1, 64, 64]).into())
+            .map_err(|e| EncoderError::OnnxLoad(e.to_string()))?
+            .into_optimized()
+            .map_err(|e| EncoderError::OnnxLoad(e.to_string()))?
+            .into_runnable()
+            .map_err(|e| EncoderError::OnnxLoad(e.to_string()))?;
+        Ok(Self { model, dim: 256 })
+    }
+
+    pub fn from_bytes(model_bytes: &[u8]) -> Result<Self, EncoderError> {
+        use tract_onnx::prelude::*;
+        let model = tract_onnx::onnx()
+            .model_for_read(&mut std::io::Cursor::new(model_bytes))
+            .map_err(|e| EncoderError::OnnxLoad(e.to_string()))?
+            .with_input_fact(0, f32::fact([1, 1, 64, 64]).into())
+            .map_err(|e| EncoderError::OnnxLoad(e.to_string()))?
+            .into_optimized()
+            .map_err(|e| EncoderError::OnnxLoad(e.to_string()))?
+            .into_runnable()
+            .map_err(|e| EncoderError::OnnxLoad(e.to_string()))?;
+        Ok(Self { model, dim: 256 })
+    }
+}
+
+#[cfg(feature = "cnn")]
+impl Encoder for OnnxCnnEncoder {
+    fn embed(&self, patch: &GrayImage) -> Result<Embedding, EncoderError> {
+        use tract_onnx::prelude::*;
+        let resized = {
+            use crate::encoder::resize_nn;
+            resize_nn(patch, PATCH_SIZE, PATCH_SIZE)
+        };
+        let input: Tensor = tract_ndarray::Array4::from_shape_fn((1, 1, 64, 64), |(_, _, y, x)| {
+            resized.get_pixel(x as u32, y as u32)[0] as f32 / 255.0
+        })
+        .into();
+        let outputs = self.model.run(tvec![input.into()])
+            .map_err(|e| EncoderError::OnnxInference(e.to_string()))?;
+        let arr = outputs[0]
+            .to_array_view::<f32>()
+            .map_err(|e| EncoderError::OnnxInference(e.to_string()))?;
+        let vec: Vec<f32> = arr.iter().copied().collect();
+        if vec.len() != self.dim {
+            return Err(EncoderError::OutputShape { expected: self.dim, got: vec.len() });
+        }
+        Ok(Embedding { vec, version: self.version().to_string() })
+    }
+
+    fn dim(&self) -> usize { self.dim }
+    fn version(&self) -> &str { "cnn-v1" }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::{GrayImage, Luma};
+
+    fn gradient_patch() -> GrayImage {
+        let mut img = GrayImage::new(64, 64);
+        for y in 0..64u32 {
+            for x in 0..64u32 {
+                img.put_pixel(x, y, Luma([(x * 4).min(255) as u8]));
+            }
+        }
+        img
+    }
+
+    fn uniform_patch(v: u8) -> GrayImage {
+        GrayImage::from_pixel(64, 64, Luma([v]))
+    }
+
+    #[test]
+    fn hog_encoder_produces_consistent_dim() {
+        let enc = HogEncoder::new();
+        let patch = gradient_patch();
+        let emb = enc.embed(&patch).unwrap();
+        assert_eq!(emb.vec.len(), enc.dim());
+        assert_eq!(emb.vec.len(), FEATURE_LEN);
+    }
+
+    #[test]
+    fn hog_encoder_same_patch_same_embedding() {
+        let enc = HogEncoder::new();
+        let patch = gradient_patch();
+        let e1 = enc.embed(&patch).unwrap();
+        let e2 = enc.embed(&patch).unwrap();
+        assert_eq!(e1.vec, e2.vec, "HoG must be deterministic");
+    }
+
+    #[test]
+    fn hog_encoder_different_patches_different_embeddings() {
+        let enc = HogEncoder::new();
+        let e1 = enc.embed(&gradient_patch()).unwrap();
+        let e2 = enc.embed(&uniform_patch(0)).unwrap();
+        assert_ne!(e1.vec, e2.vec);
+    }
+
+    #[test]
+    fn hog_normalize_makes_unit_length() {
+        let enc = HogEncoder::new();
+        let mut emb = enc.embed(&gradient_patch()).unwrap();
+        emb.normalize();
+        let norm: f32 = emb.vec.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!(
+            (norm - 1.0).abs() < 1e-5 || norm < 1e-6,
+            "expected unit norm, got {norm}"
+        );
+    }
+}

--- a/src/omr-rust/crates/omr-embed/src/index.rs
+++ b/src/omr-rust/crates/omr-embed/src/index.rs
@@ -1,0 +1,265 @@
+//! k-NN Index for embedding vectors.
+//!
+//! Default backend: **linear scan** (O(n) per query, zero dependencies).
+//! Sufficient for labeling corpora up to ~50k patches; swap in HNSW via the
+//! `hnsw` feature flag when higher throughput is needed.
+//!
+//! Embedding-version is validated on every `add()` call — no mixing of
+//! different encoder versions.
+
+use std::collections::BinaryHeap;
+use std::cmp::Reverse;
+
+use omr_sig::Distribution;
+
+use crate::types::{ClassLabel, Embedding, Match, PatchSource};
+
+// ── KnnResult ─────────────────────────────────────────────────────────────────
+
+/// Sorted by distance ascending.
+pub type KnnResult = Vec<Match>;
+
+// ── IndexError ────────────────────────────────────────────────────────────────
+
+#[derive(thiserror::Error, Debug)]
+pub enum IndexError {
+    #[error("version mismatch: index expects '{expected}', got '{found}'")]
+    VersionMismatch { expected: String, found: String },
+    #[error("dim mismatch: index expects {expected}, got {found}")]
+    DimMismatch { expected: usize, found: usize },
+    #[error("index is empty — call add() first")]
+    EmptyIndex,
+}
+
+// ── Stored entry ──────────────────────────────────────────────────────────────
+
+struct Entry {
+    patch_id: u64,
+    label: ClassLabel,
+    source: PatchSource,
+    vec: Vec<f32>,
+}
+
+// ── EmbeddingIndex ────────────────────────────────────────────────────────────
+
+/// Flat k-NN index with cosine distance.
+///
+/// Uses a linear scan — O(n · dim) per query. For corpora up to ~50k patches
+/// this easily stays under 1 ms.  Enable the `hnsw` feature for approximate
+/// HNSW lookup on larger corpora.
+pub struct EmbeddingIndex {
+    expected_version: String,
+    expected_dim: usize,
+    entries: Vec<Entry>,
+}
+
+impl EmbeddingIndex {
+    /// Create a new empty index for a specific encoder version and dimension.
+    pub fn new(version: &str, dim: usize) -> Self {
+        Self {
+            expected_version: version.to_string(),
+            expected_dim: dim,
+            entries: Vec::new(),
+        }
+    }
+
+    /// Add a labeled embedding.  Version and dim must match the index.
+    pub fn add(
+        &mut self,
+        patch_id: u64,
+        embedding: &Embedding,
+        label: ClassLabel,
+        source: PatchSource,
+    ) -> Result<(), IndexError> {
+        if embedding.version != self.expected_version {
+            return Err(IndexError::VersionMismatch {
+                expected: self.expected_version.clone(),
+                found: embedding.version.clone(),
+            });
+        }
+        if embedding.vec.len() != self.expected_dim {
+            return Err(IndexError::DimMismatch {
+                expected: self.expected_dim,
+                found: embedding.vec.len(),
+            });
+        }
+        self.entries.push(Entry {
+            patch_id,
+            label,
+            source,
+            vec: embedding.vec.clone(),
+        });
+        Ok(())
+    }
+
+    /// No-op for API compatibility with HNSW backends (linear scan needs no build step).
+    pub fn build(&mut self) {}
+
+    /// k-NN search via linear scan.  Returns up to `k` matches sorted
+    /// by cosine distance (closest first).
+    pub fn knn(&mut self, query: &Embedding, k: usize) -> Result<KnnResult, IndexError> {
+        if query.version != self.expected_version {
+            return Err(IndexError::VersionMismatch {
+                expected: self.expected_version.clone(),
+                found: query.version.clone(),
+            });
+        }
+        if self.entries.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Max-heap keyed on Reverse(distance) so we keep the k smallest distances.
+        // Heap element: (Reverse(distance_bits), index_in_entries)
+        let k_actual = k.min(self.entries.len());
+        let mut heap: BinaryHeap<(Reverse<u32>, usize)> = BinaryHeap::with_capacity(k_actual + 1);
+
+        for (i, entry) in self.entries.iter().enumerate() {
+            let d = crate::distance::cosine(&query.vec, &entry.vec);
+            let bits = d.to_bits();
+            if heap.len() < k_actual {
+                heap.push((Reverse(bits), i));
+            } else if let Some(&(Reverse(worst_bits), _)) = heap.peek() {
+                if bits < worst_bits {
+                    heap.pop();
+                    heap.push((Reverse(bits), i));
+                }
+            }
+        }
+
+        let mut results: KnnResult = heap
+            .into_sorted_vec()
+            .into_iter()
+            .map(|(Reverse(bits), i)| {
+                let e = &self.entries[i];
+                Match {
+                    patch_id: e.patch_id,
+                    label: e.label.clone(),
+                    distance: f32::from_bits(bits),
+                    source: e.source,
+                }
+            })
+            .collect();
+
+        // BinaryHeap::into_sorted_vec returns descending; reverse to ascending.
+        results.reverse();
+        Ok(results)
+    }
+
+    /// k-NN search returning a `Distribution<ClassLabel>`.
+    ///
+    /// Weights per label: sum of `exp(−distance)` over the top-k neighbours.
+    pub fn knn_distribution(
+        &mut self,
+        query: &Embedding,
+        k: usize,
+    ) -> Result<Distribution<ClassLabel>, IndexError> {
+        let matches = self.knn(query, k)?;
+        if matches.is_empty() {
+            return Err(IndexError::EmptyIndex);
+        }
+        let mut label_weights: std::collections::HashMap<ClassLabel, f32> =
+            std::collections::HashMap::new();
+        for m in &matches {
+            *label_weights.entry(m.label.clone()).or_insert(0.0) += (-m.distance).exp();
+        }
+        let weights: Vec<(ClassLabel, f32)> = label_weights.into_iter().collect();
+        Ok(Distribution::from_weights(weights))
+    }
+
+    /// Number of embeddings stored in the index.
+    pub fn corpus_size(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::encoder::{Encoder, HogEncoder, FEATURE_LEN};
+    use image::GrayImage;
+
+    fn hog_embed(patch: &GrayImage) -> Embedding {
+        HogEncoder::new().embed(patch).unwrap()
+    }
+
+    #[test]
+    fn add_and_knn_returns_self_first() {
+        let mut idx = EmbeddingIndex::new("hog-v1", FEATURE_LEN);
+        let patch = GrayImage::from_fn(64, 64, |x, _| image::Luma([(x * 4) as u8]));
+        let emb = hog_embed(&patch);
+        idx.add(1, &emb, "notehead".to_string(), PatchSource::Synthetic).unwrap();
+        let results = idx.knn(&emb, 1).unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(
+            results[0].distance < 1e-3,
+            "self-distance should be ≈0, got {}",
+            results[0].distance
+        );
+        assert_eq!(results[0].label, "notehead");
+    }
+
+    #[test]
+    fn knn_returns_sorted_by_distance() {
+        let mut idx = EmbeddingIndex::new("hog-v1", FEATURE_LEN);
+        let p1 = GrayImage::from_fn(64, 64, |x, _| image::Luma([(x * 4) as u8]));
+        let p2 = GrayImage::from_fn(64, 64, |_, y| image::Luma([(y * 4) as u8]));
+        let p3 = GrayImage::from_pixel(64, 64, image::Luma([128u8]));
+        idx.add(1, &hog_embed(&p1), "a".into(), PatchSource::Synthetic).unwrap();
+        idx.add(2, &hog_embed(&p2), "b".into(), PatchSource::User).unwrap();
+        idx.add(3, &hog_embed(&p3), "c".into(), PatchSource::DetectorAuto).unwrap();
+
+        let results = idx.knn(&hog_embed(&p1), 3).unwrap();
+        assert_eq!(results.len(), 3);
+        for w in results.windows(2) {
+            assert!(
+                w[0].distance <= w[1].distance,
+                "distances not ascending: {} > {}",
+                w[0].distance,
+                w[1].distance
+            );
+        }
+    }
+
+    #[test]
+    fn knn_distribution_softmax_normalizes() {
+        let mut idx = EmbeddingIndex::new("hog-v1", FEATURE_LEN);
+        let p1 = GrayImage::from_fn(64, 64, |x, _| image::Luma([(x * 4) as u8]));
+        let p2 = GrayImage::from_fn(64, 64, |_, y| image::Luma([(y * 4) as u8]));
+        idx.add(1, &hog_embed(&p1), "a".into(), PatchSource::Synthetic).unwrap();
+        idx.add(2, &hog_embed(&p2), "b".into(), PatchSource::User).unwrap();
+
+        let dist = idx.knn_distribution(&hog_embed(&p1), 2).unwrap();
+        let total: f32 = dist.alternatives.iter().map(|(_, p)| p).sum();
+        assert!((total - 1.0).abs() < 1e-5, "probs must sum to 1, got {total}");
+    }
+
+    #[test]
+    fn version_mismatch_returns_error() {
+        let mut idx = EmbeddingIndex::new("hog-v1", FEATURE_LEN);
+        let bad = Embedding { vec: vec![0.0; FEATURE_LEN], version: "other-v1".to_string() };
+        assert!(matches!(
+            idx.add(1, &bad, "x".into(), PatchSource::Synthetic),
+            Err(IndexError::VersionMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn dim_mismatch_returns_error() {
+        let mut idx = EmbeddingIndex::new("hog-v1", FEATURE_LEN);
+        let bad = Embedding { vec: vec![0.0; 10], version: "hog-v1".to_string() };
+        assert!(matches!(
+            idx.add(1, &bad, "x".into(), PatchSource::Synthetic),
+            Err(IndexError::DimMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn empty_index_returns_empty() {
+        let mut idx = EmbeddingIndex::new("hog-v1", FEATURE_LEN);
+        let emb = Embedding { vec: vec![0.0; FEATURE_LEN], version: "hog-v1".to_string() };
+        let results = idx.knn(&emb, 5).unwrap();
+        assert!(results.is_empty());
+    }
+}

--- a/src/omr-rust/crates/omr-embed/src/lib.rs
+++ b/src/omr-rust/crates/omr-embed/src/lib.rs
@@ -1,0 +1,20 @@
+//! omr-embed — Vector-Embedding-System für OMR-Symbole.
+//!
+//! Wandelt Symbol-Patches (64×64 Grayscale) in Embedding-Vektoren um.
+//! Per HNSW-Index findet man die k-Nachbarn und aus deren Labeln eine
+//! Distribution.  Füttert Phase-5 `HeadInterMulti.pitch_distribution`.
+
+pub mod corpus;
+pub mod distance;
+pub mod encoder;
+pub mod index;
+pub mod types;
+
+pub use encoder::{EncoderError, Encoder, HogEncoder};
+pub use index::{EmbeddingIndex, IndexError, KnnResult};
+pub use corpus::{Corpus, CorpusError, LabeledPatch};
+pub use types::{ClassLabel, Embedding, Match};
+pub use distance::{cosine, euclidean};
+
+#[cfg(feature = "cnn")]
+pub use encoder::OnnxCnnEncoder;

--- a/src/omr-rust/crates/omr-embed/src/types.rs
+++ b/src/omr-rust/crates/omr-embed/src/types.rs
@@ -1,0 +1,74 @@
+//! Core value types: Embedding, Match, ClassLabel, PatchSource.
+
+use serde::{Deserialize, Serialize};
+
+/// Dense float vector produced by an Encoder.
+///
+/// `version` is an opaque tag (e.g. `"hog-v1"`, `"cnn-v3-mobilenet"`) that
+/// identifies the encoder variant.  Embeddings from different versions MUST
+/// NOT be mixed in the same index or compared directly.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Embedding {
+    pub vec: Vec<f32>,
+    /// Encoder-Version-Tag.  Used for corpus migration checks.
+    pub version: String,
+}
+
+impl Embedding {
+    /// Dimensionality of this embedding.
+    pub fn dim(&self) -> usize {
+        self.vec.len()
+    }
+
+    /// L2-normalise the vector in-place.  No-op for zero vectors.
+    pub fn normalize(&mut self) {
+        let norm: f32 = self.vec.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 1e-6 {
+            for v in &mut self.vec {
+                *v /= norm;
+            }
+        }
+    }
+}
+
+/// Human-readable symbol class identifier (e.g. `"notehead-filled"`, `"rest-quarter"`).
+pub type ClassLabel = String;
+
+/// One k-NN search result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Match {
+    pub patch_id: u64,
+    pub label: ClassLabel,
+    pub distance: f32,
+    pub source: PatchSource,
+}
+
+/// Where a training patch came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum PatchSource {
+    /// Synthetically rendered (Bravura font, PrIMuS render pipeline).
+    Synthetic,
+    /// Manually confirmed by a human user.
+    User,
+    /// Automatically labelled by the ML detector at low confidence.
+    DetectorAuto,
+}
+
+impl PatchSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PatchSource::Synthetic => "Synthetic",
+            PatchSource::User => "User",
+            PatchSource::DetectorAuto => "DetectorAuto",
+        }
+    }
+
+    pub fn from_str_opt(s: &str) -> Option<Self> {
+        match s {
+            "Synthetic" => Some(PatchSource::Synthetic),
+            "User" => Some(PatchSource::User),
+            "DetectorAuto" => Some(PatchSource::DetectorAuto),
+            _ => None,
+        }
+    }
+}

--- a/src/omr-rust/crates/omr-labeler/Cargo.toml
+++ b/src/omr-rust/crates/omr-labeler/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+name = "omr-labeler"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# Standalone Active-Learning-Labeling-Tool für OMR.
+#
+# Dieses Crate enthält:
+# - Eine HTTP-API (axum) zum Bedienen der Labeling-Queue.
+# - Eingebettete Web-Frontend-Assets (HTML/CSS/JS).
+# - SQLite-basierte Persistenz (rusqlite, dynamisch gegen winsqlite3 wie
+#   im Workspace üblich — siehe `.cargo/config.toml`).
+# - Eine Pipeline-Hülle, die PDFs einliest, StaffSysteme erkennt und
+#   pro System Symbol-Patches (Connected Components) extrahiert.
+#
+# Das Tool ist bewusst self-contained gehalten: ein einziger Prozess
+# liefert Frontend + API, sodass der Annotator nur einen Befehl
+# ausführen muss.
+
+[[bin]]
+name = "omr-labeler"
+path = "src/main.rs"
+
+[dependencies]
+omr-core.workspace = true
+omr-staff.workspace = true
+omr-symbols.workspace = true
+omr-pipeline.workspace = true
+omr-sig.workspace = true
+omr-sig-store.workspace = true
+omr-embed.workspace = true
+axum.workspace = true
+tokio.workspace = true
+tower.workspace = true
+tower-http.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true
+image.workspace = true
+clap = { workspace = true }
+# rusqlite ohne `bundled`, um mit dem Workspace-Setup
+# (winsqlite3.dll, siehe `.cargo/config.toml`) konsistent zu bleiben.
+# omr-sig-store nutzt dieselbe Konfiguration.
+rusqlite = { version = "0.32", features = [] }
+pdfium-render.workspace = true
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full", "test-util"] }

--- a/src/omr-rust/crates/omr-labeler/README.md
+++ b/src/omr-rust/crates/omr-labeler/README.md
@@ -1,0 +1,124 @@
+# omr-labeler
+
+Standalone Active-Learning-Labeling-Tool für die Sheetstorm OMR-Pipeline.
+
+## Was es ist
+
+Ein einzelner Rust-Prozess (`omr-labeler`), der
+
+1. einen lokalen HTTP-Server (axum) startet,
+2. ein eingebettetes Web-Frontend ausliefert (Vanilla JS, kein Build-Step),
+3. PDFs aus einem Filestore einliest, StaffSysteme erkennt und Element-
+   Patches extrahiert,
+4. einen synthetischen Cold-Start-Corpus zum Seed der Queue verwendet,
+5. den Annotator mit hochmotiviertem keyboard-driven UX durch die Queue
+   führt und
+6. alle Antworten in einer SQLite-Datenbank persistiert.
+
+## Architektur
+
+```
+src/
+├── main.rs              CLI + Server-Bootstrapping
+├── api.rs               axum-Router + Handler
+├── pipeline.rs          PDF → Systems → Elements + HoG-Embeddings
+├── active_learning.rs   Queue (Level, Decision, Re-Prioritization)
+├── synthetic_warmup.rs  Cold-Start aus Klassen-Subdirs
+├── persistence.rs       SQLite-Repository für Labels
+└── frontend.rs          Embed der HTML/CSS/JS-Assets
+
+web/
+├── index.html           Layout + Sidebar
+├── style.css            Dark-mode, minimalist
+└── app.js               Queue-Polling, Hotkeys, Stats
+```
+
+Abhängige Crates:
+
+- `omr-core` — Typen (Binary, StaffSystem, Rect, …).
+- `omr-staff` — Staff-Detection + Removal.
+- `omr-pipeline` — `pdf_render::render_pages` (best effort, fällt
+  zurück, wenn pdfium nicht verfügbar ist).
+- `omr-embed` — neuer Stub-Crate; HogEncoder + EmbeddingIndex.
+
+## Start
+
+```pwsh
+cd src/omr-rust
+cargo run -p omr-labeler -- --filestore <pfad> --port 8095
+```
+
+Optionen:
+
+| Option              | Default                                   | Beschreibung                          |
+|---------------------|-------------------------------------------|---------------------------------------|
+| `--filestore`       | `src/.filestore/parts`                    | Wurzelverzeichnis mit PDFs            |
+| `--synthetic-corpus`| `tools/training/data/synthetic_corpus_v1` | Klassen-Subdirs für den Cold-Start    |
+| `--db`              | `labeler.db`                              | SQLite-Datei                          |
+| `--port`            | `8095`                                    | TCP-Port                              |
+| `--no-browser`      | (off)                                     | Browser nicht automatisch öffnen      |
+
+## Hotkeys
+
+| Taste     | Aktion                       |
+|-----------|------------------------------|
+| `Y`       | Antwort *Yes*                |
+| `N`       | Antwort *No*                 |
+| `Space`   | Item überspringen            |
+| `U`       | Letztes Label rückgängig     |
+| `1`–`5`   | Top-K-Klassen wählen         |
+| `E`       | Klasse manuell eingeben      |
+
+## API-Endpoints
+
+| Methode | Pfad                          | Zweck                                  |
+|---------|-------------------------------|----------------------------------------|
+| GET     | `/`                           | Frontend (`index.html`)                |
+| GET     | `/api/status`                 | Counts (PDFs, Systems, Elements, Labels)|
+| GET     | `/api/queue/next?level=&n=`   | Nächste Items                          |
+| POST    | `/api/queue/answer`           | Antwort speichern                      |
+| POST    | `/api/queue/skip`             | Item überspringen                      |
+| POST    | `/api/queue/undo`             | Letztes Label entfernen                |
+| GET     | `/api/system/{id}/image`      | PNG des Systems                        |
+| GET     | `/api/element/{id}/image`     | PNG des Element-Patches                |
+| GET     | `/api/stats`                  | Fortschritt + Per-Level-Counts         |
+| GET     | `/api/export/corpus`          | JSON-Export aller Labels               |
+
+## Wichtige Entscheidungen
+
+* **Kein `bundled`-Feature für rusqlite.** Der Workspace nutzt
+  dynamisches Linken gegen `winsqlite3.dll` (siehe `.cargo/config.toml`
+  und `omr-sig-store`). Das Tool folgt dieser Konvention.
+* **Eingebettete Web-Assets via `include_str!`.** Damit der Binary ohne
+  externe Datei-Abhängigkeiten ausgeliefert werden kann.
+* **Brute-force-EmbeddingIndex** im neuen `omr-embed`-Crate — reicht für
+  Labeling-Workloads (< 10k Items), kann später durch HNSW ersetzt
+  werden.
+* **pdfium-Fallback.** Wenn die pdfium-Bibliothek nicht verfügbar ist,
+  loggt das Tool eine Warnung und arbeitet mit einer leeren Pipeline-
+  State weiter — kein Panic.
+
+## Tests
+
+```pwsh
+cd src/omr-rust
+cargo test -p omr-labeler
+```
+
+Abdeckung:
+
+* `pipeline::tests::scan_filestore_finds_pdfs`
+* `pipeline::tests::scan_filestore_handles_missing_dir`
+* `active_learning::tests::push_and_next`
+* `active_learning::tests::re_prioritize_sorts_high_first`
+* `active_learning::tests::answered_items_dont_repeat`
+* `active_learning::tests::skip_moves_to_end`
+* `synthetic_warmup::tests::load_empty_dir_returns_empty`
+* `synthetic_warmup::tests::load_corpus_with_classes`
+* `persistence::tests::save_and_count_labels`
+* `persistence::tests::pop_last_returns_inserted`
+* Integration: `tests/api_tests.rs` mit
+  `api_status_returns_counts`,
+  `api_queue_next_returns_item`,
+  `api_queue_answer_persists_label`,
+  `api_export_corpus_returns_json`.

--- a/src/omr-rust/crates/omr-labeler/src/active_learning.rs
+++ b/src/omr-rust/crates/omr-labeler/src/active_learning.rs
@@ -1,0 +1,217 @@
+//! Active-Learning-Queue.
+//!
+//! Items werden nach Unsicherheit (`uncertainty`, höher = wichtiger) in
+//! eine Queue gelegt. `next()` liefert den höchst-unsicheren noch nicht
+//! beantworteten Eintrag; `answer()` markiert ihn als bearbeitet und
+//! verhindert Wiederholungen.
+//!
+//! Die Queue ist bewusst einfach gehalten: ein `VecDeque` plus ein
+//! `HashSet<u64>` der bereits bearbeiteten IDs. Re-Prioritisierung
+//! erfolgt durch Stabil-Sortieren nach Unsicherheit.
+
+use serde::{Deserialize, Serialize};
+use std::collections::{HashSet, VecDeque};
+
+/// Welcher Aspekt eines Items wird gerade gelabelt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[serde(rename_all = "lowercase")]
+pub enum Level {
+    /// Ist dies eine zusammenhängende Notenzeile / ein StaffSystem?
+    Line,
+    /// Ist dies ein zu klassifizierendes Element (Notehead, Akzidens, …)?
+    Element,
+    /// Klassen-Zuordnung (mehrere Top-K-Klassen sind vorgeschlagen).
+    Class,
+}
+
+impl Level {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Level::Line => "line",
+            Level::Element => "element",
+            Level::Class => "class",
+        }
+    }
+}
+
+/// Ein Eintrag in der Labeling-Queue.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueueItem {
+    pub id: u64,
+    pub level: Level,
+    pub uncertainty: f32,
+    pub system_id: String,
+    pub element_id: Option<String>,
+    pub suggested_class: Option<String>,
+    pub top_k: Vec<(String, f32)>,
+}
+
+/// Antwort des Annotators.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "value", rename_all = "lowercase")]
+pub enum Decision {
+    Yes,
+    No,
+    Skip,
+    Class(String),
+}
+
+impl Decision {
+    pub fn as_str(&self) -> String {
+        match self {
+            Decision::Yes => "yes".to_string(),
+            Decision::No => "no".to_string(),
+            Decision::Skip => "skip".to_string(),
+            Decision::Class(c) => format!("class:{}", c),
+        }
+    }
+}
+
+/// Die Labeling-Queue.
+#[derive(Debug, Default)]
+pub struct LabelingQueue {
+    pub items: VecDeque<QueueItem>,
+    pub labeled: HashSet<u64>,
+    pub labeled_count: usize,
+    pub last_resort: usize,
+    next_id: u64,
+}
+
+impl LabelingQueue {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Fügt ein neues Item hinzu und liefert dessen ID. Bei höherer
+    /// Unsicherheit landet das Item weiter vorne nach dem nächsten
+    /// `re_prioritize()`.
+    pub fn push(
+        &mut self,
+        level: Level,
+        system_id: String,
+        element_id: Option<String>,
+        uncertainty: f32,
+    ) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.items.push_back(QueueItem {
+            id,
+            level,
+            uncertainty,
+            system_id,
+            element_id,
+            suggested_class: None,
+            top_k: Vec::new(),
+        });
+        id
+    }
+
+    /// Fügt ein vorgefertigtes Item ein (z.B. aus dem synthetischen
+    /// Warmup) und sorgt dafür, dass `next_id` immer monoton steigt.
+    pub fn push_item(&mut self, mut item: QueueItem) -> u64 {
+        if item.id == 0 || item.id < self.next_id {
+            item.id = self.next_id;
+        }
+        self.next_id = item.id + 1;
+        let id = item.id;
+        self.items.push_back(item);
+        id
+    }
+
+    /// Liefert das höchst-unsichere noch nicht beantwortete Item, ohne
+    /// es zu entfernen. Items mit gesetzter `labeled`-Markierung werden
+    /// übersprungen.
+    pub fn next(&mut self) -> Option<&QueueItem> {
+        // Aufräumen: entferne bereits bearbeitete Items am Anfang.
+        while let Some(front) = self.items.front() {
+            if self.labeled.contains(&front.id) {
+                self.items.pop_front();
+            } else {
+                break;
+            }
+        }
+        self.items.front()
+    }
+
+    /// Markiert ein Item als beantwortet.
+    pub fn answer(&mut self, item_id: u64, _decision: Decision) {
+        if self.labeled.insert(item_id) {
+            self.labeled_count += 1;
+            self.items.retain(|it| it.id != item_id);
+        }
+    }
+
+    /// Markiert ein Item als übersprungen — es wird ans Ende der Queue
+    /// verschoben und kann später erneut angeboten werden.
+    pub fn skip(&mut self, item_id: u64) {
+        self.last_resort += 1;
+        if let Some(pos) = self.items.iter().position(|it| it.id == item_id) {
+            if let Some(it) = self.items.remove(pos) {
+                self.items.push_back(it);
+            }
+        }
+    }
+
+    /// Sortiert die Queue stabil nach Unsicherheit absteigend.
+    pub fn re_prioritize(&mut self) {
+        let mut v: Vec<QueueItem> = self.items.drain(..).collect();
+        v.sort_by(|a, b| {
+            b.uncertainty
+                .partial_cmp(&a.uncertainty)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        self.items = v.into();
+    }
+
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn push_and_next() {
+        let mut q = LabelingQueue::new();
+        let id = q.push(Level::Line, "sys-1".into(), None, 0.5);
+        let n = q.next().unwrap();
+        assert_eq!(n.id, id);
+    }
+
+    #[test]
+    fn re_prioritize_sorts_high_first() {
+        let mut q = LabelingQueue::new();
+        q.push(Level::Line, "a".into(), None, 0.1);
+        q.push(Level::Line, "b".into(), None, 0.9);
+        q.push(Level::Line, "c".into(), None, 0.5);
+        q.re_prioritize();
+        let n = q.next().unwrap();
+        assert_eq!(n.system_id, "b");
+    }
+
+    #[test]
+    fn answered_items_dont_repeat() {
+        let mut q = LabelingQueue::new();
+        let a = q.push(Level::Line, "a".into(), None, 0.1);
+        let b = q.push(Level::Line, "b".into(), None, 0.9);
+        q.answer(a, Decision::Yes);
+        q.answer(b, Decision::No);
+        assert!(q.next().is_none());
+    }
+
+    #[test]
+    fn skip_moves_to_end() {
+        let mut q = LabelingQueue::new();
+        let a = q.push(Level::Line, "a".into(), None, 0.5);
+        let b = q.push(Level::Line, "b".into(), None, 0.5);
+        q.skip(a);
+        let nxt = q.next().unwrap();
+        assert_eq!(nxt.id, b);
+    }
+}

--- a/src/omr-rust/crates/omr-labeler/src/api.rs
+++ b/src/omr-rust/crates/omr-labeler/src/api.rs
@@ -1,0 +1,377 @@
+//! HTTP-API (axum) für das Labeling-Tool.
+//!
+//! Liefert die folgenden Endpoints:
+//!
+//! - `GET  /                          ` → eingebettete index.html
+//! - `GET  /app.js                    ` → eingebettetes JS
+//! - `GET  /style.css                 ` → eingebettetes CSS
+//! - `GET  /api/status                ` → aktuelle Counts
+//! - `GET  /api/queue/next?level=&n=  ` → nächste Items aus der Queue
+//! - `POST /api/queue/answer          ` → Antwort persistieren + Queue
+//! - `POST /api/queue/skip            ` → Item überspringen
+//! - `POST /api/queue/undo            ` → letztes Label entfernen
+//! - `GET  /api/system/{id}/image     ` → System-PNG
+//! - `GET  /api/element/{id}/image    ` → Element-PNG
+//! - `GET  /api/stats                 ` → Fortschritts-Stats
+//! - `GET  /api/export/corpus         ` → JSON-Export aller Labels
+
+use crate::active_learning::{Decision, LabelingQueue, Level, QueueItem};
+use crate::frontend::{APP_JS, INDEX_HTML, STYLE_CSS};
+use crate::persistence::{Label, LabelDb};
+use crate::pipeline::{encode_png, PipelineState};
+use axum::{
+    body::Body,
+    extract::{Path as AxumPath, Query, State},
+    http::{header, StatusCode},
+    response::{IntoResponse, Response},
+    routing::{get, post},
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use tokio::sync::RwLock;
+use tower_http::cors::CorsLayer;
+
+/// Globaler App-State, geteilt über alle Handler.
+///
+/// Hinweise zur Synchronisation:
+/// - `pipeline` und `queue` sind reine Datenstrukturen → `tokio::RwLock`.
+/// - `db` umschließt eine `rusqlite::Connection`, die nicht `Sync` ist
+///   (sie hat einen internen `RefCell`-Statement-Cache). Daher
+///   verwenden wir `std::sync::Mutex`, das `Sync` bereitstellt für
+///   `T: Send`. Die Datenbankoperationen sind kurz und blockierend,
+///   sodass das Halten des Mutex über `await`-Punkte vermieden wird.
+#[derive(Default)]
+pub struct AppState {
+    pub pipeline: RwLock<PipelineState>,
+    pub queue: RwLock<LabelingQueue>,
+    pub db: Mutex<Option<LabelDb>>,
+}
+
+impl AppState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_db(db: LabelDb) -> Self {
+        Self {
+            pipeline: RwLock::new(PipelineState::new()),
+            queue: RwLock::new(LabelingQueue::new()),
+            db: Mutex::new(Some(db)),
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct StatusResponse {
+    pub pdfs: usize,
+    pub systems: usize,
+    pub elements: usize,
+    pub labels: u64,
+}
+
+#[derive(Deserialize)]
+pub struct NextQuery {
+    #[serde(default)]
+    pub level: Option<String>,
+    #[serde(default)]
+    pub n: Option<usize>,
+}
+
+#[derive(Serialize)]
+pub struct NextResponse {
+    pub items: Vec<QueueItem>,
+    pub remaining: usize,
+}
+
+#[derive(Deserialize)]
+pub struct AnswerRequest {
+    pub item_id: u64,
+    pub level: String,
+    pub decision: String,
+    #[serde(default)]
+    pub value: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct SkipRequest {
+    pub item_id: u64,
+}
+
+#[derive(Serialize)]
+pub struct StatsResponse {
+    pub total: usize,
+    pub labeled: usize,
+    pub remaining: usize,
+    pub last_resort: usize,
+    pub progress: f32,
+    pub by_level: HashMap<String, u64>,
+}
+
+/// Erzeugt den Axum-Router mit allen Endpoints und CORS.
+pub fn router(state: Arc<AppState>) -> Router {
+    Router::new()
+        .route("/", get(index_html))
+        .route("/index.html", get(index_html))
+        .route("/app.js", get(app_js))
+        .route("/style.css", get(style_css))
+        .route("/api/status", get(api_status))
+        .route("/api/queue/next", get(api_queue_next))
+        .route("/api/queue/answer", post(api_queue_answer))
+        .route("/api/queue/skip", post(api_queue_skip))
+        .route("/api/queue/undo", post(api_queue_undo))
+        .route("/api/system/:id/image", get(api_system_image))
+        .route("/api/element/:id/image", get(api_element_image))
+        .route("/api/stats", get(api_stats))
+        .route("/api/export/corpus", get(api_export_corpus))
+        .with_state(state)
+        .layer(CorsLayer::permissive())
+}
+
+// --- Static handlers ---
+
+async fn index_html() -> impl IntoResponse {
+    Response::builder()
+        .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
+        .body(Body::from(INDEX_HTML))
+        .unwrap()
+}
+
+async fn app_js() -> impl IntoResponse {
+    Response::builder()
+        .header(header::CONTENT_TYPE, "application/javascript; charset=utf-8")
+        .body(Body::from(APP_JS))
+        .unwrap()
+}
+
+async fn style_css() -> impl IntoResponse {
+    Response::builder()
+        .header(header::CONTENT_TYPE, "text/css; charset=utf-8")
+        .body(Body::from(STYLE_CSS))
+        .unwrap()
+}
+
+// --- API ---
+
+async fn api_status(State(state): State<Arc<AppState>>) -> Json<StatusResponse> {
+    let pipeline = state.pipeline.read().await;
+    let labels = {
+        let guard = state.db.lock().expect("db mutex poisoned");
+        match guard.as_ref() {
+            Some(db) => db.count_labels("").unwrap_or(0),
+            None => 0,
+        }
+    };
+    Json(StatusResponse {
+        pdfs: pipeline.pdf_paths.len(),
+        systems: pipeline.systems.len(),
+        elements: pipeline.elements.len(),
+        labels,
+    })
+}
+
+async fn api_queue_next(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<NextQuery>,
+) -> Json<NextResponse> {
+    let queue = state.queue.write().await;
+    let want = q.n.unwrap_or(1).max(1).min(20);
+    let level_filter = q.level.as_deref().and_then(parse_level);
+    let mut taken = Vec::new();
+    // Iteriere über Queue, sammle bis zu `want` matching items, ohne sie
+    // zu entfernen.
+    for it in queue.items.iter() {
+        if queue.labeled.contains(&it.id) {
+            continue;
+        }
+        if let Some(lf) = level_filter {
+            if it.level != lf {
+                continue;
+            }
+        }
+        taken.push(it.clone());
+        if taken.len() >= want {
+            break;
+        }
+    }
+    let remaining = queue
+        .items
+        .iter()
+        .filter(|it| !queue.labeled.contains(&it.id))
+        .count();
+    Json(NextResponse {
+        items: taken,
+        remaining,
+    })
+}
+
+fn parse_level(s: &str) -> Option<Level> {
+    match s.to_ascii_lowercase().as_str() {
+        "line" => Some(Level::Line),
+        "element" => Some(Level::Element),
+        "class" => Some(Level::Class),
+        _ => None,
+    }
+}
+
+async fn api_queue_answer(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<AnswerRequest>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let dec = match req.decision.to_ascii_lowercase().as_str() {
+        "yes" => Decision::Yes,
+        "no" => Decision::No,
+        "skip" => Decision::Skip,
+        "class" => Decision::Class(req.value.clone().unwrap_or_default()),
+        other => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!("Unbekannte decision: {}", other),
+            ))
+        }
+    };
+
+    // Item-Ref ermitteln (system_id oder element_id) bevor die Queue
+    // den Eintrag entfernt.
+    let item_ref = {
+        let queue = state.queue.read().await;
+        queue
+            .items
+            .iter()
+            .find(|it| it.id == req.item_id)
+            .map(|it| {
+                it.element_id
+                    .clone()
+                    .unwrap_or_else(|| it.system_id.clone())
+            })
+            .unwrap_or_else(|| format!("item-{}", req.item_id))
+    };
+
+    {
+        let mut queue = state.queue.write().await;
+        queue.answer(req.item_id, dec.clone());
+        if queue.labeled_count % 10 == 0 {
+            queue.re_prioritize();
+        }
+    }
+
+    {
+        let guard = state.db.lock().expect("db mutex poisoned");
+        if let Some(db) = guard.as_ref() {
+            let label = Label::new(&req.level, dec.as_str(), item_ref);
+            db.save_label(&label).map_err(internal)?;
+        }
+    }
+
+    Ok(Json(serde_json::json!({ "ok": true })))
+}
+
+async fn api_queue_skip(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<SkipRequest>,
+) -> Json<serde_json::Value> {
+    let mut queue = state.queue.write().await;
+    queue.skip(req.item_id);
+    Json(serde_json::json!({ "ok": true }))
+}
+async fn api_queue_undo(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let popped = {
+        let guard = state.db.lock().expect("db mutex poisoned");
+        if let Some(db) = guard.as_ref() {
+            db.pop_last_label().map_err(internal)?
+        } else {
+            None
+        }
+    };
+    Ok(Json(serde_json::json!({
+        "ok": true,
+        "popped": popped,
+    })))
+}
+
+async fn api_system_image(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<String>,
+) -> Result<Response, (StatusCode, String)> {
+    let pipeline = state.pipeline.read().await;
+    let sys = pipeline
+        .systems
+        .iter()
+        .find(|s| s.id == id)
+        .ok_or((StatusCode::NOT_FOUND, "System nicht gefunden".to_string()))?;
+    let png = encode_png(&sys.image).map_err(internal)?;
+    Ok(Response::builder()
+        .header(header::CONTENT_TYPE, "image/png")
+        .body(Body::from(png))
+        .unwrap())
+}
+
+async fn api_element_image(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<String>,
+) -> Result<Response, (StatusCode, String)> {
+    let pipeline = state.pipeline.read().await;
+    let elt = pipeline
+        .elements
+        .iter()
+        .find(|e| e.id == id)
+        .ok_or((StatusCode::NOT_FOUND, "Element nicht gefunden".to_string()))?;
+    let png = encode_png(&elt.patch).map_err(internal)?;
+    Ok(Response::builder()
+        .header(header::CONTENT_TYPE, "image/png")
+        .body(Body::from(png))
+        .unwrap())
+}
+
+async fn api_stats(State(state): State<Arc<AppState>>) -> Json<StatsResponse> {
+    let queue = state.queue.read().await;
+    let total = queue.items.len() + queue.labeled_count;
+    let labeled = queue.labeled_count;
+    let remaining = queue.items.len();
+    let last_resort = queue.last_resort;
+    let progress = if total > 0 {
+        labeled as f32 / total as f32
+    } else {
+        0.0
+    };
+
+    let mut by_level: HashMap<String, u64> = HashMap::new();
+    {
+        let guard = state.db.lock().expect("db mutex poisoned");
+        if let Some(db) = guard.as_ref() {
+            for lvl in ["line", "element", "class"] {
+                let c = db.count_labels(lvl).unwrap_or(0);
+                by_level.insert(lvl.to_string(), c);
+            }
+        }
+    }
+    Json(StatsResponse {
+        total,
+        labeled,
+        remaining,
+        last_resort,
+        progress,
+        by_level,
+    })
+}
+
+async fn api_export_corpus(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<Vec<Label>>, (StatusCode, String)> {
+    let labels = {
+        let guard = state.db.lock().expect("db mutex poisoned");
+        if let Some(db) = guard.as_ref() {
+            db.get_all_labels().map_err(internal)?
+        } else {
+            Vec::new()
+        }
+    };
+    Ok(Json(labels))
+}
+
+fn internal<E: std::fmt::Display>(e: E) -> (StatusCode, String) {
+    (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+}

--- a/src/omr-rust/crates/omr-labeler/src/frontend.rs
+++ b/src/omr-rust/crates/omr-labeler/src/frontend.rs
@@ -1,0 +1,9 @@
+//! Eingebettete Frontend-Assets.
+//!
+//! Die Web-Dateien werden zur Compile-Zeit in das Binary geschrieben,
+//! damit der `omr-labeler`-Prozess wirklich self-contained ist und ohne
+//! externe Datei-Abhängigkeiten ausgeliefert werden kann.
+
+pub const INDEX_HTML: &str = include_str!("../web/index.html");
+pub const APP_JS: &str = include_str!("../web/app.js");
+pub const STYLE_CSS: &str = include_str!("../web/style.css");

--- a/src/omr-rust/crates/omr-labeler/src/lib.rs
+++ b/src/omr-rust/crates/omr-labeler/src/lib.rs
@@ -1,0 +1,11 @@
+//! Bibliotheks-Wurzel des `omr-labeler`-Crates.
+//!
+//! Re-exportiert die Module, sodass Tests und andere Crates auf die
+//! Pipeline, Queue, Persistenz und API zugreifen können.
+
+pub mod active_learning;
+pub mod api;
+pub mod frontend;
+pub mod persistence;
+pub mod pipeline;
+pub mod synthetic_warmup;

--- a/src/omr-rust/crates/omr-labeler/src/main.rs
+++ b/src/omr-rust/crates/omr-labeler/src/main.rs
@@ -1,0 +1,165 @@
+//! `omr-labeler` — CLI + HTTP-Server-Einstieg.
+//!
+//! Startet einen lokalen axum-Server, scannt im Hintergrund den Filestore
+//! nach PDFs, lädt einen optionalen synthetischen Warmup-Corpus und öffnet
+//! standardmäßig den Browser auf der UI.
+
+use clap::Parser;
+use omr_labeler::active_learning::LabelingQueue;
+use omr_labeler::api::{router, AppState};
+use omr_labeler::persistence::LabelDb;
+use omr_labeler::pipeline::PipelineState;
+use omr_labeler::synthetic_warmup::{load_synthetic_corpus, seed_queue_with_synthetic};
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tracing::{info, warn};
+
+#[derive(Parser, Debug)]
+#[command(name = "omr-labeler", about = "Active-Learning Symbol Labeling Tool for OMR")]
+pub struct Cli {
+    /// Filestore-Pfad mit den zu labelnden PDFs.
+    #[arg(long, default_value = "src/.filestore/parts")]
+    pub filestore: PathBuf,
+    /// Verzeichnis mit synthetischen Klassen-Subdirs für den Cold-Start.
+    #[arg(long, default_value = "tools/training/data/synthetic_corpus_v1")]
+    pub synthetic_corpus: PathBuf,
+    /// SQLite-Datei, in der Labels persistiert werden.
+    #[arg(long, default_value = "labeler.db")]
+    pub db: PathBuf,
+    /// Lokaler Port, auf dem der Server läuft.
+    #[arg(long, default_value_t = 8095)]
+    pub port: u16,
+    /// Wenn gesetzt, wird der Browser NICHT automatisch geöffnet.
+    #[arg(long)]
+    pub no_browser: bool,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let cli = Cli::parse();
+    info!(
+        "Starte omr-labeler — Port {} | Filestore {} | DB {}",
+        cli.port,
+        cli.filestore.display(),
+        cli.db.display()
+    );
+
+    // Datenbank initialisieren.
+    let db = match LabelDb::open(&cli.db) {
+        Ok(db) => db,
+        Err(e) => {
+            warn!("Konnte Datenbank nicht öffnen ({}): {}", cli.db.display(), e);
+            warn!("Falle zurück auf In-Memory-Datenbank.");
+            LabelDb::open_in_memory()?
+        }
+    };
+    let state = Arc::new(AppState::with_db(db));
+
+    // PDFs scannen.
+    {
+        let pdfs = PipelineState::scan_filestore(&cli.filestore);
+        info!("Filestore-Scan: {} PDFs gefunden in {}", pdfs.len(), cli.filestore.display());
+        let mut p = state.pipeline.write().await;
+        p.pdf_paths = pdfs;
+    }
+
+    // Im Hintergrund: PDFs verarbeiten (best effort).
+    {
+        let state_bg = state.clone();
+        tokio::spawn(async move {
+            let pdfs = state_bg.pipeline.read().await.pdf_paths.clone();
+            for pdf in pdfs {
+                let mut p = state_bg.pipeline.write().await;
+                if let Err(e) = p.pre_process_pdf(&pdf) {
+                    warn!("PDF-Vorverarbeitung fehlgeschlagen ({}): {}", pdf.display(), e);
+                }
+            }
+            // Initial-Items der Queue: ein Line-Item pro System.
+            let mut q = state_bg.queue.write().await;
+            let p = state_bg.pipeline.read().await;
+            let mut q_owned = std::mem::take(&mut *q);
+            for sys in &p.systems {
+                q_owned.push(
+                    omr_labeler::active_learning::Level::Line,
+                    sys.id.clone(),
+                    None,
+                    0.5,
+                );
+            }
+            for elt in &p.elements {
+                q_owned.push(
+                    omr_labeler::active_learning::Level::Element,
+                    elt.system_id.clone(),
+                    Some(elt.id.clone()),
+                    0.7,
+                );
+            }
+            q_owned.re_prioritize();
+            *q = q_owned;
+        });
+    }
+
+    // Synthetic Warmup.
+    let samples = load_synthetic_corpus(&cli.synthetic_corpus);
+    if samples.is_empty() {
+        warn!(
+            "Kein synthetischer Corpus unter {} — Cold-Start ohne Seed-Items.",
+            cli.synthetic_corpus.display()
+        );
+    } else {
+        info!("Synthetischer Corpus: {} Klassen geladen.", samples.len());
+        let mut q = state.queue.write().await;
+        let mut q_owned = std::mem::take(&mut *q);
+        seed_queue_with_synthetic(&mut q_owned, &samples);
+        *q = q_owned;
+    }
+
+    let app = router(state.clone());
+    let addr = SocketAddr::from(([127, 0, 0, 1], cli.port));
+    info!("HTTP-Server bereit auf http://{}", addr);
+
+    if !cli.no_browser {
+        let url = format!("http://127.0.0.1:{}/", cli.port);
+        if let Err(e) = open_browser(&url) {
+            warn!("Konnte Browser nicht öffnen: {}", e);
+        }
+    }
+
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn open_browser(url: &str) -> std::io::Result<()> {
+    std::process::Command::new("cmd")
+        .args(["/C", "start", "", url])
+        .spawn()
+        .map(|_| ())
+}
+
+#[cfg(target_os = "macos")]
+fn open_browser(url: &str) -> std::io::Result<()> {
+    std::process::Command::new("open").arg(url).spawn().map(|_| ())
+}
+
+#[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
+fn open_browser(url: &str) -> std::io::Result<()> {
+    std::process::Command::new("xdg-open")
+        .arg(url)
+        .spawn()
+        .map(|_| ())
+}
+
+// Sicherstellen, dass die Tests aus `LabelingQueue` & co. zur Compile-
+// Zeit korrekt sind, auch wenn `lib`-Reexporte ungenutzt erscheinen.
+#[allow(dead_code)]
+fn _ensure_used(_q: LabelingQueue) {}

--- a/src/omr-rust/crates/omr-labeler/src/persistence.rs
+++ b/src/omr-rust/crates/omr-labeler/src/persistence.rs
@@ -1,0 +1,239 @@
+//! SQLite-Persistenz für Labels.
+//!
+//! Schema (idempotent):
+//! ```sql
+//! CREATE TABLE IF NOT EXISTS labels (
+//!     id INTEGER PRIMARY KEY AUTOINCREMENT,
+//!     level TEXT NOT NULL,
+//!     decision TEXT NOT NULL,
+//!     item_ref TEXT NOT NULL,
+//!     image_data BLOB,
+//!     created_at TEXT NOT NULL,
+//!     user_session TEXT
+//! );
+//! ```
+
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// Eintrag in der Labels-Tabelle.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Label {
+    /// Datenbank-ID. Bei neuen Labels kann das `None` sein.
+    pub id: Option<i64>,
+    /// Level: "line", "element" oder "class".
+    pub level: String,
+    /// Entscheidung: "yes", "no", "skip" oder "class:<name>".
+    pub decision: String,
+    /// Referenz auf das gelabelte Item (System-/Element-/Sample-ID).
+    pub item_ref: String,
+    /// Optional: PNG-Bytes des Patches zum Zeitpunkt des Labelings.
+    pub image_data: Option<Vec<u8>>,
+    /// ISO-8601-Timestamp.
+    pub created_at: String,
+    /// Optionaler Session-Identifier (z.B. User-Cookie).
+    pub user_session: Option<String>,
+}
+
+impl Label {
+    /// Hilfsfunktion: erzeugt ein neues Label mit aktuellem Timestamp.
+    pub fn new(level: impl Into<String>, decision: impl Into<String>, item_ref: impl Into<String>) -> Self {
+        Self {
+            id: None,
+            level: level.into(),
+            decision: decision.into(),
+            item_ref: item_ref.into(),
+            image_data: None,
+            created_at: now_iso8601(),
+            user_session: None,
+        }
+    }
+}
+
+fn now_iso8601() -> String {
+    // Vermeidet die `chrono`-Abhängigkeit. Nutzt SystemTime und
+    // formatiert "YYYY-MM-DDTHH:MM:SSZ" via `humantime`-freier Variante.
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    // Sehr einfache Konvertierung — ausreichend für Sortier-/Audit-Zwecke.
+    let secs = now as i64;
+    let days = secs / 86400;
+    let rem = secs % 86400;
+    let hh = rem / 3600;
+    let mm = (rem % 3600) / 60;
+    let ss = rem % 60;
+    // Vereinfachte Datumsberechnung (Howard Hinnant / civil_from_days).
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as i64;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        y, m, d, hh, mm, ss
+    )
+}
+
+/// SQLite-basiertes Label-Repository.
+pub struct LabelDb {
+    conn: Connection,
+}
+
+impl LabelDb {
+    /// Öffnet (oder erstellt) eine SQLite-Datei.
+    pub fn open(path: &Path) -> Result<Self> {
+        let conn = Connection::open(path)
+            .with_context(|| format!("SQLite öffnen: {}", path.display()))?;
+        let me = Self { conn };
+        me.migrate()?;
+        Ok(me)
+    }
+
+    /// Öffnet eine In-Memory-Datenbank (für Tests).
+    pub fn open_in_memory() -> Result<Self> {
+        let conn = Connection::open_in_memory()?;
+        let me = Self { conn };
+        me.migrate()?;
+        Ok(me)
+    }
+
+    fn migrate(&self) -> Result<()> {
+        self.conn.execute_batch(
+            r#"
+            CREATE TABLE IF NOT EXISTS labels (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                level TEXT NOT NULL,
+                decision TEXT NOT NULL,
+                item_ref TEXT NOT NULL,
+                image_data BLOB,
+                created_at TEXT NOT NULL,
+                user_session TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_labels_level ON labels(level);
+            CREATE INDEX IF NOT EXISTS idx_labels_item_ref ON labels(item_ref);
+            "#,
+        )?;
+        Ok(())
+    }
+
+    /// Persistiert ein Label und liefert die generierte ID.
+    pub fn save_label(&self, label: &Label) -> Result<i64> {
+        self.conn.execute(
+            "INSERT INTO labels (level, decision, item_ref, image_data, created_at, user_session)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                label.level,
+                label.decision,
+                label.item_ref,
+                label.image_data,
+                label.created_at,
+                label.user_session,
+            ],
+        )?;
+        Ok(self.conn.last_insert_rowid())
+    }
+
+    /// Anzahl Labels für einen Level (oder "" für alle).
+    pub fn count_labels(&self, level: &str) -> Result<u64> {
+        let count: i64 = if level.is_empty() {
+            self.conn
+                .query_row("SELECT COUNT(*) FROM labels", [], |row| row.get(0))?
+        } else {
+            self.conn.query_row(
+                "SELECT COUNT(*) FROM labels WHERE level = ?1",
+                params![level],
+                |row| row.get(0),
+            )?
+        };
+        Ok(count.max(0) as u64)
+    }
+
+    /// Liefert alle Labels (sortiert nach ID).
+    pub fn get_all_labels(&self) -> Result<Vec<Label>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, level, decision, item_ref, image_data, created_at, user_session
+             FROM labels ORDER BY id ASC",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(Label {
+                id: Some(row.get(0)?),
+                level: row.get(1)?,
+                decision: row.get(2)?,
+                item_ref: row.get(3)?,
+                image_data: row.get(4)?,
+                created_at: row.get(5)?,
+                user_session: row.get(6)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+
+    /// Löscht das zuletzt eingefügte Label und liefert es zurück (Undo).
+    pub fn pop_last_label(&self) -> Result<Option<Label>> {
+        let row: Option<Label> = self
+            .conn
+            .query_row(
+                "SELECT id, level, decision, item_ref, image_data, created_at, user_session
+                 FROM labels ORDER BY id DESC LIMIT 1",
+                [],
+                |row| {
+                    Ok(Label {
+                        id: Some(row.get(0)?),
+                        level: row.get(1)?,
+                        decision: row.get(2)?,
+                        item_ref: row.get(3)?,
+                        image_data: row.get(4)?,
+                        created_at: row.get(5)?,
+                        user_session: row.get(6)?,
+                    })
+                },
+            )
+            .ok();
+        if let Some(ref l) = row {
+            if let Some(id) = l.id {
+                self.conn
+                    .execute("DELETE FROM labels WHERE id = ?1", params![id])?;
+            }
+        }
+        Ok(row)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn save_and_count_labels() {
+        let db = LabelDb::open_in_memory().unwrap();
+        assert_eq!(db.count_labels("").unwrap(), 0);
+        db.save_label(&Label::new("line", "yes", "sys-1")).unwrap();
+        db.save_label(&Label::new("element", "no", "elt-1")).unwrap();
+        assert_eq!(db.count_labels("").unwrap(), 2);
+        assert_eq!(db.count_labels("line").unwrap(), 1);
+    }
+
+    #[test]
+    fn pop_last_returns_inserted() {
+        let db = LabelDb::open_in_memory().unwrap();
+        db.save_label(&Label::new("line", "yes", "sys-1")).unwrap();
+        db.save_label(&Label::new("element", "no", "elt-1")).unwrap();
+        let popped = db.pop_last_label().unwrap().unwrap();
+        assert_eq!(popped.item_ref, "elt-1");
+        assert_eq!(db.count_labels("").unwrap(), 1);
+    }
+}

--- a/src/omr-rust/crates/omr-labeler/src/pipeline.rs
+++ b/src/omr-rust/crates/omr-labeler/src/pipeline.rs
@@ -1,0 +1,394 @@
+//! Pipeline-Hülle für das Labeling-Tool.
+//!
+//! Sammelt PDFs aus einem Filestore, rendert sie (best effort, fällt
+//! still zurück, wenn pdfium nicht verfügbar ist), erkennt Staff-Systeme
+//! und extrahiert pro System einfache Element-Patches (Connected
+//! Components nach Staff-Removal). HoG-Embeddings werden für jedes
+//! Element berechnet.
+
+use anyhow::Result;
+use image::{DynamicImage, GrayImage, ImageBuffer, Luma};
+use omr_core::{Binary, Rect, StaffSystem};
+use omr_embed::{Encoder, HogEncoder};
+use std::path::{Path, PathBuf};
+
+pub type SystemId = String;
+pub type ElementId = String;
+
+#[derive(Debug, Clone)]
+pub struct RectifiedSystem {
+    pub id: SystemId,
+    pub image: GrayImage,
+    pub page: usize,
+    pub system_idx: usize,
+    pub bbox_top: u32,
+    pub bbox_bottom: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct DetectedElement {
+    pub id: ElementId,
+    pub system_id: SystemId,
+    pub bbox: Rect,
+    pub patch: GrayImage,
+    pub suggested_class: Option<String>,
+    pub hog_embedding: Vec<f32>,
+}
+
+#[derive(Default)]
+pub struct PipelineState {
+    pub pdf_paths: Vec<PathBuf>,
+    pub systems: Vec<RectifiedSystem>,
+    pub elements: Vec<DetectedElement>,
+}
+
+impl PipelineState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Rekursiver Walk durch `dir`; sammelt alle `*.pdf`-Dateien.
+    pub fn scan_filestore(dir: &Path) -> Vec<PathBuf> {
+        let mut out = Vec::new();
+        if !dir.exists() {
+            return out;
+        }
+        let mut stack = vec![dir.to_path_buf()];
+        while let Some(d) = stack.pop() {
+            let entries = match std::fs::read_dir(&d) {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            for entry in entries.flatten() {
+                let p = entry.path();
+                if p.is_dir() {
+                    stack.push(p);
+                } else if let Some(ext) = p.extension().and_then(|s| s.to_str()) {
+                    if ext.eq_ignore_ascii_case("pdf") {
+                        out.push(p);
+                    }
+                }
+            }
+        }
+        out.sort();
+        out
+    }
+
+    /// Pre-Process eine PDF-Datei. Liefert die Anzahl der hinzugefügten
+    /// Systeme. Falls pdfium nicht verfügbar ist, wird eine Warnung
+    /// geloggt und die Methode mit 0 zurückgegeben (kein Panic).
+    pub fn pre_process_pdf(&mut self, pdf: &Path) -> Result<usize> {
+        let pages = match render_pages_safe(pdf, 200) {
+            Ok(p) => p,
+            Err(err) => {
+                tracing::warn!(
+                    "pdfium nicht verfügbar oder PDF nicht lesbar — überspringe {}: {}",
+                    pdf.display(),
+                    err
+                );
+                return Ok(0);
+            }
+        };
+
+        let encoder = HogEncoder::new();
+        let mut added_systems = 0usize;
+
+        for (page_idx, gray) in pages.into_iter().enumerate() {
+            let bin = Binary::threshold_global(&gray, 128);
+            let systems = omr_staff::detect_systems(&bin);
+            if systems.is_empty() {
+                continue;
+            }
+            let staff_removed = omr_staff::remove_staff(&bin, &systems);
+            for (sys_idx, system) in systems.iter().enumerate() {
+                let (top, bottom) = system_bbox(&gray, system);
+                let crop_h = bottom.saturating_sub(top).max(1);
+                let cropped = sub_image(&gray, 0, top, gray.width(), crop_h);
+                let rectified = rectify_system(&cropped, system, top);
+                let id: SystemId =
+                    format!("{}#p{}s{}", short_id(pdf), page_idx, sys_idx);
+
+                let cropped_removed = sub_image(
+                    &binary_to_gray(&staff_removed),
+                    0,
+                    top,
+                    gray.width(),
+                    crop_h,
+                );
+                let rects = detect_elements(&cropped_removed, system, top);
+
+                for (elt_idx, r) in rects.iter().enumerate() {
+                    let patch = extract_patch(&cropped, r, 64);
+                    let emb = encoder
+                        .embed(&patch)
+                        .map(|e| e.vec)
+                        .unwrap_or_default();
+                    let elt_id = format!("{}#e{}", id, elt_idx);
+                    self.elements.push(DetectedElement {
+                        id: elt_id,
+                        system_id: id.clone(),
+                        bbox: *r,
+                        patch,
+                        suggested_class: None,
+                        hog_embedding: emb,
+                    });
+                }
+
+                self.systems.push(RectifiedSystem {
+                    id,
+                    image: rectified,
+                    page: page_idx,
+                    system_idx: sys_idx,
+                    bbox_top: top,
+                    bbox_bottom: bottom,
+                });
+                added_systems += 1;
+            }
+        }
+        Ok(added_systems)
+    }
+}
+
+/// Wrapper um `pdf_render::render_pages`, fängt Panics ab und liefert
+/// einen ordentlichen Result.
+fn render_pages_safe(pdf: &Path, dpi: u32) -> Result<Vec<GrayImage>> {
+    let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        omr_pipeline::pdf_render::render_pages(pdf, dpi)
+    }));
+    match res {
+        Ok(Ok(v)) => Ok(v),
+        Ok(Err(e)) => Err(anyhow::anyhow!("{}", e)),
+        Err(_) => Err(anyhow::anyhow!("pdfium-Panic abgefangen")),
+    }
+}
+
+fn short_id(p: &Path) -> String {
+    p.file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown")
+        .replace(' ', "_")
+}
+
+fn sub_image(img: &GrayImage, x: u32, y: u32, w: u32, h: u32) -> GrayImage {
+    let w = w.min(img.width().saturating_sub(x));
+    let h = h.min(img.height().saturating_sub(y));
+    let mut out: GrayImage = ImageBuffer::new(w.max(1), h.max(1));
+    for yy in 0..h {
+        for xx in 0..w {
+            out.put_pixel(xx, yy, *img.get_pixel(x + xx, y + yy));
+        }
+    }
+    out
+}
+
+fn binary_to_gray(bin: &Binary) -> GrayImage {
+    bin.to_gray()
+}
+
+/// Bbox-Approximation eines Systems: minY der obersten Linie, maxY der
+/// untersten Linie, plus etwa eine Linienhöhe Polster.
+fn system_bbox(_gray: &GrayImage, system: &StaffSystem) -> (u32, u32) {
+    let top = system
+        .lines
+        .first()
+        .map(|l| l.mean_y())
+        .unwrap_or(0.0);
+    let bot = system
+        .lines
+        .last()
+        .map(|l| l.mean_y())
+        .unwrap_or(top);
+    let pad = (system.line_spacing * 4.0).max(8.0);
+    let top = (top - pad).max(0.0) as u32;
+    let bot = (bot + pad) as u32;
+    (top, bot)
+}
+
+/// Vereinfachte Rectification: pro X-Spalte wird ein vertikaler Shift
+/// angewandt, sodass die Mittellinie auf eine horizontale Linie
+/// projiziert wird. Das ist eine Light-Variante eines affinen Warps und
+/// ohne `imageproc`-Abhängigkeit umsetzbar.
+fn rectify_system(crop: &GrayImage, system: &StaffSystem, top_offset: u32) -> GrayImage {
+    let w = crop.width();
+    let h = crop.height();
+    if h == 0 || w == 0 || system.lines.is_empty() {
+        return crop.clone();
+    }
+    let target_mid = (h as f32) * 0.5;
+    let mut out: GrayImage = ImageBuffer::from_pixel(w, h, Luma([255u8]));
+    for x in 0..w {
+        // Mittlere Y-Position der mittleren Linie an dieser Spalte.
+        let mid_idx = system.lines.len() / 2;
+        let y_mid = system
+            .line_y_at(mid_idx, x)
+            .unwrap_or_else(|| system.middle_y());
+        let local_mid = (y_mid - top_offset as f32).max(0.0);
+        let shift = (target_mid - local_mid).round() as i32;
+        for y in 0..h as i32 {
+            let src_y = y - shift;
+            if src_y < 0 || src_y >= h as i32 {
+                continue;
+            }
+            let p = *crop.get_pixel(x, src_y as u32);
+            out.put_pixel(x, y as u32, p);
+        }
+    }
+    out
+}
+
+/// Extrahiert Connected-Components-Bboxes aus dem (staff-removed)
+/// System-Crop. Bewusst sehr einfach: 4-Connectivity, BFS, Filter auf
+/// Mindestgröße.
+fn detect_elements(crop: &GrayImage, system: &StaffSystem, _top_offset: u32) -> Vec<Rect> {
+    let w = crop.width() as i32;
+    let h = crop.height() as i32;
+    if w == 0 || h == 0 {
+        return Vec::new();
+    }
+    let n = (w * h) as usize;
+    let mut seen = vec![false; n];
+    let min_dim = ((system.line_spacing * 0.5).max(3.0)) as i32;
+    let max_dim = ((system.line_spacing * 10.0).max(64.0)) as i32;
+
+    let is_fg = |x: i32, y: i32| -> bool {
+        if x < 0 || y < 0 || x >= w || y >= h {
+            return false;
+        }
+        crop.get_pixel(x as u32, y as u32)[0] < 128
+    };
+
+    let mut rects = Vec::new();
+    let mut queue: std::collections::VecDeque<(i32, i32)> = std::collections::VecDeque::new();
+
+    for sy in 0..h {
+        for sx in 0..w {
+            let idx = (sy * w + sx) as usize;
+            if seen[idx] || !is_fg(sx, sy) {
+                continue;
+            }
+            queue.clear();
+            queue.push_back((sx, sy));
+            seen[idx] = true;
+            let mut min_x = sx;
+            let mut min_y = sy;
+            let mut max_x = sx;
+            let mut max_y = sy;
+            let mut size = 0u32;
+            while let Some((x, y)) = queue.pop_front() {
+                size += 1;
+                min_x = min_x.min(x);
+                min_y = min_y.min(y);
+                max_x = max_x.max(x);
+                max_y = max_y.max(y);
+                for (dx, dy) in [(-1, 0), (1, 0), (0, -1), (0, 1)] {
+                    let nx = x + dx;
+                    let ny = y + dy;
+                    if nx < 0 || ny < 0 || nx >= w || ny >= h {
+                        continue;
+                    }
+                    let nidx = (ny * w + nx) as usize;
+                    if seen[nidx] || !is_fg(nx, ny) {
+                        continue;
+                    }
+                    seen[nidx] = true;
+                    queue.push_back((nx, ny));
+                }
+            }
+            let bw = max_x - min_x + 1;
+            let bh = max_y - min_y + 1;
+            if bw < min_dim || bh < min_dim {
+                continue;
+            }
+            if bw > max_dim * 4 || bh > max_dim {
+                continue;
+            }
+            if size < 8 {
+                continue;
+            }
+            rects.push(Rect {
+                x: min_x as u32,
+                y: min_y as u32,
+                w: bw as u32,
+                h: bh as u32,
+            });
+        }
+    }
+    rects
+}
+
+/// Schneidet einen Patch aus einem System-Crop und resampled ihn auf
+/// `target × target` mittels Nearest-Neighbor.
+pub fn extract_patch(crop: &GrayImage, r: &Rect, target: u32) -> GrayImage {
+    let sub = sub_image(crop, r.x, r.y, r.w, r.h);
+    let resized = resize_nn(&sub, target, target);
+    resized
+}
+
+fn resize_nn(src: &GrayImage, w: u32, h: u32) -> GrayImage {
+    let mut dst = GrayImage::new(w.max(1), h.max(1));
+    let sw = src.width().max(1) as f32;
+    let sh = src.height().max(1) as f32;
+    for y in 0..dst.height() {
+        for x in 0..dst.width() {
+            let sx = ((x as f32 + 0.5) * sw / dst.width() as f32).floor() as u32;
+            let sy = ((y as f32 + 0.5) * sh / dst.height() as f32).floor() as u32;
+            let sx = sx.min(src.width().saturating_sub(1));
+            let sy = sy.min(src.height().saturating_sub(1));
+            dst.put_pixel(x, y, *src.get_pixel(sx, sy));
+        }
+    }
+    dst
+}
+
+/// Hilfsfunktion: kodiert ein GrayImage als PNG-Bytes.
+pub fn encode_png(img: &GrayImage) -> Result<Vec<u8>> {
+    let mut buf: Vec<u8> = Vec::new();
+    let dyn_img = DynamicImage::ImageLuma8(img.clone());
+    dyn_img.write_to(
+        &mut std::io::Cursor::new(&mut buf),
+        image::ImageFormat::Png,
+    )?;
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+
+    fn make_test_dir(suffix: &str) -> std::path::PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let dir = std::env::temp_dir().join(format!("omr-labeler-test-{}-{}", suffix, nanos));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn scan_filestore_finds_pdfs() {
+        let dir = make_test_dir("scan");
+        let p1 = dir.join("a.pdf");
+        let p2 = dir.join("sub").join("b.pdf");
+        let p3 = dir.join("c.txt");
+        std::fs::create_dir_all(dir.join("sub")).unwrap();
+        File::create(&p1).unwrap().write_all(b"x").unwrap();
+        File::create(&p2).unwrap().write_all(b"x").unwrap();
+        File::create(&p3).unwrap().write_all(b"x").unwrap();
+
+        let found = PipelineState::scan_filestore(&dir);
+        assert_eq!(found.len(), 2);
+        assert!(found.iter().any(|p| p.ends_with("a.pdf")));
+        assert!(found.iter().any(|p| p.ends_with("b.pdf")));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn scan_filestore_handles_missing_dir() {
+        let v = PipelineState::scan_filestore(Path::new("Z:/does-not-exist-12345"));
+        assert!(v.is_empty());
+    }
+}

--- a/src/omr-rust/crates/omr-labeler/src/synthetic_warmup.rs
+++ b/src/omr-rust/crates/omr-labeler/src/synthetic_warmup.rs
@@ -1,0 +1,154 @@
+//! Synthetic Cold-Start: lädt einen kleinen, klassen-balancierten
+//! Sample-Vorrat aus einem Verzeichnis von Klassen-Subdirs und seedet
+//! die Labeling-Queue damit. Damit kann der Active-Learner bereits in
+//! der ersten Sitzung qualitativ relevante Antworten einsammeln.
+
+use crate::active_learning::{LabelingQueue, Level, QueueItem};
+use std::path::{Path, PathBuf};
+
+/// Ein synthetisches Sample mit Klassen-Label und Pfad zur Bilddatei.
+#[derive(Debug, Clone)]
+pub struct SyntheticSample {
+    pub class: String,
+    pub image_path: PathBuf,
+}
+
+const IMAGE_EXTS: [&str; 5] = ["png", "jpg", "jpeg", "bmp", "tiff"];
+
+/// Liest `dir` und liefert bis zu 5 verschiedene Klassen mit je einem
+/// Sample (Round-Robin, Round 1). Wenn `dir` nicht existiert oder leer
+/// ist, kommt ein leeres Vec zurück.
+pub fn load_synthetic_corpus(dir: &Path) -> Vec<SyntheticSample> {
+    if !dir.exists() {
+        return Vec::new();
+    }
+    let mut by_class: Vec<(String, Vec<PathBuf>)> = Vec::new();
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return Vec::new(),
+    };
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if !p.is_dir() {
+            continue;
+        }
+        let class_name = match p.file_name().and_then(|s| s.to_str()) {
+            Some(s) => s.to_string(),
+            None => continue,
+        };
+        let mut images = Vec::new();
+        if let Ok(read) = std::fs::read_dir(&p) {
+            for f in read.flatten() {
+                let fp = f.path();
+                let ext = fp
+                    .extension()
+                    .and_then(|s| s.to_str())
+                    .map(|s| s.to_ascii_lowercase());
+                if let Some(ext) = ext {
+                    if IMAGE_EXTS.contains(&ext.as_str()) {
+                        images.push(fp);
+                    }
+                }
+            }
+        }
+        if !images.is_empty() {
+            images.sort();
+            by_class.push((class_name, images));
+        }
+    }
+    by_class.sort_by(|a, b| a.0.cmp(&b.0));
+
+    // Round-Robin: pro Klasse genau ein Sample, max. 5 Klassen.
+    let mut out = Vec::new();
+    for (class, images) in by_class.into_iter().take(5) {
+        if let Some(p) = images.into_iter().next() {
+            out.push(SyntheticSample {
+                class,
+                image_path: p,
+            });
+        }
+    }
+    out
+}
+
+/// Seedet die Queue mit den ersten 5 synthetischen Samples (oder weniger,
+/// falls der Corpus kleiner ist). Diese Samples bekommen hohe
+/// Unsicherheit (1.0), damit sie als erste behandelt werden.
+pub fn seed_queue_with_synthetic(queue: &mut LabelingQueue, samples: &[SyntheticSample]) {
+    for (i, s) in samples.iter().take(5).enumerate() {
+        let item = QueueItem {
+            id: 0, // wird von push_item überschrieben
+            level: Level::Class,
+            uncertainty: 1.0,
+            system_id: format!("synthetic#{}", i),
+            element_id: Some(format!("synthetic#{}", i)),
+            suggested_class: Some(s.class.clone()),
+            top_k: vec![(s.class.clone(), 1.0)],
+        };
+        queue.push_item(item);
+    }
+    queue.re_prioritize();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+
+    fn make_test_dir(suffix: &str) -> std::path::PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let dir = std::env::temp_dir().join(format!("omr-labeler-test-{}-{}", suffix, nanos));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn load_empty_dir_returns_empty() {
+        let dir = make_test_dir("synth-empty");
+        assert!(load_synthetic_corpus(&dir).is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_missing_dir_returns_empty() {
+        assert!(load_synthetic_corpus(Path::new("Z:/no/such/dir-12345")).is_empty());
+    }
+
+    #[test]
+    fn load_corpus_with_classes() {
+        let dir = make_test_dir("synth-classes");
+        for cls in ["notehead", "rest", "clef"] {
+            let d = dir.join(cls);
+            std::fs::create_dir_all(&d).unwrap();
+            let mut f = File::create(d.join("a.png")).unwrap();
+            f.write_all(&[0u8; 8]).unwrap();
+        }
+        let samples = load_synthetic_corpus(&dir);
+        assert_eq!(samples.len(), 3);
+        let mut classes: Vec<_> = samples.iter().map(|s| s.class.clone()).collect();
+        classes.sort();
+        assert_eq!(classes, vec!["clef", "notehead", "rest"]);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn seed_pushes_into_queue() {
+        let mut q = LabelingQueue::new();
+        let samples = vec![
+            SyntheticSample {
+                class: "notehead".into(),
+                image_path: PathBuf::from("/x/n.png"),
+            },
+            SyntheticSample {
+                class: "rest".into(),
+                image_path: PathBuf::from("/x/r.png"),
+            },
+        ];
+        seed_queue_with_synthetic(&mut q, &samples);
+        assert_eq!(q.len(), 2);
+    }
+}

--- a/src/omr-rust/crates/omr-labeler/tests/api_tests.rs
+++ b/src/omr-rust/crates/omr-labeler/tests/api_tests.rs
@@ -1,0 +1,162 @@
+//! Integration-Tests für die HTTP-API. Greift auf den Router direkt zu
+//! (kein TCP-Listener nötig — `tower::ServiceExt::oneshot`).
+
+use axum::body::to_bytes;
+use axum::http::{Method, Request, StatusCode};
+use omr_labeler::active_learning::{Level, LabelingQueue};
+use omr_labeler::api::{router, AppState};
+use omr_labeler::persistence::LabelDb;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+fn make_state() -> Arc<AppState> {
+    let db = LabelDb::open_in_memory().unwrap();
+    Arc::new(AppState::with_db(db))
+}
+
+async fn body_string(resp: axum::response::Response) -> String {
+    let bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+#[tokio::test]
+async fn api_status_returns_counts() {
+    let state = make_state();
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/api/status")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_string(resp).await;
+    let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(v["pdfs"], 0);
+    assert_eq!(v["systems"], 0);
+    assert_eq!(v["elements"], 0);
+    assert_eq!(v["labels"], 0);
+}
+
+#[tokio::test]
+async fn api_queue_next_returns_item() {
+    let state = make_state();
+    {
+        let mut q = state.queue.write().await;
+        q.push(Level::Line, "sys-test".into(), None, 0.9);
+    }
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/api/queue/next?n=1")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v: serde_json::Value = serde_json::from_str(&body_string(resp).await).unwrap();
+    assert_eq!(v["items"].as_array().unwrap().len(), 1);
+    assert_eq!(v["items"][0]["system_id"], "sys-test");
+}
+
+#[tokio::test]
+async fn api_queue_answer_persists_label() {
+    let state = make_state();
+    let id = {
+        let mut q = state.queue.write().await;
+        q.push(Level::Line, "sys-1".into(), None, 0.9)
+    };
+    let app = router(state.clone());
+    let body = serde_json::json!({
+        "item_id": id,
+        "level": "line",
+        "decision": "yes",
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/queue/answer")
+                .header("Content-Type", "application/json")
+                .body(axum::body::Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Anschließend prüfen, dass das Label persistiert wurde.
+    let count = {
+        let guard = state.db.lock().expect("db mutex poisoned");
+        guard.as_ref().unwrap().count_labels("").unwrap()
+    };
+    assert_eq!(count, 1);
+}
+
+#[tokio::test]
+async fn api_export_corpus_returns_json() {
+    let state = make_state();
+    {
+        let mut q = state.queue.write().await;
+        let _ = q.push(Level::Line, "sys-1".into(), None, 0.9);
+    }
+    // Antwort einbringen, damit der Export nicht leer ist.
+    let id = state.queue.read().await.items.front().unwrap().id;
+    let app = router(state.clone());
+    let answer = serde_json::json!({
+        "item_id": id,
+        "level": "line",
+        "decision": "yes",
+    });
+    let _ = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/queue/answer")
+                .header("Content-Type", "application/json")
+                .body(axum::body::Body::from(answer.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/api/export/corpus")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v: serde_json::Value = serde_json::from_str(&body_string(resp).await).unwrap();
+    let arr = v.as_array().expect("export muss ein JSON-Array sein");
+    assert!(!arr.is_empty(), "export darf nicht leer sein");
+    assert_eq!(arr[0]["level"], "line");
+    assert_eq!(arr[0]["decision"], "yes");
+}
+
+// Sicherstellen, dass die LabelingQueue selbst ohne API getestet wird —
+// dies dient als zweites Sicherheits-Netz, falls die API-Wiring bricht.
+#[tokio::test]
+async fn queue_basic_invariants() {
+    let mut q = LabelingQueue::new();
+    let a = q.push(Level::Line, "a".into(), None, 0.1);
+    let b = q.push(Level::Line, "b".into(), None, 0.9);
+    q.re_prioritize();
+    let nxt = q.next().unwrap();
+    assert_eq!(nxt.id, b);
+    q.answer(b, omr_labeler::active_learning::Decision::Yes);
+    let nxt = q.next().unwrap();
+    assert_eq!(nxt.id, a);
+}

--- a/src/omr-rust/crates/omr-labeler/web/app.js
+++ b/src/omr-rust/crates/omr-labeler/web/app.js
@@ -1,0 +1,266 @@
+// OMR Labeler — Vanilla JS frontend.
+// ----------------------------------------------------------------------
+// Verantwortlich für:
+//   * Polling der Queue (`/api/queue/next`)
+//   * Rendern des Items je nach Level (line / element / class)
+//   * Senden von Antworten (`/api/queue/answer`, `/skip`, `/undo`)
+//   * Hotkey-Handling
+//   * Stats / Progress-Aktualisierung
+//
+// Bewusst kein Framework — der Tool soll ohne Build-Schritt laufen.
+// ----------------------------------------------------------------------
+
+(function () {
+  "use strict";
+
+  const state = {
+    currentItem: null,
+    contextSystems: [],
+  };
+
+  // ---------- Utility ---------------------------------------------------
+
+  function $(id) {
+    return document.getElementById(id);
+  }
+
+  async function jsonGet(url) {
+    const r = await fetch(url, { headers: { "Accept": "application/json" } });
+    if (!r.ok) throw new Error("GET " + url + " → " + r.status);
+    return r.json();
+  }
+
+  async function jsonPost(url, body) {
+    const r = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body || {}),
+    });
+    if (!r.ok) throw new Error("POST " + url + " → " + r.status);
+    return r.json();
+  }
+
+  function setText(id, text) {
+    const el = $(id);
+    if (el) el.textContent = text;
+  }
+
+  // ---------- Status / Stats --------------------------------------------
+
+  async function updateStatus() {
+    try {
+      const s = await jsonGet("/api/status");
+      setText("stat-pdfs", "PDFs: " + s.pdfs);
+      setText("stat-systems", "Systems: " + s.systems);
+      setText("stat-elements", "Elements: " + s.elements);
+      setText("stat-labels", "Labels: " + s.labels);
+    } catch (e) {
+      console.warn("status failed", e);
+    }
+  }
+
+  async function updateStats() {
+    try {
+      const s = await jsonGet("/api/stats");
+      const pct = Math.round(s.progress * 100);
+      const bar = $("progress-bar");
+      if (bar) bar.style.width = pct + "%";
+      setText(
+        "progress-text",
+        s.labeled + " / " + s.total + " (" + pct + "%)",
+      );
+    } catch (e) {
+      console.warn("stats failed", e);
+    }
+  }
+
+  // ---------- Queue -----------------------------------------------------
+
+  async function fetchQueue() {
+    try {
+      const r = await jsonGet("/api/queue/next?n=1");
+      if (r.items && r.items.length > 0) {
+        state.currentItem = r.items[0];
+        renderLevel(state.currentItem);
+      } else {
+        state.currentItem = null;
+        renderEmpty();
+      }
+    } catch (e) {
+      console.error("queue fetch failed", e);
+      renderEmpty("Verbindung verloren — bitte neu laden.");
+    }
+  }
+
+  function renderEmpty(msg) {
+    state.currentItem = null;
+    const m = $("main-image");
+    if (m) m.innerHTML = '<p class="empty">' + (msg || "Queue leer — alle Items bearbeitet 🎉") + "</p>";
+    const c = $("class-buttons");
+    if (c) c.classList.add("hidden");
+    setText("current-info", "—");
+  }
+
+  function renderLevel(item) {
+    const m = $("main-image");
+    if (!m) return;
+    m.innerHTML = "";
+    const img = document.createElement("img");
+    if (item.level === "line") {
+      img.src = "/api/system/" + encodeURIComponent(item.system_id) + "/image";
+    } else {
+      const id = item.element_id || item.system_id;
+      img.src = "/api/element/" + encodeURIComponent(id) + "/image";
+    }
+    img.alt = "Item " + item.id;
+    img.onerror = () => {
+      m.innerHTML = '<p class="empty">Kein Bild verfügbar (id=' + item.id + ").</p>";
+    };
+    m.appendChild(img);
+    setText(
+      "current-info",
+      "ID " + item.id + " · Level " + item.level + " · u=" + (item.uncertainty || 0).toFixed(2) +
+        (item.suggested_class ? " · suggested " + item.suggested_class : ""),
+    );
+
+    renderContextImages(item);
+    renderClassButtons(item);
+  }
+
+  function renderContextImages(item) {
+    // Platzhalter: wir laden keine echten Nachbar-Systeme, aber zeigen
+    // die letzten beiden gelabelten als gedimmte Strip-Items.
+    const prev = $("context-prev");
+    const next = $("context-next");
+    if (prev) prev.innerHTML = "";
+    if (next) next.innerHTML = "";
+  }
+
+  function renderClassButtons(item) {
+    const wrap = $("class-buttons");
+    if (!wrap) return;
+    wrap.innerHTML = "";
+    if (item.level !== "class" || !item.top_k || item.top_k.length === 0) {
+      wrap.classList.add("hidden");
+      return;
+    }
+    wrap.classList.remove("hidden");
+    item.top_k.slice(0, 5).forEach((entry, idx) => {
+      const btn = document.createElement("button");
+      btn.className = "btn";
+      btn.textContent = (idx + 1) + ". " + entry[0];
+      btn.dataset.action = "class";
+      btn.dataset.value = entry[0];
+      wrap.appendChild(btn);
+    });
+  }
+
+  // ---------- Sending ---------------------------------------------------
+
+  async function sendAnswer(decision, value) {
+    if (!state.currentItem) return;
+    const item = state.currentItem;
+    try {
+      await jsonPost("/api/queue/answer", {
+        item_id: item.id,
+        level: item.level,
+        decision: decision,
+        value: value || null,
+      });
+    } catch (e) {
+      console.error("answer failed", e);
+    }
+    autoAdvance();
+  }
+
+  async function sendSkip() {
+    if (!state.currentItem) return;
+    try {
+      await jsonPost("/api/queue/skip", { item_id: state.currentItem.id });
+    } catch (e) {
+      console.error("skip failed", e);
+    }
+    autoAdvance();
+  }
+
+  async function sendUndo() {
+    try {
+      await jsonPost("/api/queue/undo", {});
+    } catch (e) {
+      console.error("undo failed", e);
+    }
+    refreshAll();
+  }
+
+  function autoAdvance() {
+    refreshAll();
+  }
+
+  function refreshAll() {
+    fetchQueue();
+    updateStatus();
+    updateStats();
+  }
+
+  // ---------- Hotkeys ---------------------------------------------------
+
+  function handleKeypress(e) {
+    if (e.target && (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA")) {
+      return;
+    }
+    const k = e.key.toLowerCase();
+    if (k === "y") return sendAnswer("yes");
+    if (k === "n") return sendAnswer("no");
+    if (k === " " || k === "spacebar") {
+      e.preventDefault();
+      return sendSkip();
+    }
+    if (k === "u") return sendUndo();
+    if (k === "e") {
+      const cls = prompt("Klasse eingeben:");
+      if (cls && cls.trim().length > 0) {
+        sendAnswer("class", cls.trim());
+      }
+      return;
+    }
+    if (/^[1-5]$/.test(k)) {
+      const idx = parseInt(k, 10) - 1;
+      const item = state.currentItem;
+      if (item && item.top_k && item.top_k[idx]) {
+        return sendAnswer("class", item.top_k[idx][0]);
+      }
+    }
+  }
+
+  // ---------- Setup -----------------------------------------------------
+
+  function bindButtons() {
+    document.body.addEventListener("click", (e) => {
+      const t = e.target;
+      if (!(t instanceof HTMLElement)) return;
+      const action = t.dataset.action;
+      if (!action) return;
+      if (action === "yes") return sendAnswer("yes");
+      if (action === "no") return sendAnswer("no");
+      if (action === "skip") return sendSkip();
+      if (action === "undo") return sendUndo();
+      if (action === "class") return sendAnswer("class", t.dataset.value || "");
+    });
+  }
+
+  function init() {
+    bindButtons();
+    window.addEventListener("keydown", handleKeypress);
+    refreshAll();
+    setInterval(updateStatus, 5000);
+    setInterval(() => {
+      if (!state.currentItem) fetchQueue();
+    }, 4000);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/src/omr-rust/crates/omr-labeler/web/index.html
+++ b/src/omr-rust/crates/omr-labeler/web/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>OMR Labeler</title>
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+  <header class="topbar">
+    <h1>OMR Labeler</h1>
+    <div class="status" id="status-bar">
+      <span id="stat-pdfs">PDFs: …</span>
+      <span id="stat-systems">Systems: …</span>
+      <span id="stat-elements">Elements: …</span>
+      <span id="stat-labels">Labels: …</span>
+    </div>
+  </header>
+  <main class="layout">
+    <section class="main-panel">
+      <div id="context-prev" class="context-strip"></div>
+      <div id="main-image" class="main-image">
+        <p class="empty">Loading next item…</p>
+      </div>
+      <div id="context-next" class="context-strip"></div>
+      <div id="action-bar" class="action-bar">
+        <button data-action="yes" class="btn yes">Yes (Y)</button>
+        <button data-action="no" class="btn no">No (N)</button>
+        <button data-action="skip" class="btn">Skip (Space)</button>
+        <button data-action="undo" class="btn">Undo (U)</button>
+      </div>
+      <div id="class-buttons" class="class-buttons hidden"></div>
+    </section>
+    <aside class="sidebar">
+      <h2>Hotkeys</h2>
+      <ul class="hotkey-list">
+        <li><kbd>Y</kbd> Yes</li>
+        <li><kbd>N</kbd> No</li>
+        <li><kbd>Space</kbd> Skip</li>
+        <li><kbd>U</kbd> Undo</li>
+        <li><kbd>1</kbd>–<kbd>5</kbd> Class shortcut</li>
+        <li><kbd>E</kbd> Edit class…</li>
+      </ul>
+      <h2>Progress</h2>
+      <div class="progress">
+        <div id="progress-bar" class="progress-bar"></div>
+      </div>
+      <p id="progress-text">0 / 0</p>
+      <h2>Current</h2>
+      <p id="current-info">—</p>
+    </aside>
+  </main>
+  <script src="/app.js"></script>
+</body>
+</html>

--- a/src/omr-rust/crates/omr-labeler/web/style.css
+++ b/src/omr-rust/crates/omr-labeler/web/style.css
@@ -1,0 +1,198 @@
+/* OMR Labeler — Dark Mode, minimalist. */
+
+:root {
+  --bg: #111418;
+  --fg: #e8eaed;
+  --muted: #8a929b;
+  --accent: #4ea3ff;
+  --good: #34c759;
+  --bad: #ff453a;
+  --panel: #1a1d22;
+  --panel-light: #232830;
+  --border: #2a2f37;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: ui-sans-serif, -apple-system, "Segoe UI", Roboto, sans-serif;
+  height: 100%;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1.5rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--panel);
+}
+
+.topbar h1 {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.04em;
+}
+
+.status {
+  display: flex;
+  gap: 1rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 1fr 280px;
+  height: calc(100% - 56px);
+}
+
+.main-panel {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  overflow: hidden;
+}
+
+.context-strip {
+  display: flex;
+  gap: 0.5rem;
+  height: 80px;
+  opacity: 0.4;
+  overflow-x: auto;
+}
+
+.context-strip img {
+  height: 100%;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+}
+
+.main-image {
+  flex: 1;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: auto;
+}
+
+.main-image img {
+  max-width: 100%;
+  max-height: 100%;
+  image-rendering: pixelated;
+}
+
+.main-image .empty {
+  color: var(--muted);
+}
+
+.action-bar {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+}
+
+.btn {
+  background: var(--panel-light);
+  border: 1px solid var(--border);
+  color: var(--fg);
+  padding: 0.6rem 1.2rem;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.95rem;
+  font-weight: 600;
+  transition: background 0.1s ease;
+}
+
+.btn:hover {
+  background: #2c333d;
+}
+
+.btn.yes {
+  border-color: var(--good);
+}
+
+.btn.no {
+  border-color: var(--bad);
+}
+
+.class-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  justify-content: center;
+}
+
+.class-buttons.hidden {
+  display: none;
+}
+
+.sidebar {
+  background: var(--panel);
+  border-left: 1px solid var(--border);
+  padding: 1rem;
+  font-size: 0.9rem;
+  overflow-y: auto;
+}
+
+.sidebar h2 {
+  margin: 1rem 0 0.5rem 0;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+}
+
+.hotkey-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.hotkey-list li {
+  padding: 0.3rem 0;
+}
+
+kbd {
+  background: var(--panel-light);
+  border: 1px solid var(--border);
+  border-bottom-width: 2px;
+  border-radius: 4px;
+  padding: 0.1rem 0.4rem;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-size: 0.8rem;
+  margin-right: 0.4rem;
+}
+
+.progress {
+  background: var(--panel-light);
+  border-radius: 6px;
+  overflow: hidden;
+  height: 10px;
+}
+
+.progress-bar {
+  background: var(--accent);
+  height: 100%;
+  width: 0;
+  transition: width 0.3s ease;
+}
+
+#progress-text {
+  margin: 0.4rem 0 0 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+#current-info {
+  color: var(--muted);
+  word-break: break-all;
+}


### PR DESCRIPTION
## Overview

Adds \	ools/training/generate_synthetic_patterns.py\ — a comprehensive synthetic pattern generator for Sheetstorm's OMR (Optical Music Recognition) cold-start training corpus.

Generates **115 classes** of 64×64 grayscale PNG patches across three levels:

---

## Generated Classes (115 total)

### Level 1 — Single Symbols (100 classes, Bravura SMuFL + PIL)
| Category | Classes |
|---|---|
| Noteheads | \
otehead_filled\, \
otehead_open\, \
otehead_whole\ |
| Rests | \est_whole\, \est_half\, \est_quarter\, \est_eighth\, \est_16th\, \est_32nd\, \est_64th\ |
| Clefs | \clef_treble\, \clef_bass\, \clef_alto\, \clef_tenor\, \clef_percussion\ |
| Time Signatures | \	imesig_4\, \	imesig_3\, \	imesig_2\, \	imesig_6\, \	imesig_0\, \	imesig_c\, \	imesig_cut\ |
| Key Sig. Accidentals | \keysig_sharp\, \keysig_flat\, \keysig_natural\ |
| Accidentals | \cc_sharp\, \cc_flat\, \cc_natural\, \cc_double_sharp\, \cc_double_flat\ |
| Augmentation | \ug_dot\ |
| Barlines | \arline_single\, \arline_double\, \arline_final\, \arline_repeat_start\, \arline_repeat_end\, \arline_repeat_both\ |
| Volta Brackets | \olta_1\, \olta_2\ |
| Dynamics | \dynamic_p\, \dynamic_pp\, \dynamic_ppp\, \dynamic_f\, \dynamic_ff\, \dynamic_fff\, \dynamic_mp\, \dynamic_mf\, \dynamic_sf\, \dynamic_sfz\, \dynamic_fp\, \dynamic_fz\ |
| Articulations | \rtic_accent\, \rtic_tenuto\, \rtic_staccato\, \rtic_staccatissimo\, \rtic_marcato\, \rtic_fermata\, \rtic_trill\, \rtic_turn\, \rtic_mordent\ |
| Ornaments | \orn_trill\, \orn_turn\, \orn_mordent\, \orn_mordent_inv\ |
| Flags | \lag_up_8th\, \lag_down_8th\, \lag_up_16th\, \lag_down_16th\ |
| Stems | \stem_up\, \stem_down\ |
| Beams | \eam\ |
| Ledger Lines | \ledger_line\ |
| Slurs/Ties | \slur_above\, \slur_below\, \	ie_above\, \	ie_below\ |
| Crescendo/Diminuendo | \cresc_hairpin\, \dim_hairpin\ |
| Tremolos | \	remolo_1\, \	remolo_2\, \	remolo_3\ |
| Repeat Signs | \segno\, \coda\ |
| Glyphs | \glyph_8va\, \glyph_8vb\ |
| Octave Brackets | \ottava_8va\, \ottava_8vb\ |
| Pedal Marks | \pedal_mark\, \pedal_up\ |
| Brackets | \racket\, \race\ |
| Tempo Text | \	empo_andante\, \	empo_moderato\, \	empo_allegro\, \	empo_presto\, \	empo_adagio\, \	empo_largo\, \	empo_vivace\ |
| Jump Marks | \jump_dcalfine\, \jump_dsalfine\, \jump_fine\, \jump_coda\, \jump_segno\ |

### Level 2 — Logical Groups (10 classes, Verovio + Playwright)
\eam_group_quarter\, \eam_group_eighth\, \chord_cluster_major\, \chord_cluster_minor\, \	ied_notes\, \	uplet_triplet\, \mordent_trill_ornament\, \grace_note_appoggiatura\, \dynamic_hairpin_cresc\, \dynamic_hairpin_dim\

### Level 3 — Phrase Snippets (5 classes, Verovio + Playwright)
\phrase_cadence_authentic\, \phrase_cadence_half\, \phrase_marcia\, \phrase_polka\, \phrase_walzer\

---

## Architecture

- **Level 1**: Direct Bravura SMuFL glyph rendering via PIL — no browser needed, fast (~8s for 5k patches)
- **Level 2 & 3**: MusicXML → Verovio SVG → Playwright PNG pipeline — accurate typeset music notation
- **Augmentation** (8 types): Gaussian noise, JPEG compression, salt-pepper, toner smear, faded ink, rotation ±2°, skew ±1°, scale 0.85-1.15
- **Output**: 64×64 grayscale PNG + \manifest.json\ with class/source/augmentation metadata

---

## Stats (smoke run, \--n-per-class 50\)
- **5,173 samples** across 115 classes
- **9.1 MB** total
- **~46 seconds** runtime (PIL + Playwright)

## Usage

\\\ash
cd tools/training
python generate_synthetic_patterns.py --output data/synthetic_corpus_v1 --n-per-class 800
# Full run: ~92,000 samples, ~115 classes, ~12min
\\\

CLI options:
\\\
--output      Output directory (default: data/synthetic_corpus_v1)
--n-per-class Augmented patches per class (default: 50)
--bravura     Path to Bravura.otf (auto-detected)
--seed        Random seed for reproducibility
--no-groups   Skip level 2 (logical groups)
--no-snippets Skip level 3 (phrase snippets)
\\\

---

## Tests

\\\
tools/training/tests/test_generate_synthetic.py — 55/55 PASSED in 53s
\\\

Test coverage: directory structure, manifest schema, class count (≥50), 64×64 grayscale PNG format, non-blank images, specific class existence check.

---

## Notes

- Verovio may emit tie warnings (\identical startid/endid\) — cosmetic, images render correctly
- \	ools/training/data/\ is gitignored — generated corpus not committed
- Requires: \pillow\, \
umpy\, \erovio\, \playwright\ (Chromium)