### PR TITLE
feat(omr-embed): Per-line Rectification + Logical-Group-Detection

### DIFF
--- a/src/omr-rust/crates/omr-core/src/lib.rs
+++ b/src/omr-rust/crates/omr-core/src/lib.rs
@@ -450,6 +450,7 @@ pub struct PipelineOptions {
     /// Beams, Bars) und gibt sie im `PipelineResult.detections` zurück.
     /// Nötig für das Annotation-/Training-Tool. Default: true.
     pub collect_detections: bool,
+    pub rectify_systems: bool,
 }
 
 impl Default for PipelineOptions {
@@ -459,6 +460,7 @@ impl Default for PipelineOptions {
             trace_only: false,
             unet_model_path: None,
             collect_detections: true,
+            rectify_systems: false,
         }
     }
 }

--- a/src/omr-rust/crates/omr-labeler/src/embedding_corpus.rs
+++ b/src/omr-rust/crates/omr-labeler/src/embedding_corpus.rs
@@ -1,0 +1,300 @@
+//! Active-Learning — Embedding-Corpus-Integration.
+//!
+//! Kapselt den `omr-embed`-Corpus + Index als einen synchronen Zustandsblock,
+//! der hinter einem `tokio::sync::Mutex` geteilt wird.
+//!
+//! Workflow:
+//! 1. Beim Start: `EmbeddingState::from_corpus_dir(dir)` oder leer via `new()`.
+//! 2. Wenn Annotator eine Klassen-Entscheidung trifft: `add_user_label(...)`.
+//! 3. Für Re-Priorisierung der Queue: `knn_classify(...)` + `entropy()`.
+//! 4. Stats über `corpus_stats()` für den UI-Endpoint.
+
+use omr_embed::{
+    corpus::{Corpus, CorpusError, LabeledPatch},
+    encoder::{Encoder, HogEncoder, FEATURE_LEN},
+    index::EmbeddingIndex,
+    types::{ClassLabel, Match, PatchSource},
+};
+use std::collections::HashMap;
+use std::path::Path;
+
+const ENCODER_VERSION: &str = "hog-v1";
+const REBUILD_EVERY: usize = 10;
+
+// ── EmbeddingState ─────────────────────────────────────────────────────────────
+
+/// Zustandsblock für Embedding-Corpus + k-NN-Index.
+///
+/// Nicht `Clone` — wird hinter einem `Arc<tokio::sync::Mutex<EmbeddingState>>`
+/// geteilt.
+pub struct EmbeddingState {
+    corpus: Corpus,
+    index: EmbeddingIndex,
+    encoder: HogEncoder,
+    labels_since_rebuild: usize,
+}
+
+impl std::fmt::Debug for EmbeddingState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EmbeddingState")
+            .field("index_size", &self.index.corpus_size())
+            .field("labels_since_rebuild", &self.labels_since_rebuild)
+            .finish()
+    }
+}
+
+impl EmbeddingState {
+    /// Erstellt einen leeren Corpus im Arbeitsspeicher (nützlich für Tests).
+    pub fn new() -> Result<Self, CorpusError> {
+        let corpus = Corpus::open_in_memory()?;
+        let index = EmbeddingIndex::new(ENCODER_VERSION, FEATURE_LEN);
+        Ok(Self {
+            corpus,
+            index,
+            encoder: HogEncoder::new(),
+            labels_since_rebuild: 0,
+        })
+    }
+
+    /// Öffnet (oder erstellt) einen Corpus unter `dir/corpus.db`.
+    /// Baut den Index direkt aus dem gespeicherten Corpus auf.
+    pub fn from_corpus_dir(dir: &Path) -> Result<Self, CorpusError> {
+        std::fs::create_dir_all(dir).ok();
+        let db_path = dir.join("corpus.db");
+        let corpus = Corpus::open(&db_path)?;
+        let index = corpus.into_index(ENCODER_VERSION)?;
+        Ok(Self {
+            corpus,
+            index,
+            encoder: HogEncoder::new(),
+            labels_since_rebuild: 0,
+        })
+    }
+
+    /// Fügt ein vom Annotator bestätigtes Label + PNG-Patch hinzu.
+    ///
+    /// - Der Patch wird HoG-enkodiert und ins Corpus eingefügt.
+    /// - Das Embedding wird auch direkt in den laufenden Index eingespielt
+    ///   (kein vollständiger Rebuild nötig).
+    /// - Alle `REBUILD_EVERY` Labels wird der Index vollständig neu aufgebaut,
+    ///   um akumulierte Drifts zu beseitigen.
+    pub fn add_user_label(
+        &mut self,
+        label: ClassLabel,
+        patch_png: Vec<u8>,
+        provenance: String,
+    ) -> Result<(), anyhow::Error> {
+        let gray = decode_png_to_gray(&patch_png)
+            .ok_or_else(|| anyhow::anyhow!("PNG-Decode fehlgeschlagen"))?;
+        let emb = self
+            .encoder
+            .embed(&gray)
+            .map_err(|e| anyhow::anyhow!("HoG-Encode fehlgeschlagen: {e}"))?;
+
+        let patch = LabeledPatch {
+            id: 0,
+            label: label.clone(),
+            source: PatchSource::User,
+            patch_png,
+            embedding: Some(emb.clone()),
+            provenance,
+            created_at: chrono_now(),
+            user_confirmed: true,
+        };
+
+        let id = self.corpus.add_patch(patch)?;
+        let _ = self
+            .index
+            .add(id, &emb, label, PatchSource::User);
+
+        self.labels_since_rebuild += 1;
+        if self.labels_since_rebuild >= REBUILD_EVERY {
+            self.rebuild_index()?;
+        }
+        Ok(())
+    }
+
+    /// Klassifiziert einen PNG-Patch mit k-NN und gibt den Top-1-Match zurück.
+    /// Gibt `None` zurück wenn der Index leer ist.
+    pub fn knn_classify(&mut self, patch_png: &[u8]) -> Option<Match> {
+        let gray = decode_png_to_gray(patch_png)?;
+        let emb = self.encoder.embed(&gray).ok()?;
+        let results = self.index.knn(&emb, 1).ok()?;
+        results.into_iter().next()
+    }
+
+    /// Entropie der Label-Verteilung im Corpus (Shannon, in Bits).
+    ///
+    /// Niedrige Entropie = Corpus ist stark auf wenige Klassen konzentriert.
+    /// Hohe Entropie = Klassen sind gleichmäßig verteilt — guter Balanceindikator.
+    pub fn entropy(&self) -> f64 {
+        let counts = self.corpus.count_by_label().unwrap_or_default();
+        let total: usize = counts.values().sum();
+        if total == 0 {
+            return 0.0;
+        }
+        let n = total as f64;
+        counts
+            .values()
+            .map(|&c| {
+                let p = c as f64 / n;
+                if p > 0.0 {
+                    -p * p.log2()
+                } else {
+                    0.0
+                }
+            })
+            .sum()
+    }
+
+    /// Gibt Corpus-Statistiken als Key-Value-Map zurück.
+    pub fn corpus_stats(&self) -> HashMap<String, serde_json::Value> {
+        use serde_json::json;
+        let by_label = self
+            .corpus
+            .count_by_label()
+            .unwrap_or_default();
+        let by_source = self
+            .corpus
+            .count_by_source()
+            .unwrap_or_default();
+        let total: usize = by_label.values().sum();
+
+        let synthetic = by_source
+            .get(&PatchSource::Synthetic)
+            .copied()
+            .unwrap_or(0);
+        let user = by_source
+            .get(&PatchSource::User)
+            .copied()
+            .unwrap_or(0);
+
+        let mut map = HashMap::new();
+        map.insert("total".to_string(), json!(total));
+        map.insert("synthetic".to_string(), json!(synthetic));
+        map.insert("user".to_string(), json!(user));
+        map.insert("classes".to_string(), json!(by_label.len()));
+        map.insert(
+            "index_size".to_string(),
+            json!(self.index.corpus_size()),
+        );
+        map.insert("entropy_bits".to_string(), json!(self.entropy()));
+        map.insert("labels_since_rebuild".to_string(), json!(self.labels_since_rebuild));
+        map
+    }
+
+    // ── Privat ──────────────────────────────────────────────────────────────
+
+    fn rebuild_index(&mut self) -> Result<(), CorpusError> {
+        self.index = self.corpus.into_index(ENCODER_VERSION)?;
+        self.labels_since_rebuild = 0;
+        Ok(())
+    }
+}
+
+// ── Hilfsfunktionen ───────────────────────────────────────────────────────────
+
+/// Dekodiert ein PNG-Byte-Slice zu einem 64×64-Graustufenbild.
+/// Gibt `None` bei fehlerhaftem PNG oder falschem Format zurück.
+fn decode_png_to_gray(png_bytes: &[u8]) -> Option<image::GrayImage> {
+    let img = image::load_from_memory(png_bytes).ok()?;
+    let gray = img.into_luma8();
+    // Auf 64×64 skalieren, falls nötig.
+    if gray.width() == 64 && gray.height() == 64 {
+        Some(gray)
+    } else {
+        use image::imageops::FilterType;
+        let resized = image::imageops::resize(&gray, 64, 64, FilterType::Lanczos3);
+        Some(resized)
+    }
+}
+
+fn chrono_now() -> String {
+    // Kein chrono-Dependency — ISO-8601-ähnlicher Timestamp via std.
+    // Für Produktionsreife könnte man chrono einbinden.
+    std::time::SystemTime::UNIX_EPOCH
+        .elapsed()
+        .map(|d| format!("{}", d.as_secs()))
+        .unwrap_or_else(|_| "0".to_string())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::{GrayImage, Luma};
+
+    fn make_patch_png(pixel: u8) -> Vec<u8> {
+        let img = GrayImage::from_pixel(64, 64, Luma([pixel]));
+        let mut buf = Vec::new();
+        img.write_to(
+            &mut std::io::Cursor::new(&mut buf),
+            image::ImageFormat::Png,
+        )
+        .unwrap();
+        buf
+    }
+
+    #[tokio::test]
+    async fn new_state_is_empty() {
+        let state = EmbeddingState::new().unwrap();
+        assert_eq!(state.index.corpus_size(), 0);
+        let stats = state.corpus_stats();
+        assert_eq!(stats["total"], 0);
+    }
+
+    #[tokio::test]
+    async fn add_label_grows_index() {
+        let mut state = EmbeddingState::new().unwrap();
+        let png = make_patch_png(128);
+        state
+            .add_user_label("notehead-filled".to_string(), png, "test".to_string())
+            .unwrap();
+        let stats = state.corpus_stats();
+        assert_eq!(stats["total"], 1);
+        assert_eq!(stats["user"], 1);
+        assert!(state.index.corpus_size() >= 1);
+    }
+
+    #[tokio::test]
+    async fn knn_classify_returns_added_label() {
+        let mut state = EmbeddingState::new().unwrap();
+        let png = make_patch_png(200);
+        state
+            .add_user_label("notehead-filled".to_string(), png.clone(), "test".to_string())
+            .unwrap();
+        let top1 = state.knn_classify(&png).unwrap();
+        assert_eq!(top1.label, "notehead-filled");
+        assert!(top1.distance < 1e-3, "self-distance should be ≈0");
+    }
+
+    #[tokio::test]
+    async fn entropy_zero_for_uniform_class() {
+        let mut state = EmbeddingState::new().unwrap();
+        for i in 0..5u8 {
+            let png = make_patch_png(i * 20);
+            state
+                .add_user_label("notehead-filled".to_string(), png, format!("t{i}"))
+                .unwrap();
+        }
+        // Alle Patches sind in derselben Klasse → Entropie ≈ 0
+        let h = state.entropy();
+        assert!(h < 1e-6, "single-class entropy should be 0, got {h}");
+    }
+
+    #[tokio::test]
+    async fn entropy_higher_for_balanced_classes() {
+        let mut state = EmbeddingState::new().unwrap();
+        for i in 0..4u8 {
+            let png = make_patch_png(i * 60);
+            let label = format!("class-{i}");
+            state
+                .add_user_label(label, png, format!("t{i}"))
+                .unwrap();
+        }
+        let h = state.entropy();
+        // 4 gleichmäßige Klassen → H ≈ 2 Bits
+        assert!(h > 1.9, "balanced 4-class entropy should be ~2 bits, got {h}");
+    }
+}

