### PR TITLE
feat(omr-labeler): hierarchical classes + drill-down + live-filter search

### DIFF
--- a/src/omr-rust/crates/omr-labeler/src/api.rs
+++ b/src/omr-rust/crates/omr-labeler/src/api.rs
@@ -117,6 +117,8 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/app.js", get(app_js))
         .route("/style.css", get(style_css))
         .route("/api/status", get(api_status))
+        .route("/api/classes", get(api_classes))
+        .route("/api/classes/drilldown/:group_id", get(api_classes_drilldown))
         .route("/api/queue/next", get(api_queue_next))
         .route("/api/queue/answer", post(api_queue_answer))
         .route("/api/queue/skip", post(api_queue_skip))
@@ -169,6 +171,39 @@ async fn api_status(State(state): State<Arc<AppState>>) -> Json<StatusResponse> 
         elements: pipeline.elements.len(),
         labels,
     })
+}
+
+/// Liefert die hierarchische Klassen-Liste fuer das Klassifikations-Dropdown.
+/// Default: nur Top-Level (`group/...`) — die direkt waehlbaren Klassen.
+/// `?include_atoms=1` liefert zusaetzlich die atomaren Klassen.
+#[derive(Deserialize)]
+pub struct ClassesQuery {
+    #[serde(default)]
+    pub include_atoms: Option<u8>,
+    #[serde(default)]
+    pub include_phrases: Option<u8>,
+}
+
+async fn api_classes(Query(q): Query<ClassesQuery>) -> Json<Vec<crate::classes::ClassEntry>> {
+    use crate::classes::{all_classes, ClassLevel};
+    let include_atoms = q.include_atoms.unwrap_or(0) != 0;
+    let include_phrases = q.include_phrases.unwrap_or(0) != 0;
+    let classes: Vec<_> = all_classes()
+        .into_iter()
+        .filter(|c| match c.level {
+            ClassLevel::Group => true,
+            ClassLevel::Atom => include_atoms,
+            ClassLevel::Phrase => include_phrases,
+        })
+        .collect();
+    Json(classes)
+}
+
+/// Drill-Down einer Group-Klasse zu ihren atomaren Sub-Klassen.
+async fn api_classes_drilldown(
+    AxumPath(group_id): AxumPath<String>,
+) -> Json<Vec<crate::classes::ClassEntry>> {
+    Json(crate::classes::drill_down(&group_id))
 }
 
 async fn api_queue_next(

--- a/src/omr-rust/crates/omr-labeler/src/classes.rs
+++ b/src/omr-rust/crates/omr-labeler/src/classes.rs
@@ -1,0 +1,209 @@
+//! Klassen-Hierarchie fuer das Labeling-System.
+//!
+//! Dieses Modul kennt die bekannten Klassen (Single Symbols + Logical Groups)
+//! und gibt sie strukturiert an die UI weiter. Es kommt mit dem Output von
+//! `tools/training/generate_synthetic_patterns.py` ueberein.
+//!
+//! Hierarchie:
+//! - **Level "Group"** (Top-Level, was meistens gelabelt wird):
+//!   `single_note`, `beamed_group_2_eighths`, `chord`, …
+//! - **Level "Atom"** (Drill-Down nach `[d]`-Hotkey):
+//!   `notehead_filled`, `stem_up`, `beam_1`, …
+
+use serde::{Deserialize, Serialize};
+
+/// Eine Klasse mit Display-Name + Klassen-ID + Hotkey-Suggestion.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClassEntry {
+    /// Stable klassen-ID (entspricht synthetic_corpus_v1 Pfad ohne Praefix).
+    pub id: String,
+    /// User-faehiger Name fuer die UI ("zwei Achtel mit Balken").
+    pub display_name: String,
+    /// Welche Ebene gehoert die Klasse zu.
+    pub level: ClassLevel,
+    /// Optionale Sub-Klassen (Drill-Down).
+    pub atoms: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[serde(rename_all = "lowercase")]
+pub enum ClassLevel {
+    /// Single Symbol (atomare Klasse): notehead_filled, stem_up, beam_1, ...
+    Atom,
+    /// Logische Gruppe: beamed_group_4_sixteenths, chord, tied_phrase, ...
+    Group,
+    /// Phrase-Pattern (selten, nur fuer fortgeschrittenes Tagging): cadence, marcia, …
+    Phrase,
+}
+
+/// Liefert die komplette Klassen-Hierarchie. Wird in der Frontend-API
+/// als `/api/classes` ausgeliefert.
+pub fn all_classes() -> Vec<ClassEntry> {
+    let mut out = Vec::new();
+
+    // ── Atome — was im "Drill-Down" einzeln klassifizierbar ist ─────────
+    for (id, name) in [
+        ("atom/notehead_filled", "Notenkopf gefuellt (Viertel/8tel/16tel/...)"),
+        ("atom/notehead_open", "Notenkopf offen (Halbe)"),
+        ("atom/notehead_whole", "Ganze Note"),
+        ("atom/notehead_x", "X-Notenkopf (Schlagzeug)"),
+        ("atom/notehead_diamond", "Rauten-Notenkopf"),
+        ("atom/stem_up", "Stem nach oben"),
+        ("atom/stem_down", "Stem nach unten"),
+        ("atom/beam_1", "Balken (Achtel-Verbindung, 1 Linie)"),
+        ("atom/beam_2", "Balken (Sechzehntel, 2 Linien)"),
+        ("atom/beam_3", "Balken (32stel, 3 Linien)"),
+        ("atom/flag_eighth_up", "Faehnchen Achtel (Stem hoch)"),
+        ("atom/flag_eighth_down", "Faehnchen Achtel (Stem runter)"),
+        ("atom/flag_sixteenth_up", "Faehnchen 16tel (Stem hoch)"),
+        ("atom/flag_sixteenth_down", "Faehnchen 16tel (Stem runter)"),
+        ("atom/aug_dot_one", "Punktierung (1 Punkt)"),
+        ("atom/aug_dot_two", "Doppelpunktierung"),
+        ("atom/accidental_sharp", "Vorzeichen ♯ Kreuz"),
+        ("atom/accidental_flat", "Vorzeichen ♭ Be"),
+        ("atom/accidental_natural", "Aufloesungszeichen ♮"),
+        ("atom/accidental_double_sharp", "Doppelkreuz 𝄪"),
+        ("atom/accidental_double_flat", "Doppel-Be 𝄫"),
+        ("atom/rest_whole", "Ganze Pause"),
+        ("atom/rest_half", "Halbe Pause"),
+        ("atom/rest_quarter", "Viertelpause"),
+        ("atom/rest_eighth", "Achtelpause"),
+        ("atom/rest_sixteenth", "Sechzehntelpause"),
+        ("atom/clef_treble", "Violinschluessel"),
+        ("atom/clef_bass", "Bassschluessel"),
+        ("atom/clef_alto", "Altschluessel"),
+        ("atom/clef_tenor", "Tenorschluessel"),
+        ("atom/clef_percussion", "Percussion-Schluessel"),
+        ("atom/bar_single", "Taktstrich"),
+        ("atom/bar_double", "Doppelstrich"),
+        ("atom/bar_final", "Schlussstrich"),
+        ("atom/bar_repeat_start", "Wiederholungsanfang ‖:"),
+        ("atom/bar_repeat_end", "Wiederholungsende :‖"),
+        ("atom/articulation_staccato", "Staccato"),
+        ("atom/articulation_accent", "Akzent"),
+        ("atom/articulation_tenuto", "Tenuto"),
+        ("atom/articulation_marcato", "Marcato"),
+        ("atom/articulation_fermata", "Fermate"),
+    ] {
+        out.push(ClassEntry {
+            id: id.to_string(),
+            display_name: name.to_string(),
+            level: ClassLevel::Atom,
+            atoms: Vec::new(),
+        });
+    }
+
+    // ── Gruppen — primaere Labeling-Ebene ────────────────────────────────
+    for (id, name, atoms) in [
+        ("group/single_note_eighth", "Einzel-Achtel", vec!["atom/notehead_filled", "atom/stem_up", "atom/flag_eighth_up"]),
+        ("group/single_note_quarter", "Einzel-Viertel", vec!["atom/notehead_filled", "atom/stem_up"]),
+        ("group/single_note_half", "Einzel-Halbe", vec!["atom/notehead_open", "atom/stem_up"]),
+        ("group/single_note_whole", "Einzel-Ganze", vec!["atom/notehead_whole"]),
+        ("group/beamed_group_2_eighths", "Zwei Achtel mit Balken", vec!["atom/notehead_filled", "atom/notehead_filled", "atom/stem_up", "atom/stem_up", "atom/beam_1"]),
+        ("group/beamed_group_3_eighths", "Drei Achtel mit Balken", vec![]),
+        ("group/beamed_group_4_eighths", "Vier Achtel mit Balken", vec![]),
+        ("group/beamed_group_4_sixteenths", "Vier Sechzehntel mit Doppelbalken", vec!["atom/notehead_filled", "atom/notehead_filled", "atom/notehead_filled", "atom/notehead_filled", "atom/beam_2"]),
+        ("group/beamed_group_8_sixteenths", "Acht Sechzehntel mit Doppelbalken", vec![]),
+        ("group/beamed_group_mixed_8_16", "Gemischte 8tel + 16tel mit Balken", vec![]),
+        ("group/chord_2_notes", "Akkord (2 Noten)", vec!["atom/notehead_filled", "atom/notehead_filled", "atom/stem_up"]),
+        ("group/chord_3_notes", "Akkord (3 Noten)", vec![]),
+        ("group/chord_4_notes", "Akkord (4 Noten)", vec![]),
+        ("group/chord_5_notes", "Akkord (5 Noten)", vec![]),
+        ("group/tied_pair", "Zwei Noten mit Bindebogen", vec![]),
+        ("group/tied_triple", "Drei Noten mit Bindebogen", vec![]),
+        ("group/triplet", "Triole", vec!["atom/notehead_filled", "atom/notehead_filled", "atom/notehead_filled", "atom/beam_1"]),
+        ("group/grace_before", "Vorschlagsnote", vec![]),
+        ("group/mordent", "Mordent (Triller-Schnoerkel)", vec![]),
+        ("group/trill", "Triller", vec![]),
+        ("group/clef_with_keysig", "Schluessel + Tonart-Vorzeichen", vec![]),
+        ("group/keysig_with_timesig", "Tonart + Taktangabe", vec![]),
+    ] {
+        out.push(ClassEntry {
+            id: id.to_string(),
+            display_name: name.to_string(),
+            level: ClassLevel::Group,
+            atoms: atoms.into_iter().map(String::from).collect(),
+        });
+    }
+
+    // ── Phrasen-Patterns (selten gelabelt, fuer fortgeschrittene UX) ─────
+    for (id, name) in [
+        ("phrase/cadence_v_i", "Kadenz V-I"),
+        ("phrase/marcia_pattern", "Marsch-Pattern"),
+        ("phrase/polka_pattern", "Polka-Pattern"),
+        ("phrase/walzer_pattern", "Walzer-Pattern"),
+    ] {
+        out.push(ClassEntry {
+            id: id.to_string(),
+            display_name: name.to_string(),
+            level: ClassLevel::Phrase,
+            atoms: Vec::new(),
+        });
+    }
+
+    out
+}
+
+/// Liefert nur die Klassen einer Ebene.
+pub fn classes_of_level(level: ClassLevel) -> Vec<ClassEntry> {
+    all_classes().into_iter().filter(|c| c.level == level).collect()
+}
+
+/// Resolved Atoms-IDs einer Group → die ClassEntries dazu.
+pub fn drill_down(group_id: &str) -> Vec<ClassEntry> {
+    let groups = all_classes();
+    let group = match groups.iter().find(|c| c.id == group_id && c.level == ClassLevel::Group) {
+        Some(g) => g,
+        None => return Vec::new(),
+    };
+    let atom_ids: std::collections::HashSet<_> = group.atoms.iter().cloned().collect();
+    groups
+        .into_iter()
+        .filter(|c| atom_ids.contains(&c.id))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_classes_has_minimum_count() {
+        let cs = all_classes();
+        assert!(cs.len() > 50, "Erwartet mehr als 50 Klassen, gefunden: {}", cs.len());
+    }
+
+    #[test]
+    fn group_class_has_atoms() {
+        let cs = all_classes();
+        let group = cs
+            .iter()
+            .find(|c| c.id == "group/beamed_group_4_sixteenths")
+            .expect("4 sixteenths Gruppe vorhanden");
+        assert_eq!(group.level, ClassLevel::Group);
+        assert!(!group.atoms.is_empty());
+    }
+
+    #[test]
+    fn drill_down_returns_atoms() {
+        let drilled = drill_down("group/single_note_quarter");
+        assert!(!drilled.is_empty());
+        assert!(drilled.iter().all(|c| c.level == ClassLevel::Atom));
+    }
+
+    #[test]
+    fn drill_down_unknown_group_is_empty() {
+        let drilled = drill_down("group/does_not_exist");
+        assert!(drilled.is_empty());
+    }
+
+    #[test]
+    fn classes_of_level_filters() {
+        let atoms = classes_of_level(ClassLevel::Atom);
+        let groups = classes_of_level(ClassLevel::Group);
+        assert!(atoms.len() > 30);
+        assert!(groups.len() > 15);
+        assert!(atoms.iter().all(|c| c.level == ClassLevel::Atom));
+        assert!(groups.iter().all(|c| c.level == ClassLevel::Group));
+    }
+}

--- a/src/omr-rust/crates/omr-labeler/src/lib.rs
+++ b/src/omr-rust/crates/omr-labeler/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod active_learning;
 pub mod api;
+pub mod classes;
 pub mod frontend;
 pub mod persistence;
 pub mod pipeline;

--- a/src/omr-rust/crates/omr-labeler/web/app.js
+++ b/src/omr-rust/crates/omr-labeler/web/app.js
@@ -16,6 +16,7 @@
   const state = {
     currentItem: null,
     contextSystems: [],
+    classes: [],
   };
 
   // ---------- Utility ---------------------------------------------------
@@ -140,20 +141,135 @@
     const wrap = $("class-buttons");
     if (!wrap) return;
     wrap.innerHTML = "";
-    if (item.level !== "class" || !item.top_k || item.top_k.length === 0) {
+    if (item.level !== "class") {
       wrap.classList.add("hidden");
       return;
     }
     wrap.classList.remove("hidden");
-    item.top_k.slice(0, 5).forEach((entry, idx) => {
+
+    // Top-5 (Hotkey 1-5) — eingebaute Vorschlaege oder erste 5 aus Klassen-Liste.
+    const topK = (item.top_k && item.top_k.length > 0)
+      ? item.top_k.slice(0, 5).map((e) => ({ id: e[0], score: e[1], display: e[0] }))
+      : (state.classes.slice(0, 5).map((c) => ({ id: c.id, score: 0, display: c.display_name })));
+    const topWrap = document.createElement("div");
+    topWrap.className = "class-top5";
+    topWrap.innerHTML = "<h3>Top 5 (Hotkey 1–5)</h3>";
+    topK.forEach((entry, idx) => {
       const btn = document.createElement("button");
-      btn.className = "btn";
-      btn.textContent = (idx + 1) + ". " + entry[0];
+      btn.className = "btn btn-top";
+      const pct = entry.score > 0 ? " (" + (entry.score * 100).toFixed(0) + "%)" : "";
+      btn.textContent = (idx + 1) + ". " + entry.display + pct;
       btn.dataset.action = "class";
-      btn.dataset.value = entry[0];
-      wrap.appendChild(btn);
+      btn.dataset.value = entry.id;
+      topWrap.appendChild(btn);
     });
+    wrap.appendChild(topWrap);
+
+    // Suche-Filter mit Live-Filter
+    const searchWrap = document.createElement("div");
+    searchWrap.className = "class-search";
+    searchWrap.innerHTML = '<h3>Alle Klassen (<kbd>/</kbd>)</h3>' +
+      '<input id="class-filter-input" type="text" placeholder="Tippen filtert..." autocomplete="off" />' +
+      '<ul id="class-filter-list"></ul>';
+    wrap.appendChild(searchWrap);
+    const input = $("class-filter-input");
+    const list = $("class-filter-list");
+    if (input && list) {
+      const renderList = (q) => {
+        list.innerHTML = "";
+        const ql = (q || "").toLowerCase();
+        const matches = state.classes.filter((c) => {
+          if (!ql) return true;
+          return c.id.toLowerCase().includes(ql) || c.display_name.toLowerCase().includes(ql);
+        }).slice(0, 30);
+        matches.forEach((c) => {
+          const li = document.createElement("li");
+          li.textContent = c.display_name + " — " + c.id;
+          li.dataset.action = "class";
+          li.dataset.value = c.id;
+          list.appendChild(li);
+        });
+      };
+      renderList("");
+      input.addEventListener("input", () => renderList(input.value));
+      input.addEventListener("keydown", (e) => {
+        if (e.key === "Enter") {
+          const first = list.querySelector("li");
+          if (first) {
+            sendAnswer("class", first.dataset.value || "");
+          }
+        }
+        if (e.key === "Escape") {
+          input.value = "";
+          input.blur();
+          renderList("");
+        }
+      });
+    }
+
+    // Drill-Down-Hinweis fuer Group-Klassen
+    if (item.suggested_class && item.suggested_class.startsWith("group/")) {
+      const drillBtn = document.createElement("button");
+      drillBtn.className = "btn btn-drill";
+      drillBtn.textContent = "[d] Drill-Down zu Atomen von " + item.suggested_class;
+      drillBtn.dataset.action = "drill";
+      drillBtn.dataset.value = item.suggested_class;
+      wrap.appendChild(drillBtn);
+    }
+
+    // Spezial-Aktionen
+    const special = document.createElement("div");
+    special.className = "class-special";
+    special.innerHTML =
+      '<button class="btn" data-action="answer-no">[n] None of these</button>' +
+      '<button class="btn" data-action="edit">[e] Eigene Klasse</button>' +
+      '<button class="btn" data-action="skip">[Space] Skip</button>';
+    wrap.appendChild(special);
   }
+
+  async function fetchClasses() {
+    try {
+      state.classes = await jsonGet("/api/classes?include_atoms=1&include_phrases=0");
+    } catch (e) {
+      console.error("fetchClasses failed", e);
+      state.classes = [];
+    }
+  }
+
+  async function showDrillDown(groupId) {
+    try {
+      const atoms = await jsonGet("/api/classes/drilldown/" + encodeURIComponent(groupId));
+      if (atoms.length === 0) {
+        alert("Keine Atome bekannt fuer " + groupId);
+        return;
+      }
+      // Zeige Atom-Liste in einem temporaeren Overlay
+      const wrap = $("class-buttons");
+      if (!wrap) return;
+      wrap.innerHTML = "";
+      const h = document.createElement("h3");
+      h.textContent = "Drill-Down: " + groupId;
+      wrap.appendChild(h);
+      atoms.forEach((c, idx) => {
+        const btn = document.createElement("button");
+        btn.className = "btn";
+        btn.textContent = (idx + 1) + ". " + c.display_name;
+        btn.dataset.action = "class";
+        btn.dataset.value = c.id;
+        wrap.appendChild(btn);
+      });
+      const back = document.createElement("button");
+      back.className = "btn";
+      back.textContent = "[Esc] zurueck";
+      back.addEventListener("click", () => {
+        if (state.currentItem) renderClassButtons(state.currentItem);
+      });
+      wrap.appendChild(back);
+    } catch (e) {
+      console.error("drilldown failed", e);
+    }
+  }
+
 
   // ---------- Sending ---------------------------------------------------
 
@@ -206,11 +322,25 @@
 
   function handleKeypress(e) {
     if (e.target && (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA")) {
+      // Im Sucheingabe-Feld: nur Esc abfangen
+      if (e.key === "Escape") {
+        e.target.blur();
+      }
       return;
     }
     const k = e.key.toLowerCase();
     if (k === "y") return sendAnswer("yes");
-    if (k === "n") return sendAnswer("no");
+    if (k === "n") {
+      // Im class-Level: "n" = none of these (geht zu manueller Eingabe)
+      if (state.currentItem && state.currentItem.level === "class") {
+        const cls = prompt("Klasse manuell eingeben (oder leer fuer Skip):");
+        if (cls && cls.trim().length > 0) {
+          sendAnswer("class", cls.trim());
+        }
+        return;
+      }
+      return sendAnswer("no");
+    }
     if (k === " " || k === "spacebar") {
       e.preventDefault();
       return sendSkip();
@@ -223,11 +353,33 @@
       }
       return;
     }
+    if (k === "/") {
+      e.preventDefault();
+      const input = $("class-filter-input");
+      if (input) {
+        input.focus();
+        input.select();
+      }
+      return;
+    }
+    if (k === "d") {
+      // Drill-Down zur aktuellen group-Klasse
+      const item = state.currentItem;
+      if (item && item.suggested_class && item.suggested_class.startsWith("group/")) {
+        return showDrillDown(item.suggested_class);
+      }
+      return;
+    }
     if (/^[1-5]$/.test(k)) {
       const idx = parseInt(k, 10) - 1;
       const item = state.currentItem;
-      if (item && item.top_k && item.top_k[idx]) {
+      if (!item) return;
+      // Top-K aus Suggestions, fallback auf state.classes
+      if (item.top_k && item.top_k[idx]) {
         return sendAnswer("class", item.top_k[idx][0]);
+      }
+      if (state.classes && state.classes[idx]) {
+        return sendAnswer("class", state.classes[idx].id);
       }
     }
   }
@@ -242,8 +394,19 @@
       if (!action) return;
       if (action === "yes") return sendAnswer("yes");
       if (action === "no") return sendAnswer("no");
+      if (action === "answer-no") {
+        const cls = prompt("Klasse manuell eingeben (oder Abbruch fuer Skip):");
+        if (cls && cls.trim().length > 0) sendAnswer("class", cls.trim());
+        return;
+      }
       if (action === "skip") return sendSkip();
       if (action === "undo") return sendUndo();
+      if (action === "edit") {
+        const cls = prompt("Klasse eingeben:");
+        if (cls && cls.trim().length > 0) sendAnswer("class", cls.trim());
+        return;
+      }
+      if (action === "drill") return showDrillDown(t.dataset.value || "");
       if (action === "class") return sendAnswer("class", t.dataset.value || "");
     });
   }
@@ -251,7 +414,7 @@
   function init() {
     bindButtons();
     window.addEventListener("keydown", handleKeypress);
-    refreshAll();
+    fetchClasses().then(() => refreshAll());
     setInterval(updateStatus, 5000);
     setInterval(() => {
       if (!state.currentItem) fetchQueue();

--- a/src/omr-rust/crates/omr-labeler/web/style.css
+++ b/src/omr-rust/crates/omr-labeler/web/style.css
@@ -196,3 +196,77 @@ kbd {
   color: var(--muted);
   word-break: break-all;
 }
+
+/* Hierarchical class picker (added by classes-update) */
+.class-top5 h3, .class-search h3 { 
+  margin: 0.25rem 0 0.5rem;
+  font-size: 0.85rem; 
+  color: var(--muted); 
+  text-transform: uppercase; 
+  letter-spacing: 0.05em; 
+}
+.btn-top { 
+  display: block; 
+  width: 100%; 
+  text-align: left; 
+  padding: 0.5rem 0.75rem; 
+  margin: 0.2rem 0; 
+  background: var(--panel-light); 
+  border: 1px solid var(--border); 
+  color: var(--fg); 
+  border-radius: 4px; 
+  font-family: ui-monospace, monospace; 
+  cursor: pointer; 
+}
+.btn-top:hover { background: var(--accent); color: white; }
+.btn-drill { 
+  display: block; 
+  width: 100%; 
+  margin: 0.5rem 0; 
+  padding: 0.4rem; 
+  background: transparent; 
+  border: 1px dashed var(--border); 
+  color: var(--muted); 
+  cursor: pointer; 
+  font-size: 0.85rem; 
+}
+.class-search input { 
+  width: 100%; 
+  padding: 0.4rem 0.6rem; 
+  background: var(--bg); 
+  color: var(--fg); 
+  border: 1px solid var(--border); 
+  border-radius: 4px; 
+  margin-bottom: 0.4rem; 
+  font-size: 0.9rem; 
+}
+.class-search ul { 
+  list-style: none; 
+  padding: 0; 
+  margin: 0; 
+  max-height: 200px; 
+  overflow-y: auto; 
+  border: 1px solid var(--border); 
+  border-radius: 4px; 
+}
+.class-search li { 
+  padding: 0.3rem 0.6rem; 
+  cursor: pointer; 
+  font-size: 0.85rem; 
+  border-bottom: 1px solid var(--border); 
+}
+.class-search li:hover { background: var(--accent); color: white; }
+.class-search li:last-child { border-bottom: none; }
+.class-special { 
+  margin-top: 0.6rem; 
+  padding-top: 0.6rem; 
+  border-top: 1px solid var(--border); 
+  display: flex; 
+  gap: 0.4rem; 
+  flex-wrap: wrap; 
+}
+.class-special .btn { 
+  flex: 1; 
+  font-size: 0.8rem; 
+  padding: 0.3rem 0.5rem; 
+}


### PR DESCRIPTION
Wie im Chat diskutiert:

## Klassen-Hierarchie

- **Atom** — atomare Symbole: notehead_filled, stem_up, beam_1, accidental_sharp, ...
- **Group** — logische Einheiten: beamed_group_4_sixteenths, chord_3_notes, single_note_quarter, tied_pair, ...
- **Phrase** — Pattern-Templates: cadence_v_i, marcia_pattern (selten gelabelt)

## UX

| Hotkey | Aktion |
|---|---|
| 1-5 | Top-5 direkt waehlen |
| / | Live-Filter-Suche oeffnen (tippen filtert alle Klassen) |
| d | Drill-Down zu Atomen einer Group |
| n | None of these (manuell) |
| Space | Skip |
| u | Undo |

User klassifiziert primaer auf Group-Ebene (1 Klick reicht), kann mit \d\ zu Atomen runter — beide Ebenen werden persistiert.

## API

- GET /api/classes?include_atoms= — Klassen-Liste
- GET /api/classes/drilldown/:group_id — Atom-Sub-Klassen einer Group

## Tests

22 Tests gruen (17 bestehend + 5 neue fuer classes-Modul).

�� Co-authored-by: Copilot