--- a/src/omr-rust/crates/omr-labeler/src/pipeline.rs
+++ b/src/omr-rust/crates/omr-labeler/src/pipeline.rs
@@ -8,7 +8,7 @@
 
 use anyhow::Result;
 use image::{DynamicImage, GrayImage, ImageBuffer, Luma};
-use omr_core::{Binary, Rect, StaffSystem};
+use omr_core::{Binary, Rect, StaffLine, StaffSystem};
 use omr_embed::{Encoder, HogEncoder};
 use std::path::{Path, PathBuf};
 
@@ -117,6 +117,18 @@ impl PipelineState {
                 );
                 let rects = detect_elements(&cropped_removed, system, top);
 
+                // Detect logical groups for suggested class labels.
+                let noteheads = omr_symbols::detect_noteheads(&staff_removed, std::slice::from_ref(system));
+                let stems = omr_symbols::stems::detect_stems(&staff_removed, &noteheads, system.line_spacing);
+                let beams = omr_symbols::detect_beams(&staff_removed, system.line_spacing);
+                let adjusted_system = adjust_system_to_crop(system, top);
+                let logical_groups = omr_symbols::detect_logical_groups(
+                    &noteheads,
+                    &stems,
+                    &beams,
+                    adjusted_system.line_spacing,
+                );
+
                 for (elt_idx, r) in rects.iter().enumerate() {
                     let patch = extract_patch(&cropped, r, 64);
                     let emb = encoder
@@ -124,12 +136,16 @@ impl PipelineState {
                         .map(|e| e.vec)
                         .unwrap_or_default();
                     let elt_id = format!("{}#e{}", id, elt_idx);
+                    let suggested_class = logical_groups.iter().find(|g| {
+                        let b = &g.bbox;
+                        r.x < b.x + b.w && r.x + r.w > b.x && r.y < b.y + b.h && r.y + r.h > b.y
+                    }).map(|g| g.class_id.clone());
                     self.elements.push(DetectedElement {
                         id: elt_id,
                         system_id: id.clone(),
                         bbox: *r,
                         patch,
-                        suggested_class: None,
+                        suggested_class,
                         hog_embedding: emb,
                     });
                 }
@@ -351,6 +367,25 @@ pub fn encode_png(img: &GrayImage) -> Result<Vec<u8>> {
     Ok(buf)
 }
 
+/// Passt ein StaffSystem an einen Y-Crop an: verschiebt alle y_per_x-Werte
+/// um `top_offset` nach oben (crop-relativ).
+fn adjust_system_to_crop(system: &StaffSystem, top_offset: u32) -> StaffSystem {
+    StaffSystem {
+        lines: system
+            .lines
+            .iter()
+            .map(|l| StaffLine {
+                y_per_x: l
+                    .y_per_x
+                    .iter()
+                    .map(|&y| y.saturating_sub(top_offset))
+                    .collect(),
+            })
+            .collect(),
+        line_spacing: system.line_spacing,
+        line_thickness: system.line_thickness,
+    }
+}
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/omr-rust/crates/omr-labeler/tests/end_to_end.rs
+++ b/src/omr-rust/crates/omr-labeler/tests/end_to_end.rs
@@ -1,0 +1,89 @@
+//! End-to-End-Test für den Active-Learning-Loop.
+//!
+//! Testet den vollständigen Zyklus:
+//!   Synthethisches Label → HNSW-Index → k-NN-Abfrage → niedrige Entropie.
+
+use image::{GrayImage, Luma};
+use omr_labeler::embedding_corpus::EmbeddingState;
+
+fn make_patch_png(pixel: u8) -> Vec<u8> {
+    let img = GrayImage::from_pixel(64, 64, Luma([pixel]));
+    let mut buf = Vec::new();
+    img.write_to(
+        &mut std::io::Cursor::new(&mut buf),
+        image::ImageFormat::Png,
+    )
+    .unwrap();
+    buf
+}
+
+#[tokio::test]
+async fn full_active_learning_cycle() {
+    // 1. Leeren In-Memory-Zustand initialisieren.
+    let mut state = EmbeddingState::new().expect("EmbeddingState::new()");
+
+    // 2. Fünf Patches als "notehead-filled" labeln.
+    for i in 0..5u8 {
+        let png = make_patch_png(100 + i * 10);
+        state
+            .add_user_label(
+                "notehead-filled".to_string(),
+                png,
+                format!("test-patch-{i}"),
+            )
+            .expect("add_user_label");
+    }
+
+    // 3. Index hat mindestens 5 Einträge.
+    let stats = state.corpus_stats();
+    assert_eq!(stats["total"], 5, "Corpus sollte 5 Einträge haben");
+    assert_eq!(stats["user"], 5, "Alle Einträge sollten User-Herkunft haben");
+
+    // 4. k-NN-Abfrage: ähnlicher Patch sollte "notehead-filled" zurückgeben.
+    let query_png = make_patch_png(105); // zwischen den trainierten Patches
+    let top1 = state
+        .knn_classify(&query_png)
+        .expect("knn_classify sollte Some(Match) liefern");
+    assert_eq!(
+        top1.label, "notehead-filled",
+        "Top-1 sollte 'notehead-filled' sein, nicht '{}'",
+        top1.label
+    );
+
+    // 5. Entropie ist niedrig (alle Einträge in einer Klasse → H = 0).
+    let entropy = state.entropy();
+    assert!(
+        entropy < 1e-6,
+        "Single-Class-Entropie sollte ≈0 sein, ist aber {entropy}"
+    );
+}
+
+#[tokio::test]
+async fn multi_class_increases_entropy() {
+    let mut state = EmbeddingState::new().expect("EmbeddingState::new()");
+
+    // Vier verschiedene Klassen mit je einem Patch.
+    let classes = ["notehead-filled", "notehead-open", "rest-quarter", "rest-half"];
+    for (i, class) in classes.iter().enumerate() {
+        let png = make_patch_png(50 + i as u8 * 50);
+        state
+            .add_user_label(class.to_string(), png, format!("patch-{i}"))
+            .expect("add_user_label");
+    }
+
+    let entropy = state.entropy();
+    // 4 gleichmäßige Klassen → H ≈ 2 Bits
+    assert!(
+        entropy > 1.9,
+        "Balanced 4-class entropy sollte ~2 bits sein, ist {entropy}"
+    );
+}
+
+#[tokio::test]
+async fn empty_state_knn_returns_none() {
+    let mut state = EmbeddingState::new().expect("EmbeddingState::new()");
+    let png = make_patch_png(128);
+    let result = state.knn_classify(&png);
+    // Leerer Index → kein Match
+    assert!(result.is_none(), "Leerer Index sollte None zurückgeben");
+}

--- a/src/omr-rust/crates/omr-pipeline/src/lib.rs
+++ b/src/omr-rust/crates/omr-pipeline/src/lib.rs
@@ -84,6 +84,7 @@ pub struct PipelineResult {
     /// Optional: Detection-Bboxes für UI/Annotation. Nur gefüllt wenn
     /// `PipelineOptions.collect_detections == true`.
     pub detections: Option<detections::DetectionsResult>,
+    pub rectified_systems: Option<Vec<omr_staff::rectify::RectifiedSystem>>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -345,6 +346,7 @@ fn merge_two_results(left: PipelineResult, right: PipelineResult) -> PipelineRes
         timings,
         stats,
         detections,
+        rectified_systems: None,
     }
 }
 
@@ -388,10 +390,17 @@ fn process_gray_single(gray: GrayImage, opts: &PipelineOptions) -> Result<Pipeli
             timings: Timings { preprocessing_ms, staff_detection_ms, total_ms: total_t.elapsed().as_millis(), ..Default::default() },
             stats: Stats { deskew_angle_deg: deskew_angle, ..Default::default() },
             detections: None,
+            rectified_systems: None,
         });
     }
 
     let line_spacing = systems[0].line_spacing;
+    // 2b) Optional rectification.
+    let rectified = if opts.rectify_systems {
+        Some(omr_staff::rectify_all_systems(&gray, &systems))
+    } else {
+        None
+    };
     let line_thickness = systems[0].line_thickness;
 
     // 2b) Document-Type-Detection: gedruckt vs handschrift.
@@ -988,6 +997,7 @@ fn process_gray_single(gray: GrayImage, opts: &PipelineOptions) -> Result<Pipeli
             doc_nh_size_cv: nh_size_cv(&noteheads),
         },
         detections: detections_dump,
+        rectified_systems: rectified,
     })
 }
 
@@ -1262,6 +1272,7 @@ pub fn process_pdf(path: &Path, opts: &PipelineOptions) -> Result<PipelineResult
         timings: merged_timings,
         stats: merged_stats,
         detections: detections_dump,
+        rectified_systems: None,
     })
 }
 

--- a/src/omr-rust/crates/omr-staff/src/lib.rs
+++ b/src/omr-rust/crates/omr-staff/src/lib.rs
@@ -18,8 +18,10 @@ use omr_core::{Binary, StaffLine, StaffSystem};
 use rayon::prelude::*;
 use tracing::{debug, info};
 
+pub mod rectify;
 pub mod removal;
 pub mod unet;
+pub use rectify::{rectify_all_systems, rectify_system, RectifiedSystem, NORMALIZED_SPACING};
 pub use removal::remove_staff;
 pub use unet::{try_remove_staff_unet, UnetStaffRemover};
 

--- a/src/omr-rust/crates/omr-staff/src/rectify.rs
+++ b/src/omr-rust/crates/omr-staff/src/rectify.rs
@@ -1,0 +1,206 @@
+// Per-line Rectification
+use image::{GrayImage, ImageBuffer, Luma};
+use omr_core::StaffSystem;
+
+pub const NORMALIZED_SPACING: f32 = 32.0;
+const PADDING: u32 = 16;
+
+#[derive(Debug, Clone)]
+pub struct RectifiedSystem {
+    pub image: GrayImage,
+    pub angle_rad: f32,
+    pub scale: f32,
+}
+
+pub fn rectify_all_systems(img: &GrayImage, systems: &[StaffSystem]) -> Vec<RectifiedSystem> {
+    systems.iter().map(|sys| rectify_system(img, sys)).collect()
+}
+
+pub fn rectify_system(img: &GrayImage, system: &StaffSystem) -> RectifiedSystem {
+    let img_w = img.width();
+    let img_h = img.height();
+    if system.lines.is_empty() || img_w == 0 || img_h == 0 {
+        return RectifiedSystem { image: img.clone(), angle_rad: 0.0, scale: 1.0 };
+    }
+    let spacing = system.line_spacing.max(1.0);
+    let scale = NORMALIZED_SPACING / spacing;
+    let angle = estimate_skew(system);
+    let top_y = system.lines.first().map(|l| l.mean_y()).unwrap_or(0.0);
+    let bot_y = system.lines.last().map(|l| l.mean_y()).unwrap_or(img_h as f32);
+    let sys_h = (bot_y - top_y).max(1.0);
+    let out_w = (img_w as f32 * scale).round() as u32;
+    let out_h = (sys_h * scale).round() as u32 + 2 * PADDING;
+    let cx = img_w as f32 * 0.5;
+    let cy = (top_y + bot_y) * 0.5;
+    let out_cx = out_w as f32 * 0.5;
+    let out_cy = out_h as f32 * 0.5;
+    let cos_a = angle.cos();
+    let sin_a = angle.sin();
+    let fwd = [
+        scale * cos_a, scale * sin_a,
+        -scale * cos_a * cx - scale * sin_a * cy + out_cx,
+        -scale * sin_a, scale * cos_a,
+        scale * sin_a * cx - scale * cos_a * cy + out_cy,
+        0.0, 0.0, 1.0_f32,
+    ];
+    let inv = invert_affine_3x3(&fwd);
+    let image = warp_affine(img, &inv, out_w, out_h);
+    RectifiedSystem { image, angle_rad: angle, scale }
+}
+
+pub(crate) fn mat3_mul(a: &[f32; 9], b: &[f32; 9]) -> [f32; 9] {
+    let mut c = [0.0f32; 9];
+    for r in 0..3 {
+        for col in 0..3 {
+            for k in 0..3 { c[r * 3 + col] += a[r * 3 + k] * b[k * 3 + col]; }
+        }
+    }
+    c
+}
+
+pub(crate) fn invert_affine_3x3(m: &[f32; 9]) -> [f32; 9] {
+    let (a, b, tx) = (m[0], m[1], m[2]);
+    let (c, d, ty) = (m[3], m[4], m[5]);
+    let det = a * d - b * c;
+    if det.abs() < 1e-12 { return [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]; }
+    let inv_det = 1.0 / det;
+    let ia = d * inv_det; let ib = -b * inv_det;
+    let ic = -c * inv_det; let id_ = a * inv_det;
+    let itx = -(ia * tx + ib * ty); let ity = -(ic * tx + id_ * ty);
+    [ia, ib, itx, ic, id_, ity, 0.0, 0.0, 1.0]
+}
+
+fn estimate_skew(system: &StaffSystem) -> f32 {
+    let mid_idx = system.lines.len() / 2;
+    let line = &system.lines[mid_idx];
+    let yy = &line.y_per_x;
+    if yy.len() < 2 { return 0.0; }
+    let step = (yy.len() / 200).max(1);
+    let (mut sum_x, mut sum_y, mut sum_xx, mut sum_xy, mut n) =
+        (0.0f64, 0.0f64, 0.0f64, 0.0f64, 0.0f64);
+    for (xi, &yi) in yy.iter().enumerate().step_by(step) {
+        let (xf, yf) = (xi as f64, yi as f64);
+        sum_x += xf; sum_y += yf; sum_xx += xf * xf; sum_xy += xf * yf; n += 1.0;
+    }
+    let denom = n * sum_xx - sum_x * sum_x;
+    if denom.abs() < 1e-12 { return 0.0; }
+    (((n * sum_xy - sum_x * sum_y) / denom) as f32).atan()
+}
+
+fn warp_affine(src: &GrayImage, inv: &[f32; 9], out_w: u32, out_h: u32) -> GrayImage {
+    let sw = src.width(); let sh = src.height();
+    let mut out: GrayImage = ImageBuffer::from_pixel(out_w.max(1), out_h.max(1), Luma([255u8]));
+    let (a, b, tx) = (inv[0], inv[1], inv[2]);
+    let (c, d, ty) = (inv[3], inv[4], inv[5]);
+    for oy in 0..out_h {
+        for ox in 0..out_w {
+            let sx = a * ox as f32 + b * oy as f32 + tx;
+            let sy = c * ox as f32 + d * oy as f32 + ty;
+            if sx < 0.0 || sy < 0.0 || sx >= (sw - 1) as f32 || sy >= (sh - 1) as f32 { continue; }
+            let x0 = sx.floor() as u32; let y0 = sy.floor() as u32;
+            let x1 = (x0 + 1).min(sw - 1); let y1 = (y0 + 1).min(sh - 1);
+            let (fx, fy) = (sx - x0 as f32, sy - y0 as f32);
+            let p00 = src.get_pixel(x0, y0)[0] as f32; let p10 = src.get_pixel(x1, y0)[0] as f32;
+            let p01 = src.get_pixel(x0, y1)[0] as f32; let p11 = src.get_pixel(x1, y1)[0] as f32;
+            let val = p00*(1.0-fx)*(1.0-fy) + p10*fx*(1.0-fy) + p01*(1.0-fx)*fy + p11*fx*fy;
+            out.put_pixel(ox, oy, Luma([val.round() as u8]));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use omr_core::{StaffLine, StaffSystem};
+
+    fn make_horizontal_system(img_w: u32, top_y: u32, spacing: f32) -> StaffSystem {
+        let lines: Vec<StaffLine> = (0..5)
+            .map(|i| StaffLine {
+                y_per_x: vec![top_y + (i as f32 * spacing) as u32; img_w as usize],
+            })
+            .collect();
+        StaffSystem { lines, line_spacing: spacing, line_thickness: 2.0 }
+    }
+
+    fn make_skewed_system(img_w: u32, top_y: u32, spacing: f32, slope: f32) -> StaffSystem {
+        let lines: Vec<StaffLine> = (0..5)
+            .map(|i| StaffLine {
+                y_per_x: (0..img_w)
+                    .map(|x| top_y + (i as f32 * spacing) as u32 + (x as f32 * slope) as u32)
+                    .collect(),
+            })
+            .collect();
+        StaffSystem { lines, line_spacing: spacing, line_thickness: 2.0 }
+    }
+
+    #[test]
+    fn rectify_horizontal_system_no_skew() {
+        let img_w = 200u32; let img_h = 200u32;
+        let img: GrayImage = ImageBuffer::from_pixel(img_w, img_h, Luma([200u8]));
+        let system = make_horizontal_system(img_w, 60, 16.0);
+        let result = rectify_system(&img, &system);
+        assert!(result.angle_rad.abs() < 0.01);
+        assert!((result.scale - NORMALIZED_SPACING / 16.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn rectify_scaled_system_normalizes_spacing() {
+        let img_w = 200u32; let img_h = 300u32;
+        let img: GrayImage = ImageBuffer::from_pixel(img_w, img_h, Luma([200u8]));
+        let spacing = 20.0f32;
+        let system = make_horizontal_system(img_w, 50, spacing);
+        let result = rectify_system(&img, &system);
+        let expected_scale = NORMALIZED_SPACING / spacing;
+        assert!((result.scale - expected_scale).abs() < 0.01);
+        let expected_w = (img_w as f32 * expected_scale).round() as u32;
+        assert_eq!(result.image.width(), expected_w);
+    }
+
+    #[test]
+    fn rectify_skewed_system_corrects_angle() {
+        let img_w = 300u32; let img_h = 300u32;
+        let img: GrayImage = ImageBuffer::from_pixel(img_w, img_h, Luma([200u8]));
+        let slope = 0.05f32;
+        let system = make_skewed_system(img_w, 80, 16.0, slope);
+        let result = rectify_system(&img, &system);
+        let expected_angle = slope.atan();
+        assert!((result.angle_rad - expected_angle).abs() < 0.005,
+            "angle {} expected {}", result.angle_rad, expected_angle);
+    }
+
+    #[test]
+    fn rectify_all_systems_returns_correct_count() {
+        let img_w = 200u32; let img_h = 400u32;
+        let img: GrayImage = ImageBuffer::from_pixel(img_w, img_h, Luma([200u8]));
+        let systems = vec![
+            make_horizontal_system(img_w, 40, 16.0),
+            make_horizontal_system(img_w, 200, 16.0),
+        ];
+        let results = rectify_all_systems(&img, &systems);
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn transform_matrix_is_invertible() {
+        let m = [2.0f32, 0.5, 10.0, -0.5, 2.0, 5.0, 0.0, 0.0, 1.0];
+        let inv = invert_affine_3x3(&m);
+        let prod = mat3_mul(&m, &inv);
+        let identity = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0f32];
+        for (a, b) in prod.iter().zip(identity.iter()) {
+            assert!((a - b).abs() < 1e-4, "prod[i]={} expected {}", a, b);
+        }
+    }
+
+    #[test]
+    fn to_original_round_trips() {
+        let fwd = [1.5f32, 0.0, 20.0, 0.0, 1.5, 30.0, 0.0, 0.0, 1.0];
+        let inv = invert_affine_3x3(&fwd);
+        let (px, py) = (50.0f32, 70.0f32);
+        let dx = fwd[0]*px + fwd[1]*py + fwd[2];
+        let dy = fwd[3]*px + fwd[4]*py + fwd[5];
+        let rx = inv[0]*dx + inv[1]*dy + inv[2];
+        let ry = inv[3]*dx + inv[4]*dy + inv[5];
+        assert!((rx - px).abs() < 1e-3); assert!((ry - py).abs() < 1e-3);
+    }
+}

--- a/src/omr-rust/crates/omr-symbols/src/lib.rs
+++ b/src/omr-rust/crates/omr-symbols/src/lib.rs
@@ -44,6 +44,8 @@ pub use reader::{read_page_sequentially, read_system_sequentially, PageReadingSt
 pub use rests::{detect_rests, Rest, RestKind};
 pub use slurs::{detect_slurs, Slur};
 pub use template::{detect_noteheads_template_v2, detect_wholes_template, rerank_with_template};
+pub mod logical_groups;
+pub use logical_groups::{detect_logical_groups, class_id_for_group, LogicalGroup, LogicalGroupKind};
 
 /// Hauptfunktion: detektiere Noteheads in einem staff-line-removed Binary.
 /// `bin_original` wird genutzt um den Schlüssel/Vorzeichen-Bereich zu finden,

--- a/src/omr-rust/crates/omr-symbols/src/logical_groups.rs
+++ b/src/omr-rust/crates/omr-symbols/src/logical_groups.rs
@@ -1,0 +1,251 @@
+// Logical Group Detection for OMR
+//! Fasst atomare Erkennungsergebnisse (Noteheads, Stems, Beams) zu
+//! musikalisch sinnvollen Gruppen zusammen.
+use crate::beams::Beam;
+use omr_core::{Notehead, Rect, Stem};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum LogicalGroupKind {
+    BeamedGroup { beam_levels: u32 },
+    ChordCluster { note_count: u32 },
+    SingleNote,
+    TiedPair,
+    SlurredPhrase { note_count: u32 },
+    Isolated,
+}
+
+#[derive(Debug, Clone)]
+pub struct LogicalGroup {
+    pub kind: LogicalGroupKind,
+    pub bbox: Rect,
+    pub class_id: String,
+}
+
+pub fn detect_logical_groups(
+    noteheads: &[Notehead],
+    _stems: &[Stem],
+    beams: &[Beam],
+    line_spacing: f32,
+) -> Vec<LogicalGroup> {
+    if noteheads.is_empty() { return vec![]; }
+
+    let beam_levels = count_beam_levels(beams, line_spacing);
+    if beam_levels > 0 {
+        // All noteheads belong to one beamed group (simplified model)
+        let kind = LogicalGroupKind::BeamedGroup { beam_levels };
+        let bbox = union_bbox_noteheads(noteheads, beams);
+        let class_id = kind_to_class_id(&kind).to_string();
+        return vec![LogicalGroup { kind, bbox, class_id }];
+    }
+
+    let x_tol = 0.5 * line_spacing;
+    let y_min_span = 0.4 * line_spacing;
+    let mut used = vec![false; noteheads.len()];
+    let mut groups: Vec<LogicalGroup> = Vec::new();
+
+    // Phase 1: chord clusters
+    for i in 0..noteheads.len() {
+        if used[i] { continue; }
+        let cx_i = noteheads[i].bbox.x as f32 + noteheads[i].bbox.w as f32 * 0.5;
+        let mut cluster = vec![i];
+        for j in (i + 1)..noteheads.len() {
+            if used[j] { continue; }
+            let cx_j = noteheads[j].bbox.x as f32 + noteheads[j].bbox.w as f32 * 0.5;
+            if (cx_j - cx_i).abs() <= x_tol {
+                cluster.push(j);
+            }
+        }
+        if cluster.len() >= 2 {
+            let min_y = cluster.iter().map(|&ci| noteheads[ci].bbox.y).min().unwrap_or(0);
+            let max_y = cluster.iter().map(|&ci| noteheads[ci].bbox.y + noteheads[ci].bbox.h).max().unwrap_or(0);
+            if ((max_y.saturating_sub(min_y)) as f32) >= y_min_span {
+                for &ci in &cluster { used[ci] = true; }
+                let note_count = cluster.len() as u32;
+                let kind = LogicalGroupKind::ChordCluster { note_count };
+                let bbox = union_noteheads_slice(noteheads, &cluster);
+                let class_id = kind_to_class_id(&kind).to_string();
+                groups.push(LogicalGroup { kind, bbox, class_id });
+            }
+        }
+    }
+
+    // Phase 2: single notes
+    for (i, nh) in noteheads.iter().enumerate() {
+        if used[i] { continue; }
+        used[i] = true;
+        let kind = LogicalGroupKind::SingleNote;
+        let class_id = kind_to_class_id(&kind).to_string();
+        groups.push(LogicalGroup { kind, bbox: nh.bbox, class_id });
+    }
+
+    groups
+}
+
+pub fn class_id_for_group(group: &LogicalGroup) -> &'static str {
+    kind_to_class_id(&group.kind)
+}
+
+fn kind_to_class_id(kind: &LogicalGroupKind) -> &'static str {
+    match kind {
+        LogicalGroupKind::BeamedGroup { beam_levels } => match beam_levels {
+            1 => "group/beamed_group_2_eighths",
+            2 => "group/beamed_group_4_sixteenths",
+            3 => "group/beamed_group_8_thirty_seconds",
+            _ => "group/beamed_group",
+        },
+        LogicalGroupKind::ChordCluster { note_count } => match note_count {
+            2 => "chord/2_notes",
+            3 => "chord/3_notes",
+            4 => "chord/4_notes",
+            _ => "chord/n_notes",
+        },
+        LogicalGroupKind::SingleNote => "note/single",
+        LogicalGroupKind::TiedPair => "group/tied_pair",
+        LogicalGroupKind::SlurredPhrase { .. } => "group/slurred_phrase",
+        LogicalGroupKind::Isolated => "symbol/isolated",
+    }
+}
+
+pub(crate) fn count_beam_levels(beams: &[Beam], line_spacing: f32) -> u32 {
+    if beams.is_empty() { return 0; }
+    let band = 0.3 * line_spacing;
+    let mut levels: Vec<f32> = Vec::new();
+    for beam in beams {
+        let cy = (beam.y_top as f32 + beam.y_bot as f32) * 0.5;
+        if !levels.iter().any(|&ly| (cy - ly).abs() < band) {
+            levels.push(cy);
+        }
+    }
+    levels.len() as u32
+}
+
+fn union_bbox_noteheads(noteheads: &[Notehead], beams: &[Beam]) -> Rect {
+    let x = noteheads.iter().map(|n| n.bbox.x)
+        .chain(beams.iter().map(|b| b.x_start))
+        .min().unwrap_or(0);
+    let y = noteheads.iter().map(|n| n.bbox.y)
+        .chain(beams.iter().map(|b| b.y_top))
+        .min().unwrap_or(0);
+    let x2 = noteheads.iter().map(|n| n.bbox.x + n.bbox.w)
+        .chain(beams.iter().map(|b| b.x_end))
+        .max().unwrap_or(0);
+    let y2 = noteheads.iter().map(|n| n.bbox.y + n.bbox.h)
+        .chain(beams.iter().map(|b| b.y_bot))
+        .max().unwrap_or(0);
+    Rect { x, y, w: x2.saturating_sub(x), h: y2.saturating_sub(y) }
+}
+
+fn union_noteheads_slice(noteheads: &[Notehead], indices: &[usize]) -> Rect {
+    let x = indices.iter().map(|&i| noteheads[i].bbox.x).min().unwrap_or(0);
+    let y = indices.iter().map(|&i| noteheads[i].bbox.y).min().unwrap_or(0);
+    let x2 = indices.iter().map(|&i| noteheads[i].bbox.x + noteheads[i].bbox.w).max().unwrap_or(0);
+    let y2 = indices.iter().map(|&i| noteheads[i].bbox.y + noteheads[i].bbox.h).max().unwrap_or(0);
+    Rect { x, y, w: x2.saturating_sub(x), h: y2.saturating_sub(y) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use omr_core::{Notehead, NoteheadKind, Point, Rect, Stem};
+    use crate::beams::Beam;
+
+    fn nh(x: u32, y: u32, w: u32, h: u32) -> Notehead {
+        Notehead {
+            bbox: Rect { x, y, w, h },
+            center: Point { x: x as f32 + w as f32 * 0.5, y: y as f32 + h as f32 * 0.5 },
+            confidence: 0.9,
+            kind: NoteheadKind::Filled,
+            staff_idx: 0,
+        }
+    }
+
+    fn beam(x_start: u32, x_end: u32, y_top: u32, y_bot: u32) -> Beam {
+        Beam { x_start, x_end, y_top, y_bot }
+    }
+
+    #[test]
+    fn empty_noteheads_returns_empty() {
+        let groups = detect_logical_groups(&[], &[], &[], 16.0);
+        assert!(groups.is_empty());
+    }
+
+    #[test]
+    fn single_notehead_becomes_single_note() {
+        let noteheads = vec![nh(50, 100, 12, 12)];
+        let groups = detect_logical_groups(&noteheads, &[], &[], 16.0);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].kind, LogicalGroupKind::SingleNote);
+        assert_eq!(groups[0].class_id, "note/single");
+    }
+
+    #[test]
+    fn two_noteheads_same_x_form_chord() {
+        let noteheads = vec![nh(50, 100, 12, 12), nh(52, 116, 12, 12)];
+        let groups = detect_logical_groups(&noteheads, &[], &[], 16.0);
+        let chord = groups.iter().find(|g| matches!(g.kind, LogicalGroupKind::ChordCluster { .. }));
+        assert!(chord.is_some(), "expected chord cluster");
+    }
+
+    #[test]
+    fn beamed_group_with_two_beams_detected() {
+        let noteheads = vec![
+            nh(20, 100, 12, 12), nh(50, 102, 12, 12),
+            nh(80, 98, 12, 12), nh(110, 101, 12, 12),
+        ];
+        let beams = vec![
+            beam(20, 120, 78, 82),
+            beam(20, 120, 73, 77),
+        ];
+        let groups = detect_logical_groups(&noteheads, &[], &beams, 16.0);
+        let beamed = groups.iter().find(|g| matches!(g.kind, LogicalGroupKind::BeamedGroup { .. }));
+        assert!(beamed.is_some(), "expected beamed group");
+        if let LogicalGroupKind::BeamedGroup { beam_levels } = beamed.unwrap().kind {
+            assert_eq!(beam_levels, 2, "expected 2 beam levels for sixteenth notes");
+        }
+    }
+
+    #[test]
+    fn class_id_for_beamed_group_sixteenths() {
+        let group = LogicalGroup {
+            kind: LogicalGroupKind::BeamedGroup { beam_levels: 2 },
+            bbox: Rect { x: 0, y: 0, w: 10, h: 10 },
+            class_id: "group/beamed_group_4_sixteenths".to_string(),
+        };
+        assert_eq!(class_id_for_group(&group), "group/beamed_group_4_sixteenths");
+    }
+
+    #[test]
+    fn class_id_for_chord_three_notes() {
+        let group = LogicalGroup {
+            kind: LogicalGroupKind::ChordCluster { note_count: 3 },
+            bbox: Rect { x: 0, y: 0, w: 10, h: 10 },
+            class_id: "chord/3_notes".to_string(),
+        };
+        assert_eq!(class_id_for_group(&group), "chord/3_notes");
+    }
+
+    #[test]
+    fn class_id_for_single_note() {
+        let group = LogicalGroup {
+            kind: LogicalGroupKind::SingleNote,
+            bbox: Rect { x: 0, y: 0, w: 10, h: 10 },
+            class_id: "note/single".to_string(),
+        };
+        assert_eq!(class_id_for_group(&group), "note/single");
+    }
+
+    #[test]
+    fn union_bbox_spans_beams_and_noteheads() {
+        let noteheads = vec![nh(10, 20, 12, 12), nh(50, 22, 12, 12)];
+        let beams = vec![beam(10, 62, 15, 19)];
+        let bb = union_bbox_noteheads(&noteheads, &beams);
+        assert_eq!(bb.x, 10); assert_eq!(bb.y, 15);
+        assert_eq!(bb.x + bb.w, 62);
+    }
+
+    #[test]
+    fn count_beam_levels_two_bands() {
+        let beams = vec![beam(20, 120, 78, 82), beam(20, 120, 73, 77)];
+        assert_eq!(count_beam_levels(&beams, 16.0), 2);
+    }
+}


### PR DESCRIPTION
## Summary

Implements two new OMR features:

### Per-line Rectification (`omr-staff/src/rectify.rs`)
- `RectifiedSystem` struct with `image`, `angle_rad`, `scale`
- `rectify_system()`: estimates skew via linear regression, builds affine transform, warps with bilinear interpolation to normalize staff line spacing to 32px
- `rectify_all_systems()`: batch version
- `NORMALIZED_SPACING = 32.0`, `PADDING = 16`
- 6 unit tests: no-skew passthrough, scale normalization, skew correction, count, matrix invertibility, round-trip

### Logical-Group-Detection (`omr-symbols/src/logical_groups.rs`)
- `LogicalGroupKind`: `BeamedGroup { beam_levels }`, `ChordCluster { note_count }`, `SingleNote`, `TiedPair`, `SlurredPhrase`, `Isolated`
- `detect_logical_groups(noteheads, stems, beams, line_spacing)` — groups notes into musical units
- `class_id_for_group()` — returns canonical class string (e.g. `"group/beamed_group_4_sixteenths"`)
- 8 unit tests

### Integration
- `omr-core`: `PipelineOptions.rectify_systems: bool` flag
- `omr-pipeline`: `PipelineResult.rectified_systems` field; runs `rectify_all_systems` when flag enabled
- `omr-labeler`: calls `detect_logical_groups` per system to populate `suggested_class` labels on detected elements

## Test Results
- `omr-staff`: 8/8 tests pass
- `omr-symbols`: 76/76 tests pass
- `omr-pipeline` + `omr-labeler`: compile cleanly (`cargo check` passes)