### PR TITLE
feat(omr-labeler): UX polish + auto-promote class queue + label backfill

### DIFF
--- a/src/omr-rust/crates/omr-labeler/src/active_learning.rs
+++ b/src/omr-rust/crates/omr-labeler/src/active_learning.rs
@@ -24,6 +24,17 @@ pub enum Level {
     Class,
 }
 
+/// Sortier-Reihenfolge der Levels in der Queue. Wir wollen, dass der
+/// User erst ALLE Line-Items abarbeitet, dann ALLE Element-Items,
+/// dann ALLE Class-Items — und nicht zwischendurch wechselt.
+fn level_rank(l: Level) -> u8 {
+    match l {
+        Level::Line => 0,
+        Level::Element => 1,
+        Level::Class => 2,
+    }
+}
+
 impl Level {
     pub fn as_str(&self) -> &'static str {
         match self {
@@ -152,13 +163,25 @@ impl LabelingQueue {
         }
     }
 
-    /// Sortiert die Queue stabil nach Unsicherheit absteigend.
+    /// Sortiert die Queue strikt nach Level (Line vor Element vor Class)
+    /// und innerhalb eines Levels nach Unsicherheit absteigend.
+    ///
+    /// **Wichtig fuer die UX:** der User will nicht zwischen Frage-Typen
+    /// hin- und herspringen ("Ist das eine Notenzeile?" vs "Was ist im
+    /// roten Rahmen?"). Daher gruppieren wir strikt:
+    ///   1. Alle line-Items (Notenzeile-Validierung)
+    ///   2. Alle element-Items (Element-Validierung)
+    ///   3. Alle class-Items (Klassifikation)
     pub fn re_prioritize(&mut self) {
         let mut v: Vec<QueueItem> = self.items.drain(..).collect();
         v.sort_by(|a, b| {
-            b.uncertainty
-                .partial_cmp(&a.uncertainty)
-                .unwrap_or(std::cmp::Ordering::Equal)
+            level_rank(a.level)
+                .cmp(&level_rank(b.level))
+                .then_with(|| {
+                    b.uncertainty
+                        .partial_cmp(&a.uncertainty)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                })
         });
         self.items = v.into();
     }
@@ -213,5 +236,30 @@ mod tests {
         q.skip(a);
         let nxt = q.next().unwrap();
         assert_eq!(nxt.id, b);
+    }
+
+    #[test]
+    fn re_prioritize_groups_by_level_first() {
+        let mut q = LabelingQueue::new();
+        // Mische Levels: zwei Class-Items mit hoher Unsicherheit, ein
+        // Element-Item mit mittlerer, ein Line-Item mit niedriger.
+        // Erwartung nach re_prioritize: Line zuerst, dann Element, dann Class —
+        // unabhaengig von Unsicherheit.
+        q.push(Level::Class, "c1".into(), Some("c1#e0".into()), 0.99);
+        q.push(Level::Class, "c2".into(), Some("c2#e0".into()), 0.95);
+        q.push(Level::Element, "e1".into(), Some("e1#e0".into()), 0.5);
+        q.push(Level::Line, "l1".into(), None, 0.1);
+        q.re_prioritize();
+        let n1 = q.next().cloned().unwrap();
+        assert_eq!(n1.level, Level::Line);
+        // Item beantworten + zum naechsten gehen
+        q.answer(n1.id, Decision::Yes);
+        let n2 = q.next().cloned().unwrap();
+        assert_eq!(n2.level, Level::Element);
+        q.answer(n2.id, Decision::Yes);
+        let n3 = q.next().cloned().unwrap();
+        assert_eq!(n3.level, Level::Class);
+        // Innerhalb des Class-Levels: hoehere Unsicherheit zuerst.
+        assert!((n3.uncertainty - 0.99).abs() < 1e-6);
     }
 }

--- a/src/omr-rust/crates/omr-labeler/src/api.rs
+++ b/src/omr-rust/crates/omr-labeler/src/api.rs
@@ -425,15 +425,15 @@ pub fn top_k_for_class_item(state: &AppState) -> Vec<(String, f32)> {
 }
 
 /// Default-Top-5 fuer Class-Items ohne trainierten Classifier und ohne
-/// User-Historie: die haeufigsten Blasmusik-Group-Klassen. Wird ersetzt,
+/// User-Historie: die haeufigsten Blasmusik-Ton-Ereignisse. Wird ersetzt,
 /// sobald der User Klassen gelabelt hat oder ein Embedding-Index vorliegt.
 pub fn default_class_top_k() -> Vec<(String, f32)> {
     vec![
-        ("group/single_note_quarter".to_string(), 0.0),
-        ("group/single_note_eighth".to_string(), 0.0),
-        ("group/beamed_group_2_eighths".to_string(), 0.0),
-        ("group/beamed_group_4_sixteenths".to_string(), 0.0),
-        ("group/chord_2_notes".to_string(), 0.0),
+        ("ton/viertel".to_string(), 0.0),
+        ("ton/achtel".to_string(), 0.0),
+        ("balken/2_noten".to_string(), 0.0),
+        ("balken/4_noten".to_string(), 0.0),
+        ("akkord/2_noten".to_string(), 0.0),
     ]
 }
 

--- a/src/omr-rust/crates/omr-labeler/src/api.rs
+++ b/src/omr-rust/crates/omr-labeler/src/api.rs
@@ -10,15 +10,19 @@
 //! - `POST /api/queue/answer          ` → Antwort persistieren + Queue
 //! - `POST /api/queue/skip            ` → Item überspringen
 //! - `POST /api/queue/undo            ` → letztes Label entfernen
-//! - `GET  /api/system/{id}/image     ` → System-PNG
-//! - `GET  /api/element/{id}/image    ` → Element-PNG
+//! - `GET  /api/system/{id}/image     ` → System-PNG (gesamte Notenzeile)
+//! - `GET  /api/element/{id}/image    ` → Element-PNG (nur das Patch)
+//! - `GET  /api/element/{id}/context  ` → Element im System-Kontext mit
+//!                                        rotem Highlight-Rahmen
+//! - `GET  /api/element/{id}/info     ` → Element-Metadaten (system_id, bbox,
+//!                                        suggested_class, ...)
 //! - `GET  /api/stats                 ` → Fortschritts-Stats
 //! - `GET  /api/export/corpus         ` → JSON-Export aller Labels
 
 use crate::active_learning::{Decision, LabelingQueue, Level, QueueItem};
 use crate::frontend::{APP_JS, INDEX_HTML, STYLE_CSS};
 use crate::persistence::{Label, LabelDb};
-use crate::pipeline::{encode_png, PipelineState};
+use crate::pipeline::{encode_png, encode_png_rgb, PipelineState};
 use axum::{
     body::Body,
     extract::{Path as AxumPath, Query, State},
@@ -27,6 +31,7 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
+use image::{ImageBuffer, Rgb, RgbImage};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -125,6 +130,8 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/api/queue/undo", post(api_queue_undo))
         .route("/api/system/:id/image", get(api_system_image))
         .route("/api/element/:id/image", get(api_element_image))
+        .route("/api/element/:id/context", get(api_element_context))
+        .route("/api/element/:id/info", get(api_element_info))
         .route("/api/stats", get(api_stats))
         .route("/api/export/corpus", get(api_export_corpus))
         .with_state(state)
@@ -267,21 +274,25 @@ async fn api_queue_answer(
         }
     };
 
-    // Item-Ref ermitteln (system_id oder element_id) bevor die Queue
-    // den Eintrag entfernt.
-    let item_ref = {
+    // Original-Item zwischenspeichern, bevor die Queue es entfernt.
+    // Wir brauchen es spaeter fuer die Auto-Promotion (Element-Yes -> Class-Item).
+    let original_item: Option<QueueItem> = {
         let queue = state.queue.read().await;
         queue
             .items
             .iter()
             .find(|it| it.id == req.item_id)
-            .map(|it| {
-                it.element_id
-                    .clone()
-                    .unwrap_or_else(|| it.system_id.clone())
-            })
-            .unwrap_or_else(|| format!("item-{}", req.item_id))
+            .cloned()
     };
+
+    let item_ref = original_item
+        .as_ref()
+        .map(|it| {
+            it.element_id
+                .clone()
+                .unwrap_or_else(|| it.system_id.clone())
+        })
+        .unwrap_or_else(|| format!("item-{}", req.item_id));
 
     {
         let mut queue = state.queue.write().await;
@@ -299,7 +310,42 @@ async fn api_queue_answer(
         }
     }
 
+    // Auto-Promotion: wenn der User ein Element mit "Yes" bestaetigt hat,
+    // schieben wir automatisch ein Class-Level-Item hinterher, damit der
+    // naechste Klick sofort die Klassifikations-Frage stellt. Dadurch
+    // bleibt der Workflow ohne Pause: Element=Yes -> "Was ist es?".
+    if let Some(item) = original_item.as_ref() {
+        if item.level == Level::Element
+            && matches!(dec, Decision::Yes)
+            && item.element_id.is_some()
+        {
+            let mut queue = state.queue.write().await;
+            queue.push_item(QueueItem {
+                id: 0,
+                level: Level::Class,
+                uncertainty: 0.95,
+                system_id: item.system_id.clone(),
+                element_id: item.element_id.clone(),
+                suggested_class: None,
+                top_k: default_class_top_k(),
+            });
+        }
+    }
+
     Ok(Json(serde_json::json!({ "ok": true })))
+}
+
+/// Default-Top-5 fuer Class-Items ohne trainierten Classifier:
+/// die haeufigsten Blasmusik-Group-Klassen. Wird ersetzt, sobald
+/// ein Embedding-Index vorliegt.
+pub fn default_class_top_k() -> Vec<(String, f32)> {
+    vec![
+        ("group/single_note_quarter".to_string(), 0.0),
+        ("group/single_note_eighth".to_string(), 0.0),
+        ("group/beamed_group_2_eighths".to_string(), 0.0),
+        ("group/beamed_group_4_sixteenths".to_string(), 0.0),
+        ("group/chord_2_notes".to_string(), 0.0),
+    ]
 }
 
 async fn api_queue_skip(
@@ -359,6 +405,138 @@ async fn api_element_image(
         .header(header::CONTENT_TYPE, "image/png")
         .body(Body::from(png))
         .unwrap())
+}
+
+#[derive(Deserialize, Default)]
+pub struct ContextQuery {
+    /// Padding in Pixeln links und rechts vom Element.
+    /// Default 350px (~5cm bei 200dpi).
+    #[serde(default)]
+    pub padding: Option<u32>,
+    /// Vertikales Padding (oben/unten) — kann negativ wirken: 0 = ganzes System.
+    #[serde(default)]
+    pub padding_y: Option<u32>,
+}
+
+/// Liefert das **Page-Bild im Kontext um das Element herum**, mit einem
+/// roten Highlight-Rechteck um die Element-Bbox. Default-Padding 350px
+/// horizontal (~5cm bei 200dpi) und 200px vertikal (oben + unten),
+/// damit man Pausen vs. Notenkoepfe richtig einordnen kann.
+async fn api_element_context(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<String>,
+    Query(q): Query<ContextQuery>,
+) -> Result<Response, (StatusCode, String)> {
+    let pipeline = state.pipeline.read().await;
+    let elt = pipeline
+        .elements
+        .iter()
+        .find(|e| e.id == id)
+        .ok_or((StatusCode::NOT_FOUND, "Element nicht gefunden".to_string()))?;
+    let sys = pipeline
+        .systems
+        .iter()
+        .find(|s| s.id == elt.system_id)
+        .ok_or((StatusCode::NOT_FOUND, "System nicht gefunden".to_string()))?;
+
+    let pad_x = q.padding.unwrap_or(350);
+    let pad_y = q.padding_y.unwrap_or(200);
+
+    // Page-Bild: vollständiges Page in Page-Koordinaten.
+    // Element-bbox ist in CROP-Koordinaten (rel. zum System-Crop) →
+    // konvertiere via sys.page_top zurück nach Page-Koordinaten.
+    let page = &sys.page_image;
+    let pw = page.width();
+    let ph = page.height();
+    let bb = &elt.bbox;
+    let elt_page_y = bb.y + sys.page_top;
+
+    let crop_x0 = bb.x.saturating_sub(pad_x);
+    let crop_x1 = (bb.x + bb.w + pad_x).min(pw);
+    let crop_w = crop_x1.saturating_sub(crop_x0).max(1);
+
+    let crop_y0 = elt_page_y.saturating_sub(pad_y);
+    let crop_y1 = (elt_page_y + bb.h + pad_y).min(ph);
+    let crop_h = crop_y1.saturating_sub(crop_y0).max(1);
+
+    let mut rgb: RgbImage = ImageBuffer::new(crop_w, crop_h);
+    for yy in 0..crop_h {
+        for xx in 0..crop_w {
+            let sx = crop_x0 + xx;
+            let sy = crop_y0 + yy;
+            let p = page.get_pixel(sx, sy)[0];
+            rgb.put_pixel(xx, yy, Rgb([p, p, p]));
+        }
+    }
+
+    // Draw red border around the element bbox (3px thick).
+    let bx0 = bb.x.saturating_sub(crop_x0);
+    let by0 = elt_page_y.saturating_sub(crop_y0);
+    let bx1 = (bb.x + bb.w).saturating_sub(crop_x0).min(crop_w.saturating_sub(1));
+    let by1 = (elt_page_y + bb.h).saturating_sub(crop_y0).min(crop_h.saturating_sub(1));
+    let border_color = Rgb([255u8, 64, 64]);
+    let thickness = 3u32;
+    for t in 0..thickness {
+        for x in bx0..=bx1 {
+            if by0 + t < crop_h {
+                rgb.put_pixel(x, by0 + t, border_color);
+            }
+            if by1 >= t && by1 - t < crop_h {
+                rgb.put_pixel(x, by1 - t, border_color);
+            }
+        }
+        for y in by0..=by1 {
+            if bx0 + t < crop_w {
+                rgb.put_pixel(bx0 + t, y, border_color);
+            }
+            if bx1 >= t && bx1 - t < crop_w {
+                rgb.put_pixel(bx1 - t, y, border_color);
+            }
+        }
+    }
+
+    let png = encode_png_rgb(&rgb).map_err(internal)?;
+    Ok(Response::builder()
+        .header(header::CONTENT_TYPE, "image/png")
+        .body(Body::from(png))
+        .unwrap())
+}
+
+#[derive(Serialize)]
+pub struct ElementInfo {
+    pub id: String,
+    pub system_id: String,
+    pub bbox: [u32; 4],
+    pub system_size: [u32; 2],
+    pub suggested_class: Option<String>,
+    pub patch_size: [u32; 2],
+}
+
+async fn api_element_info(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<String>,
+) -> Result<Json<ElementInfo>, (StatusCode, String)> {
+    let pipeline = state.pipeline.read().await;
+    let elt = pipeline
+        .elements
+        .iter()
+        .find(|e| e.id == id)
+        .ok_or((StatusCode::NOT_FOUND, "Element nicht gefunden".to_string()))?;
+    let sys = pipeline
+        .systems
+        .iter()
+        .find(|s| s.id == elt.system_id);
+    let system_size = sys
+        .map(|s| [s.image.width(), s.image.height()])
+        .unwrap_or([0, 0]);
+    Ok(Json(ElementInfo {
+        id: elt.id.clone(),
+        system_id: elt.system_id.clone(),
+        bbox: [elt.bbox.x, elt.bbox.y, elt.bbox.w, elt.bbox.h],
+        system_size,
+        suggested_class: elt.suggested_class.clone(),
+        patch_size: [elt.patch.width(), elt.patch.height()],
+    }))
 }
 
 async fn api_stats(State(state): State<Arc<AppState>>) -> Json<StatsResponse> {

--- a/src/omr-rust/crates/omr-labeler/src/api.rs
+++ b/src/omr-rust/crates/omr-labeler/src/api.rs
@@ -20,8 +20,8 @@
 //! - `GET  /api/export/corpus         ` → JSON-Export aller Labels
 
 use crate::active_learning::{Decision, LabelingQueue, Level, QueueItem};
-use crate::frontend::{APP_JS, INDEX_HTML, STYLE_CSS};
-use crate::persistence::{Label, LabelDb};
+use crate::frontend::{ANNOTATE_HTML, ANNOTATE_JS, APP_JS, INDEX_HTML, STYLE_CSS};
+use crate::persistence::{Annotation, Label, LabelDb};
 use crate::pipeline::{encode_png, encode_png_rgb, PipelineState};
 use axum::{
     body::Body,
@@ -121,6 +121,9 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/index.html", get(index_html))
         .route("/app.js", get(app_js))
         .route("/style.css", get(style_css))
+        .route("/annotate", get(annotate_html))
+        .route("/annotate.html", get(annotate_html))
+        .route("/annotate.js", get(annotate_js))
         .route("/api/status", get(api_status))
         .route("/api/classes", get(api_classes))
         .route("/api/classes/drilldown/:group_id", get(api_classes_drilldown))
@@ -135,6 +138,11 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/api/element/:id/info", get(api_element_info))
         .route("/api/stats", get(api_stats))
         .route("/api/export/corpus", get(api_export_corpus))
+        .route("/api/annotation/systems", get(api_annotation_systems))
+        .route("/api/annotation/system/:id", get(api_annotation_for_system))
+        .route("/api/annotation/box", post(api_annotation_create))
+        .route("/api/annotation/box/:id", axum::routing::patch(api_annotation_update).delete(api_annotation_delete))
+        .route("/api/annotation/export", get(api_annotation_export))
         .with_state(state)
         .layer(CorsLayer::permissive())
 }
@@ -159,6 +167,20 @@ async fn style_css() -> impl IntoResponse {
     Response::builder()
         .header(header::CONTENT_TYPE, "text/css; charset=utf-8")
         .body(Body::from(STYLE_CSS))
+        .unwrap()
+}
+
+async fn annotate_html() -> impl IntoResponse {
+    Response::builder()
+        .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
+        .body(Body::from(ANNOTATE_HTML))
+        .unwrap()
+}
+
+async fn annotate_js() -> impl IntoResponse {
+    Response::builder()
+        .header(header::CONTENT_TYPE, "application/javascript; charset=utf-8")
+        .body(Body::from(ANNOTATE_JS))
         .unwrap()
 }
 
@@ -672,6 +694,196 @@ async fn api_export_corpus(
         }
     };
     Ok(Json(labels))
+}
+
+// ---- Annotation-API (User-gezogene Boxen) -----------------------------------
+
+#[derive(Serialize)]
+pub struct AnnotationSystemInfo {
+    pub system_id: String,
+    pub width: u32,
+    pub height: u32,
+    pub annotation_count: u64,
+    /// Anzahl auto-erkannter Elemente in diesem System (zur Orientierung).
+    pub auto_element_count: u64,
+}
+
+#[derive(Serialize)]
+pub struct AnnotationSystemsResponse {
+    pub systems: Vec<AnnotationSystemInfo>,
+}
+
+/// Liefert eine Liste aller Systeme mit Annotation-Counts. Sortiert nach
+/// `annotation_count` aufsteigend (am wenigsten annotiert zuerst), damit
+/// der User schnell unbearbeitete Systeme findet.
+async fn api_annotation_systems(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<AnnotationSystemsResponse>, (StatusCode, String)> {
+    let counts: HashMap<String, u64> = {
+        let guard = state.db.lock().expect("db mutex poisoned");
+        match guard.as_ref() {
+            Some(db) => db
+                .annotation_counts_per_system()
+                .map_err(internal)?
+                .into_iter()
+                .collect(),
+            None => HashMap::new(),
+        }
+    };
+    let pipeline = state.pipeline.read().await;
+    let mut auto_counts: HashMap<String, u64> = HashMap::new();
+    for elt in &pipeline.elements {
+        *auto_counts.entry(elt.system_id.clone()).or_insert(0) += 1;
+    }
+    let mut systems: Vec<AnnotationSystemInfo> = pipeline
+        .systems
+        .iter()
+        .map(|s| AnnotationSystemInfo {
+            system_id: s.id.clone(),
+            width: s.image.width(),
+            height: s.image.height(),
+            annotation_count: counts.get(&s.id).copied().unwrap_or(0),
+            auto_element_count: auto_counts.get(&s.id).copied().unwrap_or(0),
+        })
+        .collect();
+    // unbearbeitete zuerst, danach nach system_id
+    systems.sort_by(|a, b| {
+        a.annotation_count
+            .cmp(&b.annotation_count)
+            .then_with(|| a.system_id.cmp(&b.system_id))
+    });
+    Ok(Json(AnnotationSystemsResponse { systems }))
+}
+
+#[derive(Serialize)]
+pub struct AnnotationForSystemResponse {
+    pub system_id: String,
+    pub annotations: Vec<Annotation>,
+    /// Auto-Boxen des Systems (Element-Bboxes aus der Pipeline) — koennen
+    /// als Vorschlag fuer die manuelle Annotation verwendet werden.
+    pub auto_boxes: Vec<AutoBox>,
+}
+
+#[derive(Serialize)]
+pub struct AutoBox {
+    pub element_id: String,
+    pub x: u32,
+    pub y: u32,
+    pub w: u32,
+    pub h: u32,
+    pub suggested_class: Option<String>,
+}
+
+async fn api_annotation_for_system(
+    State(state): State<Arc<AppState>>,
+    AxumPath(system_id): AxumPath<String>,
+) -> Result<Json<AnnotationForSystemResponse>, (StatusCode, String)> {
+    let annotations = {
+        let guard = state.db.lock().expect("db mutex poisoned");
+        match guard.as_ref() {
+            Some(db) => db.annotations_for_system(&system_id).map_err(internal)?,
+            None => Vec::new(),
+        }
+    };
+    let pipeline = state.pipeline.read().await;
+    let auto_boxes: Vec<AutoBox> = pipeline
+        .elements
+        .iter()
+        .filter(|e| e.system_id == system_id)
+        .map(|e| AutoBox {
+            element_id: e.id.clone(),
+            x: e.bbox.x,
+            y: e.bbox.y,
+            w: e.bbox.w,
+            h: e.bbox.h,
+            suggested_class: e.suggested_class.clone(),
+        })
+        .collect();
+    Ok(Json(AnnotationForSystemResponse {
+        system_id,
+        annotations,
+        auto_boxes,
+    }))
+}
+
+#[derive(Deserialize)]
+pub struct AnnotationCreateRequest {
+    pub system_id: String,
+    pub x: i32,
+    pub y: i32,
+    pub w: i32,
+    pub h: i32,
+    pub class_id: String,
+}
+
+async fn api_annotation_create(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<AnnotationCreateRequest>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    if req.w <= 0 || req.h <= 0 {
+        return Err((StatusCode::BAD_REQUEST, "w/h must be positive".to_string()));
+    }
+    if req.class_id.trim().is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "class_id required".to_string()));
+    }
+    let id = {
+        let guard = state.db.lock().expect("db mutex poisoned");
+        match guard.as_ref() {
+            Some(db) => {
+                let ann = Annotation::new(
+                    req.system_id.clone(),
+                    req.x,
+                    req.y,
+                    req.w,
+                    req.h,
+                    req.class_id.clone(),
+                );
+                db.save_annotation(&ann).map_err(internal)?
+            }
+            None => 0,
+        }
+    };
+    Ok(Json(serde_json::json!({ "ok": true, "id": id })))
+}
+
+#[derive(Deserialize)]
+pub struct AnnotationUpdateRequest {
+    pub class_id: String,
+}
+
+async fn api_annotation_update(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<i64>,
+    Json(req): Json<AnnotationUpdateRequest>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let guard = state.db.lock().expect("db mutex poisoned");
+    if let Some(db) = guard.as_ref() {
+        db.update_annotation_class(id, &req.class_id)
+            .map_err(internal)?;
+    }
+    Ok(Json(serde_json::json!({ "ok": true })))
+}
+
+async fn api_annotation_delete(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<i64>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let guard = state.db.lock().expect("db mutex poisoned");
+    if let Some(db) = guard.as_ref() {
+        db.delete_annotation(id).map_err(internal)?;
+    }
+    Ok(Json(serde_json::json!({ "ok": true })))
+}
+
+async fn api_annotation_export(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<Vec<Annotation>>, (StatusCode, String)> {
+    let guard = state.db.lock().expect("db mutex poisoned");
+    let out = match guard.as_ref() {
+        Some(db) => db.get_all_annotations().map_err(internal)?,
+        None => Vec::new(),
+    };
+    Ok(Json(out))
 }
 
 fn internal<E: std::fmt::Display>(e: E) -> (StatusCode, String) {

--- a/src/omr-rust/crates/omr-labeler/src/api.rs
+++ b/src/omr-rust/crates/omr-labeler/src/api.rs
@@ -124,6 +124,7 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/api/status", get(api_status))
         .route("/api/classes", get(api_classes))
         .route("/api/classes/drilldown/:group_id", get(api_classes_drilldown))
+        .route("/api/classes/recent", get(api_classes_recent))
         .route("/api/queue/next", get(api_queue_next))
         .route("/api/queue/answer", post(api_queue_answer))
         .route("/api/queue/skip", post(api_queue_skip))
@@ -211,6 +212,61 @@ async fn api_classes_drilldown(
     AxumPath(group_id): AxumPath<String>,
 ) -> Json<Vec<crate::classes::ClassEntry>> {
     Json(crate::classes::drill_down(&group_id))
+}
+
+/// Eintrag in der Recent-Klassen-Liste: ein User-Label mit Count.
+#[derive(Serialize)]
+pub struct RecentClass {
+    pub id: String,
+    pub display_name: String,
+    pub count: u64,
+    /// `true` wenn die Klasse vom User selbst eingegeben wurde
+    /// (d.h. nicht in der eingebauten Hierarchie steht).
+    pub custom: bool,
+}
+
+#[derive(Deserialize)]
+pub struct RecentQuery {
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+/// Liefert die meistgenutzten Class-Labels aus der DB inkl. eigener
+/// User-Klassen. Wird vom Frontend genutzt, um die Top-5-Vorschlaege
+/// und die Suchliste mit Custom-Klassen anzureichern.
+async fn api_classes_recent(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<RecentQuery>,
+) -> Result<Json<Vec<RecentClass>>, (StatusCode, String)> {
+    let limit = q.limit.unwrap_or(20).min(200);
+    let recent = {
+        let guard = state.db.lock().expect("db mutex poisoned");
+        match guard.as_ref() {
+            Some(db) => db.recent_class_decisions(limit).map_err(internal)?,
+            None => Vec::new(),
+        }
+    };
+    // Built-in-Klassen-Map fuer Custom-Detection + display_name.
+    let known: HashMap<String, String> = crate::classes::all_classes()
+        .into_iter()
+        .map(|c| (c.id, c.display_name))
+        .collect();
+    let out: Vec<RecentClass> = recent
+        .into_iter()
+        .map(|(id, count)| {
+            let (display_name, custom) = match known.get(&id) {
+                Some(name) => (name.clone(), false),
+                None => (id.clone(), true),
+            };
+            RecentClass {
+                id,
+                display_name,
+                count,
+                custom,
+            }
+        })
+        .collect();
+    Ok(Json(out))
 }
 
 async fn api_queue_next(
@@ -314,11 +370,16 @@ async fn api_queue_answer(
     // schieben wir automatisch ein Class-Level-Item hinterher, damit der
     // naechste Klick sofort die Klassifikations-Frage stellt. Dadurch
     // bleibt der Workflow ohne Pause: Element=Yes -> "Was ist es?".
+    //
+    // Top-K kommt dabei aus den haeufig genutzten User-Klassen (inkl.
+    // Custom-Klassen wie "Gitarrenakkord"). Faellt zurueck auf
+    // Blasmusik-Default, wenn der User noch keine Klassen gelabelt hat.
     if let Some(item) = original_item.as_ref() {
         if item.level == Level::Element
             && matches!(dec, Decision::Yes)
             && item.element_id.is_some()
         {
+            let top_k = top_k_for_class_item(state.as_ref());
             let mut queue = state.queue.write().await;
             queue.push_item(QueueItem {
                 id: 0,
@@ -327,7 +388,7 @@ async fn api_queue_answer(
                 system_id: item.system_id.clone(),
                 element_id: item.element_id.clone(),
                 suggested_class: None,
-                top_k: default_class_top_k(),
+                top_k,
             });
         }
     }
@@ -335,9 +396,37 @@ async fn api_queue_answer(
     Ok(Json(serde_json::json!({ "ok": true })))
 }
 
-/// Default-Top-5 fuer Class-Items ohne trainierten Classifier:
-/// die haeufigsten Blasmusik-Group-Klassen. Wird ersetzt, sobald
-/// ein Embedding-Index vorliegt.
+/// Liefert die Top-5 fuer ein neues Class-Item.
+///
+/// Strategie:
+/// 1. Falls in der DB schon Class-Labels existieren -> die haeufigsten
+///    User-Klassen (mit Custom-Klassen wie "Gitarrenakkord") nehmen.
+/// 2. Andernfalls die statischen Blasmusik-Defaults
+///    (`default_class_top_k`).
+///
+/// Synchron, blockiert kurz auf der DB-Mutex (keine `await`-Punkte).
+pub fn top_k_for_class_item(state: &AppState) -> Vec<(String, f32)> {
+    let recent: Vec<(String, u64)> = {
+        let guard = state.db.lock().expect("db mutex poisoned");
+        match guard.as_ref() {
+            Some(db) => db.recent_class_decisions(5).unwrap_or_default(),
+            None => Vec::new(),
+        }
+    };
+    if recent.is_empty() {
+        return default_class_top_k();
+    }
+    // Score = Anteil an Gesamt-Labels (0..1), nur als Anzeigewert.
+    let total: u64 = recent.iter().map(|(_, c)| *c).sum::<u64>().max(1);
+    recent
+        .into_iter()
+        .map(|(id, count)| (id, count as f32 / total as f32))
+        .collect()
+}
+
+/// Default-Top-5 fuer Class-Items ohne trainierten Classifier und ohne
+/// User-Historie: die haeufigsten Blasmusik-Group-Klassen. Wird ersetzt,
+/// sobald der User Klassen gelabelt hat oder ein Embedding-Index vorliegt.
 pub fn default_class_top_k() -> Vec<(String, f32)> {
     vec![
         ("group/single_note_quarter".to_string(), 0.0),

--- a/src/omr-rust/crates/omr-labeler/src/classes.rs
+++ b/src/omr-rust/crates/omr-labeler/src/classes.rs
@@ -38,52 +38,53 @@ pub enum ClassLevel {
 
 /// Liefert die komplette Klassen-Hierarchie. Wird in der Frontend-API
 /// als `/api/classes` ausgeliefert.
+///
+/// **Konzept (User-Vorgabe 2026-05-04):**
+/// Ein TON-EREIGNIS = eine Note + ALLES was dazugehoert (Akzidenz,
+/// Stakkato, Akzent, Pralltriller, Punkt, Bindebogen-Anker, Fermate ...).
+/// Der User labelt auf diesem aggregierten Level. Atome sind nur
+/// Drill-Down-Hilfen.
+///
+/// **Ausnahmen** (kein Ton-Ereignis, eigenes Element):
+/// Crescendo/Decrescendo-Gabel, Taktnummer, Texte (Tempo, Ausdruck,
+/// Lyrics, Akkordsymbol, Sprungmarken), Probenzeichen, Segno, Coda,
+/// Voltenklammern.
 pub fn all_classes() -> Vec<ClassEntry> {
     let mut out = Vec::new();
 
-    // ── Atome — was im "Drill-Down" einzeln klassifizierbar ist ─────────
+    // ── ATOME (nur Drill-Down) ────────────────────────────────────────
     for (id, name) in [
-        ("atom/notehead_filled", "Notenkopf gefuellt (Viertel/8tel/16tel/...)"),
-        ("atom/notehead_open", "Notenkopf offen (Halbe)"),
-        ("atom/notehead_whole", "Ganze Note"),
-        ("atom/notehead_x", "X-Notenkopf (Schlagzeug)"),
-        ("atom/notehead_diamond", "Rauten-Notenkopf"),
-        ("atom/stem_up", "Stem nach oben"),
-        ("atom/stem_down", "Stem nach unten"),
-        ("atom/beam_1", "Balken (Achtel-Verbindung, 1 Linie)"),
-        ("atom/beam_2", "Balken (Sechzehntel, 2 Linien)"),
-        ("atom/beam_3", "Balken (32stel, 3 Linien)"),
-        ("atom/flag_eighth_up", "Faehnchen Achtel (Stem hoch)"),
-        ("atom/flag_eighth_down", "Faehnchen Achtel (Stem runter)"),
-        ("atom/flag_sixteenth_up", "Faehnchen 16tel (Stem hoch)"),
-        ("atom/flag_sixteenth_down", "Faehnchen 16tel (Stem runter)"),
-        ("atom/aug_dot_one", "Punktierung (1 Punkt)"),
-        ("atom/aug_dot_two", "Doppelpunktierung"),
-        ("atom/accidental_sharp", "Vorzeichen ♯ Kreuz"),
-        ("atom/accidental_flat", "Vorzeichen ♭ Be"),
-        ("atom/accidental_natural", "Aufloesungszeichen ♮"),
-        ("atom/accidental_double_sharp", "Doppelkreuz 𝄪"),
-        ("atom/accidental_double_flat", "Doppel-Be 𝄫"),
-        ("atom/rest_whole", "Ganze Pause"),
-        ("atom/rest_half", "Halbe Pause"),
-        ("atom/rest_quarter", "Viertelpause"),
-        ("atom/rest_eighth", "Achtelpause"),
-        ("atom/rest_sixteenth", "Sechzehntelpause"),
-        ("atom/clef_treble", "Violinschluessel"),
-        ("atom/clef_bass", "Bassschluessel"),
-        ("atom/clef_alto", "Altschluessel"),
-        ("atom/clef_tenor", "Tenorschluessel"),
-        ("atom/clef_percussion", "Percussion-Schluessel"),
-        ("atom/bar_single", "Taktstrich"),
-        ("atom/bar_double", "Doppelstrich"),
-        ("atom/bar_final", "Schlussstrich"),
-        ("atom/bar_repeat_start", "Wiederholungsanfang ‖:"),
-        ("atom/bar_repeat_end", "Wiederholungsende :‖"),
-        ("atom/articulation_staccato", "Staccato"),
-        ("atom/articulation_accent", "Akzent"),
-        ("atom/articulation_tenuto", "Tenuto"),
-        ("atom/articulation_marcato", "Marcato"),
-        ("atom/articulation_fermata", "Fermate"),
+        ("atom/notenkopf_gefuellt", "Notenkopf gefuellt (Viertel/Achtel/16tel/...)"),
+        ("atom/notenkopf_offen", "Notenkopf offen (Halbe)"),
+        ("atom/notenkopf_ganze", "Ganze Note (Notenkopf)"),
+        ("atom/notenkopf_x", "X-Notenkopf (Schlagzeug)"),
+        ("atom/notenkopf_raute", "Rauten-Notenkopf"),
+        ("atom/hals_oben", "Notenhals nach oben"),
+        ("atom/hals_unten", "Notenhals nach unten"),
+        ("atom/balken_1", "Balken (Achtel, 1 Linie)"),
+        ("atom/balken_2", "Balken (Sechzehntel, 2 Linien)"),
+        ("atom/balken_3", "Balken (32tel, 3 Linien)"),
+        ("atom/faehnchen_achtel", "Faehnchen Achtel"),
+        ("atom/faehnchen_sechzehntel", "Faehnchen Sechzehntel"),
+        ("atom/punktierung", "Punktierung (Aug.-Punkt)"),
+        ("atom/akzidenz_kreuz", "Vorzeichen ♯"),
+        ("atom/akzidenz_be", "Vorzeichen ♭"),
+        ("atom/akzidenz_aufloesen", "Aufloesungszeichen ♮"),
+        ("atom/akzidenz_doppelkreuz", "Doppelkreuz 𝄪"),
+        ("atom/akzidenz_doppelbe", "Doppel-Be 𝄫"),
+        ("atom/artikulation_staccato", "Staccato (Punkt)"),
+        ("atom/artikulation_staccatissimo", "Staccatissimo (Spitze)"),
+        ("atom/artikulation_tenuto", "Tenuto (Strich)"),
+        ("atom/artikulation_akzent", "Akzent ( > )"),
+        ("atom/artikulation_marcato", "Marcato ( ^ )"),
+        ("atom/artikulation_fermate", "Fermate"),
+        ("atom/verzierung_pralltriller", "Pralltriller"),
+        ("atom/verzierung_mordent", "Mordent"),
+        ("atom/verzierung_triller", "Triller (tr)"),
+        ("atom/verzierung_doppelschlag", "Doppelschlag"),
+        ("atom/verzierung_arpeggio", "Arpeggio"),
+        ("atom/verzierung_glissando", "Glissando"),
+        ("atom/hilfslinie", "Hilfslinie"),
     ] {
         out.push(ClassEntry {
             id: id.to_string(),
@@ -93,30 +94,31 @@ pub fn all_classes() -> Vec<ClassEntry> {
         });
     }
 
-    // ── Gruppen — primaere Labeling-Ebene ────────────────────────────────
+    // ── TON-EREIGNISSE (primaere Labeling-Ebene) ──────────────────────
+    //
+    // Note + alles was dranhängt = 1 Element.
     for (id, name, atoms) in [
-        ("group/single_note_eighth", "Einzel-Achtel", vec!["atom/notehead_filled", "atom/stem_up", "atom/flag_eighth_up"]),
-        ("group/single_note_quarter", "Einzel-Viertel", vec!["atom/notehead_filled", "atom/stem_up"]),
-        ("group/single_note_half", "Einzel-Halbe", vec!["atom/notehead_open", "atom/stem_up"]),
-        ("group/single_note_whole", "Einzel-Ganze", vec!["atom/notehead_whole"]),
-        ("group/beamed_group_2_eighths", "Zwei Achtel mit Balken", vec!["atom/notehead_filled", "atom/notehead_filled", "atom/stem_up", "atom/stem_up", "atom/beam_1"]),
-        ("group/beamed_group_3_eighths", "Drei Achtel mit Balken", vec![]),
-        ("group/beamed_group_4_eighths", "Vier Achtel mit Balken", vec![]),
-        ("group/beamed_group_4_sixteenths", "Vier Sechzehntel mit Doppelbalken", vec!["atom/notehead_filled", "atom/notehead_filled", "atom/notehead_filled", "atom/notehead_filled", "atom/beam_2"]),
-        ("group/beamed_group_8_sixteenths", "Acht Sechzehntel mit Doppelbalken", vec![]),
-        ("group/beamed_group_mixed_8_16", "Gemischte 8tel + 16tel mit Balken", vec![]),
-        ("group/chord_2_notes", "Akkord (2 Noten)", vec!["atom/notehead_filled", "atom/notehead_filled", "atom/stem_up"]),
-        ("group/chord_3_notes", "Akkord (3 Noten)", vec![]),
-        ("group/chord_4_notes", "Akkord (4 Noten)", vec![]),
-        ("group/chord_5_notes", "Akkord (5 Noten)", vec![]),
-        ("group/tied_pair", "Zwei Noten mit Bindebogen", vec![]),
-        ("group/tied_triple", "Drei Noten mit Bindebogen", vec![]),
-        ("group/triplet", "Triole", vec!["atom/notehead_filled", "atom/notehead_filled", "atom/notehead_filled", "atom/beam_1"]),
-        ("group/grace_before", "Vorschlagsnote", vec![]),
-        ("group/mordent", "Mordent (Triller-Schnoerkel)", vec![]),
-        ("group/trill", "Triller", vec![]),
-        ("group/clef_with_keysig", "Schluessel + Tonart-Vorzeichen", vec![]),
-        ("group/keysig_with_timesig", "Tonart + Taktangabe", vec![]),
+        ("ton/ganze", "Ganze Note (mit Drumrum)", vec!["atom/notenkopf_ganze"]),
+        ("ton/halbe", "Halbe Note", vec!["atom/notenkopf_offen", "atom/hals_oben"]),
+        ("ton/viertel", "Viertelnote", vec!["atom/notenkopf_gefuellt", "atom/hals_oben"]),
+        ("ton/achtel", "Achtelnote (mit Faehnchen)", vec!["atom/notenkopf_gefuellt", "atom/hals_oben", "atom/faehnchen_achtel"]),
+        ("ton/sechzehntel", "Sechzehntelnote (mit Faehnchen)", vec!["atom/notenkopf_gefuellt", "atom/hals_oben", "atom/faehnchen_sechzehntel"]),
+        ("ton/punktiert_halbe", "Punktierte Halbe", vec![]),
+        ("ton/punktiert_viertel", "Punktierte Viertel", vec![]),
+        ("ton/punktiert_achtel", "Punktierte Achtel", vec![]),
+        ("ton/vorschlag", "Vorschlagsnote (Acciaccatura)", vec![]),
+        ("akkord/2_noten", "Akkord (2 Noten, gleicher Hals)", vec!["atom/notenkopf_gefuellt", "atom/notenkopf_gefuellt", "atom/hals_oben"]),
+        ("akkord/3_noten", "Akkord (3 Noten)", vec![]),
+        ("akkord/4_noten", "Akkord (4 Noten)", vec![]),
+        ("akkord/5_noten_plus", "Akkord (5+ Noten)", vec![]),
+        ("balken/2_noten", "Beam-Gruppe (2 Noten)", vec![]),
+        ("balken/3_noten", "Beam-Gruppe (3 Noten / Triole)", vec![]),
+        ("balken/4_noten", "Beam-Gruppe (4 Noten)", vec![]),
+        ("balken/5_plus_noten", "Beam-Gruppe (5+ Noten)", vec![]),
+        ("balken/gemischt", "Beam-Gruppe gemischte Werte (8tel+16tel)", vec![]),
+        ("triole/freistehend", "Triole ohne Balken (3-er-Klammer)", vec![]),
+        ("bindebogen/phrase", "Phrase mit Bindebogen (Legato)", vec![]),
+        ("haltebogen/paar", "Haltebogen (zwei gleiche Noten)", vec![]),
     ] {
         out.push(ClassEntry {
             id: id.to_string(),
@@ -126,17 +128,193 @@ pub fn all_classes() -> Vec<ClassEntry> {
         });
     }
 
-    // ── Phrasen-Patterns (selten gelabelt, fuer fortgeschrittene UX) ─────
+    // ── PAUSEN ─────────────────────────────────────────────────────────
     for (id, name) in [
-        ("phrase/cadence_v_i", "Kadenz V-I"),
-        ("phrase/marcia_pattern", "Marsch-Pattern"),
-        ("phrase/polka_pattern", "Polka-Pattern"),
-        ("phrase/walzer_pattern", "Walzer-Pattern"),
+        ("pause/ganze", "Ganze Pause"),
+        ("pause/halbe", "Halbe Pause"),
+        ("pause/viertel", "Viertelpause"),
+        ("pause/achtel", "Achtelpause"),
+        ("pause/sechzehntel", "Sechzehntelpause"),
+        ("pause/zweiunddreissigstel", "32tel-Pause"),
+        ("pause/mehrtakt", "Mehrtaktpause (1 Strich + Zahl)"),
     ] {
         out.push(ClassEntry {
             id: id.to_string(),
             display_name: name.to_string(),
-            level: ClassLevel::Phrase,
+            level: ClassLevel::Group,
+            atoms: Vec::new(),
+        });
+    }
+
+    // ── SCHLUESSEL ─────────────────────────────────────────────────────
+    for (id, name) in [
+        ("schluessel/violin", "Violinschluessel (G)"),
+        ("schluessel/bass", "Bassschluessel (F)"),
+        ("schluessel/alt", "Altschluessel (C)"),
+        ("schluessel/tenor", "Tenorschluessel (C)"),
+        ("schluessel/percussion", "Percussion-Schluessel"),
+        ("schluessel/oktavierend_8va", "Oktavierender Schluessel (8va)"),
+    ] {
+        out.push(ClassEntry {
+            id: id.to_string(),
+            display_name: name.to_string(),
+            level: ClassLevel::Group,
+            atoms: Vec::new(),
+        });
+    }
+
+    // ── TAKTSTRICHE ────────────────────────────────────────────────────
+    for (id, name) in [
+        ("takt/normal", "Taktstrich (einfach)"),
+        ("takt/doppel", "Doppelstrich"),
+        ("takt/schluss", "Schlussstrich"),
+        ("takt/wdh_anfang", "Wiederholungsanfang ‖:"),
+        ("takt/wdh_ende", "Wiederholungsende :‖"),
+        ("takt/wdh_doppel", "Wiederholungsende+anfang :‖:"),
+        ("takt/gestrichelt", "Gestrichelter Taktstrich"),
+    ] {
+        out.push(ClassEntry {
+            id: id.to_string(),
+            display_name: name.to_string(),
+            level: ClassLevel::Group,
+            atoms: Vec::new(),
+        });
+    }
+
+    // ── TONART (Vorzeichen am Schluessel) ─────────────────────────────
+    for (id, name) in [
+        ("tonart/1_kreuz", "1 Kreuz (G-Dur / e-moll)"),
+        ("tonart/2_kreuze", "2 Kreuze (D-Dur / h-moll)"),
+        ("tonart/3_kreuze", "3 Kreuze (A-Dur)"),
+        ("tonart/4_kreuze", "4 Kreuze (E-Dur)"),
+        ("tonart/5_kreuze", "5 Kreuze (H-Dur)"),
+        ("tonart/1_be", "1 ♭ (F-Dur / d-moll)"),
+        ("tonart/2_be", "2 ♭ (B-Dur)"),
+        ("tonart/3_be", "3 ♭ (Es-Dur)"),
+        ("tonart/4_be", "4 ♭ (As-Dur)"),
+        ("tonart/5_be", "5 ♭ (Des-Dur)"),
+        ("tonart/keine", "Keine Vorzeichen (C-Dur)"),
+    ] {
+        out.push(ClassEntry {
+            id: id.to_string(),
+            display_name: name.to_string(),
+            level: ClassLevel::Group,
+            atoms: Vec::new(),
+        });
+    }
+
+    // ── TAKTART ────────────────────────────────────────────────────────
+    for (id, name) in [
+        ("taktart/2_4", "2/4-Takt"),
+        ("taktart/3_4", "3/4-Takt"),
+        ("taktart/4_4", "4/4-Takt"),
+        ("taktart/3_8", "3/8-Takt"),
+        ("taktart/6_8", "6/8-Takt"),
+        ("taktart/9_8", "9/8-Takt"),
+        ("taktart/12_8", "12/8-Takt"),
+        ("taktart/c_takt", "C (4/4)"),
+        ("taktart/alla_breve", "Alla breve ¢ (2/2)"),
+        ("taktart/anders", "Andere Taktart"),
+    ] {
+        out.push(ClassEntry {
+            id: id.to_string(),
+            display_name: name.to_string(),
+            level: ClassLevel::Group,
+            atoms: Vec::new(),
+        });
+    }
+
+    // ── DYNAMIK (Buchstaben — eigenes Element pro Position) ───────────
+    for (id, name) in [
+        ("dyn/p", "p (piano)"),
+        ("dyn/pp", "pp (pianissimo)"),
+        ("dyn/ppp", "ppp"),
+        ("dyn/mp", "mp (mezzopiano)"),
+        ("dyn/mf", "mf (mezzoforte)"),
+        ("dyn/f", "f (forte)"),
+        ("dyn/ff", "ff (fortissimo)"),
+        ("dyn/fff", "fff"),
+        ("dyn/sfz", "sfz (sforzando)"),
+        ("dyn/sf", "sf"),
+        ("dyn/fp", "fp"),
+        ("dyn/cresc_text", "cresc. (Text)"),
+        ("dyn/decresc_text", "decresc. / dim. (Text)"),
+    ] {
+        out.push(ClassEntry {
+            id: id.to_string(),
+            display_name: name.to_string(),
+            level: ClassLevel::Group,
+            atoms: Vec::new(),
+        });
+    }
+
+    // ── DYNAMIK-GABELN (Hairpins — eigenes Element, AUSNAHME) ────────
+    for (id, name) in [
+        ("hairpin/crescendo", "Crescendo-Gabel <"),
+        ("hairpin/decrescendo", "Decrescendo-Gabel >"),
+    ] {
+        out.push(ClassEntry {
+            id: id.to_string(),
+            display_name: name.to_string(),
+            level: ClassLevel::Group,
+            atoms: Vec::new(),
+        });
+    }
+
+    // ── TEXT (eigene Elemente, AUSNAHME) ───────────────────────────────
+    for (id, name) in [
+        ("text/tempo", "Tempoangabe (Allegro, ♩=120)"),
+        ("text/ausdruck", "Ausdruck (espressivo, dolce)"),
+        ("text/taktnummer", "Taktnummer / Bar Number"),
+        ("text/sprungmarke", "Sprungmarke (D.C., D.S., Fine, al Coda)"),
+        ("text/probenzeichen", "Probenzeichen (A, B, C in Box)"),
+        ("text/instrument", "Instrumentenname"),
+        ("text/akkordsymbol", "Gitarrenakkord (C7, Am, ...)"),
+        ("text/liedtext", "Liedtext / Lyric"),
+        ("text/anweisung", "Spielanweisung (mit Daempfer, pizz., ...)"),
+        ("text/sonstiges", "Sonstiger Text"),
+    ] {
+        out.push(ClassEntry {
+            id: id.to_string(),
+            display_name: name.to_string(),
+            level: ClassLevel::Group,
+            atoms: Vec::new(),
+        });
+    }
+
+    // ── MARKEN / ZEICHEN ──────────────────────────────────────────────
+    for (id, name) in [
+        ("marke/segno", "Segno (𝄋)"),
+        ("marke/coda", "Coda (𝄌)"),
+        ("marke/atem", "Atemzeichen (')"),
+        ("marke/cesur", "Cesur ( // )"),
+        ("marke/voltenklammer_1", "Voltenklammer 1 (1.|—)"),
+        ("marke/voltenklammer_2", "Voltenklammer 2 (2.|—)"),
+        ("marke/oktava_oben", "Oktava 8va (eine Oktave hoeher)"),
+        ("marke/oktava_unten", "Oktava 8vb (eine Oktave tiefer)"),
+        ("marke/pedal_ab", "Ped (Pedal druecken)"),
+        ("marke/pedal_auf", "* (Pedal loslassen)"),
+        ("marke/akkolade", "Akkolade (geschweifte Klammer)"),
+    ] {
+        out.push(ClassEntry {
+            id: id.to_string(),
+            display_name: name.to_string(),
+            level: ClassLevel::Group,
+            atoms: Vec::new(),
+        });
+    }
+
+    // ── SPEZIAL (Meta-Antworten) ──────────────────────────────────────
+    for (id, name) in [
+        ("spezial/kein_element", "Kein gueltiges Element (Rauschen / kaputter bbox)"),
+        ("spezial/unklar", "Unklar — kann nicht zuordnen"),
+        ("spezial/teil_eines_elements", "Nur Teil eines Elements (zu klein gefasst)"),
+        ("spezial/mehrere_elemente", "Mehrere Elemente in einer Box (zu gross gefasst)"),
+    ] {
+        out.push(ClassEntry {
+            id: id.to_string(),
+            display_name: name.to_string(),
+            level: ClassLevel::Group,
             atoms: Vec::new(),
         });
     }
@@ -178,22 +356,22 @@ mod tests {
         let cs = all_classes();
         let group = cs
             .iter()
-            .find(|c| c.id == "group/beamed_group_4_sixteenths")
-            .expect("4 sixteenths Gruppe vorhanden");
+            .find(|c| c.id == "ton/viertel")
+            .expect("Viertelnote-Gruppe vorhanden");
         assert_eq!(group.level, ClassLevel::Group);
         assert!(!group.atoms.is_empty());
     }
 
     #[test]
     fn drill_down_returns_atoms() {
-        let drilled = drill_down("group/single_note_quarter");
+        let drilled = drill_down("ton/viertel");
         assert!(!drilled.is_empty());
         assert!(drilled.iter().all(|c| c.level == ClassLevel::Atom));
     }
 
     #[test]
     fn drill_down_unknown_group_is_empty() {
-        let drilled = drill_down("group/does_not_exist");
+        let drilled = drill_down("ton/does_not_exist");
         assert!(drilled.is_empty());
     }
 
@@ -201,8 +379,8 @@ mod tests {
     fn classes_of_level_filters() {
         let atoms = classes_of_level(ClassLevel::Atom);
         let groups = classes_of_level(ClassLevel::Group);
-        assert!(atoms.len() > 30);
-        assert!(groups.len() > 15);
+        assert!(atoms.len() > 20);
+        assert!(groups.len() > 40);
         assert!(atoms.iter().all(|c| c.level == ClassLevel::Atom));
         assert!(groups.iter().all(|c| c.level == ClassLevel::Group));
     }

--- a/src/omr-rust/crates/omr-labeler/src/frontend.rs
+++ b/src/omr-rust/crates/omr-labeler/src/frontend.rs
@@ -7,3 +7,5 @@
 pub const INDEX_HTML: &str = include_str!("../web/index.html");
 pub const APP_JS: &str = include_str!("../web/app.js");
 pub const STYLE_CSS: &str = include_str!("../web/style.css");
+pub const ANNOTATE_HTML: &str = include_str!("../web/annotate.html");
+pub const ANNOTATE_JS: &str = include_str!("../web/annotate.js");

--- a/src/omr-rust/crates/omr-labeler/src/main.rs
+++ b/src/omr-rust/crates/omr-labeler/src/main.rs
@@ -5,11 +5,12 @@
 //! standardmäßig den Browser auf der UI.
 
 use clap::Parser;
-use omr_labeler::active_learning::LabelingQueue;
-use omr_labeler::api::{router, AppState};
+use omr_labeler::active_learning::{LabelingQueue, Level, QueueItem};
+use omr_labeler::api::{default_class_top_k, router, AppState};
 use omr_labeler::persistence::LabelDb;
 use omr_labeler::pipeline::PipelineState;
 use omr_labeler::synthetic_warmup::{load_synthetic_corpus, seed_queue_with_synthetic};
+use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -82,26 +83,115 @@ async fn main() -> anyhow::Result<()> {
                     warn!("PDF-Vorverarbeitung fehlgeschlagen ({}): {}", pdf.display(), e);
                 }
             }
-            // Initial-Items der Queue: ein Line-Item pro System.
+
+            // Bereits persistierte Labels aus der DB lesen, damit wir
+            // nicht doppelt fragen. Wir brauchen drei Sets:
+            //  * line_done    : System-IDs mit Line-Label (yes/no)
+            //  * element_done : Element-IDs mit Element-Label (yes/no)
+            //  * yes_elements : Element-IDs, die Element=Yes bekommen haben
+            //  * class_done   : Element-IDs mit Class-Label
+            let (line_done, element_done, yes_elements, class_done) = {
+                let guard = state_bg.db.lock().expect("db mutex poisoned");
+                match guard.as_ref() {
+                    Some(db) => match db.get_all_labels() {
+                        Ok(all) => {
+                            let mut line_done = HashSet::new();
+                            let mut element_done = HashSet::new();
+                            let mut yes_elements = HashSet::new();
+                            let mut class_done = HashSet::new();
+                            for l in all {
+                                match l.level.as_str() {
+                                    "line" => {
+                                        line_done.insert(l.item_ref.clone());
+                                    }
+                                    "element" => {
+                                        element_done.insert(l.item_ref.clone());
+                                        if l.decision == "yes" {
+                                            yes_elements.insert(l.item_ref.clone());
+                                        }
+                                    }
+                                    "class" => {
+                                        class_done.insert(l.item_ref.clone());
+                                    }
+                                    _ => {}
+                                }
+                            }
+                            (line_done, element_done, yes_elements, class_done)
+                        }
+                        Err(e) => {
+                            warn!("Konnte bestehende Labels nicht lesen: {}", e);
+                            (
+                                HashSet::new(),
+                                HashSet::new(),
+                                HashSet::new(),
+                                HashSet::new(),
+                            )
+                        }
+                    },
+                    None => (
+                        HashSet::new(),
+                        HashSet::new(),
+                        HashSet::new(),
+                        HashSet::new(),
+                    ),
+                }
+            };
+            info!(
+                "Bestehende Labels: line={} element={} yes_elements={} class={}",
+                line_done.len(),
+                element_done.len(),
+                yes_elements.len(),
+                class_done.len()
+            );
+
+            // Initial-Items der Queue:
+            //  * ein Line-Item pro System ohne Line-Label
+            //  * ein Element-Item pro Element ohne Element-Label
+            //  * ein Class-Item pro yes-Element ohne Class-Label
             let mut q = state_bg.queue.write().await;
             let p = state_bg.pipeline.read().await;
             let mut q_owned = std::mem::take(&mut *q);
+            let mut line_pushed = 0usize;
+            let mut element_pushed = 0usize;
+            let mut class_pushed = 0usize;
             for sys in &p.systems {
-                q_owned.push(
-                    omr_labeler::active_learning::Level::Line,
-                    sys.id.clone(),
-                    None,
-                    0.5,
-                );
+                if line_done.contains(&sys.id) {
+                    continue;
+                }
+                q_owned.push(Level::Line, sys.id.clone(), None, 0.5);
+                line_pushed += 1;
             }
             for elt in &p.elements {
-                q_owned.push(
-                    omr_labeler::active_learning::Level::Element,
-                    elt.system_id.clone(),
-                    Some(elt.id.clone()),
-                    0.7,
-                );
+                if !element_done.contains(&elt.id) {
+                    q_owned.push(
+                        Level::Element,
+                        elt.system_id.clone(),
+                        Some(elt.id.clone()),
+                        0.7,
+                    );
+                    element_pushed += 1;
+                }
+                // Backfill: yes-Elemente ohne Class-Label bekommen ein Class-Item.
+                if yes_elements.contains(&elt.id) && !class_done.contains(&elt.id) {
+                    q_owned.push_item(QueueItem {
+                        id: 0,
+                        level: Level::Class,
+                        uncertainty: 0.95,
+                        system_id: elt.system_id.clone(),
+                        element_id: Some(elt.id.clone()),
+                        suggested_class: None,
+                        top_k: default_class_top_k(),
+                    });
+                    class_pushed += 1;
+                }
             }
+            info!(
+                "Queue gefuellt: line+={} element+={} class+={} (gesamt {} items)",
+                line_pushed,
+                element_pushed,
+                class_pushed,
+                q_owned.len()
+            );
             q_owned.re_prioritize();
             *q = q_owned;
         });

--- a/src/omr-rust/crates/omr-labeler/src/main.rs
+++ b/src/omr-rust/crates/omr-labeler/src/main.rs
@@ -6,7 +6,7 @@
 
 use clap::Parser;
 use omr_labeler::active_learning::{LabelingQueue, Level, QueueItem};
-use omr_labeler::api::{default_class_top_k, router, AppState};
+use omr_labeler::api::{router, top_k_for_class_item, AppState};
 use omr_labeler::persistence::LabelDb;
 use omr_labeler::pipeline::PipelineState;
 use omr_labeler::synthetic_warmup::{load_synthetic_corpus, seed_queue_with_synthetic};
@@ -173,6 +173,7 @@ async fn main() -> anyhow::Result<()> {
                 }
                 // Backfill: yes-Elemente ohne Class-Label bekommen ein Class-Item.
                 if yes_elements.contains(&elt.id) && !class_done.contains(&elt.id) {
+                    let top_k = top_k_for_class_item(state_bg.as_ref());
                     q_owned.push_item(QueueItem {
                         id: 0,
                         level: Level::Class,
@@ -180,7 +181,7 @@ async fn main() -> anyhow::Result<()> {
                         system_id: elt.system_id.clone(),
                         element_id: Some(elt.id.clone()),
                         suggested_class: None,
-                        top_k: default_class_top_k(),
+                        top_k,
                     });
                     class_pushed += 1;
                 }

--- a/src/omr-rust/crates/omr-labeler/src/persistence.rs
+++ b/src/omr-rust/crates/omr-labeler/src/persistence.rs
@@ -158,6 +158,40 @@ impl LabelDb {
         Ok(count.max(0) as u64)
     }
 
+    /// Liefert die meistgenutzten Class-Decisions aus der DB, sortiert nach
+    /// Anzahl (desc) und letzter Nutzung (desc). Format: `(class_id, count)`,
+    /// ohne `class:`-Praefix. Damit kann der Labeler Top-K-Vorschlaege auf
+    /// echte User-Praeferenzen (inkl. Custom-Klassen) stuetzen.
+    pub fn recent_class_decisions(&self, limit: u32) -> Result<Vec<(String, u64)>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT decision, COUNT(*) as cnt, MAX(created_at) as last
+             FROM labels
+             WHERE level = 'class' AND decision LIKE 'class:%'
+             GROUP BY decision
+             ORDER BY cnt DESC, last DESC
+             LIMIT ?1",
+        )?;
+        let rows = stmt.query_map(params![limit as i64], |row| {
+            let decision: String = row.get(0)?;
+            let count: i64 = row.get(1)?;
+            Ok((decision, count))
+        })?;
+        let mut out = Vec::new();
+        for r in rows {
+            let (decision, count) = r?;
+            // "class:foo" → "foo"
+            let class_id = decision
+                .strip_prefix("class:")
+                .unwrap_or(&decision)
+                .to_string();
+            if class_id.is_empty() {
+                continue;
+            }
+            out.push((class_id, count.max(0) as u64));
+        }
+        Ok(out)
+    }
+
     /// Liefert alle Labels (sortiert nach ID).
     pub fn get_all_labels(&self) -> Result<Vec<Label>> {
         let mut stmt = self.conn.prepare(
@@ -235,5 +269,40 @@ mod tests {
         let popped = db.pop_last_label().unwrap().unwrap();
         assert_eq!(popped.item_ref, "elt-1");
         assert_eq!(db.count_labels("").unwrap(), 1);
+    }
+
+    #[test]
+    fn recent_class_decisions_sorted_by_count() {
+        let db = LabelDb::open_in_memory().unwrap();
+        // Drei verschiedene Klassen mit unterschiedlichen Counts.
+        for _ in 0..5 {
+            db.save_label(&Label::new("class", "class:Gitarrenakkord", "elt-x"))
+                .unwrap();
+        }
+        for _ in 0..2 {
+            db.save_label(&Label::new("class", "class:Taktnummer", "elt-y"))
+                .unwrap();
+        }
+        db.save_label(&Label::new("class", "class:atom/clef_treble", "elt-z"))
+            .unwrap();
+        // Non-class-Label darf nicht auftauchen.
+        db.save_label(&Label::new("element", "yes", "elt-w")).unwrap();
+
+        let recent = db.recent_class_decisions(10).unwrap();
+        assert_eq!(recent.len(), 3);
+        assert_eq!(recent[0], ("Gitarrenakkord".to_string(), 5));
+        assert_eq!(recent[1], ("Taktnummer".to_string(), 2));
+        assert_eq!(recent[2], ("atom/clef_treble".to_string(), 1));
+    }
+
+    #[test]
+    fn recent_class_decisions_respects_limit() {
+        let db = LabelDb::open_in_memory().unwrap();
+        for i in 0..6 {
+            db.save_label(&Label::new("class", &format!("class:cls{}", i), "elt"))
+                .unwrap();
+        }
+        let recent = db.recent_class_decisions(3).unwrap();
+        assert_eq!(recent.len(), 3);
     }
 }

--- a/src/omr-rust/crates/omr-labeler/src/persistence.rs
+++ b/src/omr-rust/crates/omr-labeler/src/persistence.rs
@@ -52,6 +52,41 @@ impl Label {
     }
 }
 
+/// Eine vom User manuell gezogene Bounding-Box-Annotation.
+///
+/// Im Gegensatz zu `Label` (Y/N-Antworten zu vorhandenen Items) speichert
+/// `Annotation` die User-eigene Box-Position als Gold-Standard fuer
+/// Detector-Training. Koordinaten sind im *gerenderten Crop-Bild* des Systems
+/// (gleiche Skalierung wie /api/system/{id}/image).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Annotation {
+    pub id: Option<i64>,
+    pub system_id: String,
+    pub x: i32,
+    pub y: i32,
+    pub w: i32,
+    pub h: i32,
+    pub class_id: String,
+    pub created_at: String,
+    pub user_session: Option<String>,
+}
+
+impl Annotation {
+    pub fn new(system_id: impl Into<String>, x: i32, y: i32, w: i32, h: i32, class_id: impl Into<String>) -> Self {
+        Self {
+            id: None,
+            system_id: system_id.into(),
+            x,
+            y,
+            w,
+            h,
+            class_id: class_id.into(),
+            created_at: now_iso8601(),
+            user_session: None,
+        }
+    }
+}
+
 fn now_iso8601() -> String {
     // Vermeidet die `chrono`-Abhängigkeit. Nutzt SystemTime und
     // formatiert "YYYY-MM-DDTHH:MM:SSZ" via `humantime`-freier Variante.
@@ -121,6 +156,20 @@ impl LabelDb {
             );
             CREATE INDEX IF NOT EXISTS idx_labels_level ON labels(level);
             CREATE INDEX IF NOT EXISTS idx_labels_item_ref ON labels(item_ref);
+
+            CREATE TABLE IF NOT EXISTS annotations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                system_id TEXT NOT NULL,
+                x INTEGER NOT NULL,
+                y INTEGER NOT NULL,
+                w INTEGER NOT NULL,
+                h INTEGER NOT NULL,
+                class_id TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                user_session TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_annotations_system_id ON annotations(system_id);
+            CREATE INDEX IF NOT EXISTS idx_annotations_class_id ON annotations(class_id);
             "#,
         )?;
         Ok(())
@@ -245,6 +294,120 @@ impl LabelDb {
         }
         Ok(row)
     }
+
+    // ---- Annotation-CRUD ---------------------------------------------------
+
+    /// Speichert eine User-gezogene Annotation.
+    pub fn save_annotation(&self, ann: &Annotation) -> Result<i64> {
+        self.conn.execute(
+            "INSERT INTO annotations (system_id, x, y, w, h, class_id, created_at, user_session)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                ann.system_id,
+                ann.x,
+                ann.y,
+                ann.w,
+                ann.h,
+                ann.class_id,
+                ann.created_at,
+                ann.user_session,
+            ],
+        )?;
+        Ok(self.conn.last_insert_rowid())
+    }
+
+    /// Aktualisiert die Klasse einer bestehenden Annotation (Reclassify).
+    pub fn update_annotation_class(&self, id: i64, class_id: &str) -> Result<()> {
+        self.conn.execute(
+            "UPDATE annotations SET class_id = ?1 WHERE id = ?2",
+            params![class_id, id],
+        )?;
+        Ok(())
+    }
+
+    /// Loescht eine Annotation.
+    pub fn delete_annotation(&self, id: i64) -> Result<()> {
+        self.conn
+            .execute("DELETE FROM annotations WHERE id = ?1", params![id])?;
+        Ok(())
+    }
+
+    /// Liefert alle Annotationen fuer ein System.
+    pub fn annotations_for_system(&self, system_id: &str) -> Result<Vec<Annotation>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, system_id, x, y, w, h, class_id, created_at, user_session
+             FROM annotations WHERE system_id = ?1 ORDER BY id ASC",
+        )?;
+        let rows = stmt.query_map(params![system_id], |row| {
+            Ok(Annotation {
+                id: Some(row.get(0)?),
+                system_id: row.get(1)?,
+                x: row.get(2)?,
+                y: row.get(3)?,
+                w: row.get(4)?,
+                h: row.get(5)?,
+                class_id: row.get(6)?,
+                created_at: row.get(7)?,
+                user_session: row.get(8)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+
+    /// Liefert pro System die Anzahl der Annotationen (fuer die System-Liste).
+    pub fn annotation_counts_per_system(&self) -> Result<Vec<(String, u64)>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT system_id, COUNT(*) FROM annotations GROUP BY system_id ORDER BY system_id",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            let sys: String = row.get(0)?;
+            let cnt: i64 = row.get(1)?;
+            Ok((sys, cnt.max(0) as u64))
+        })?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+
+    /// Anzahl Annotationen insgesamt.
+    pub fn count_annotations(&self) -> Result<u64> {
+        let count: i64 = self
+            .conn
+            .query_row("SELECT COUNT(*) FROM annotations", [], |row| row.get(0))?;
+        Ok(count.max(0) as u64)
+    }
+
+    /// Liefert alle Annotationen (fuer Export).
+    pub fn get_all_annotations(&self) -> Result<Vec<Annotation>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, system_id, x, y, w, h, class_id, created_at, user_session
+             FROM annotations ORDER BY id ASC",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(Annotation {
+                id: Some(row.get(0)?),
+                system_id: row.get(1)?,
+                x: row.get(2)?,
+                y: row.get(3)?,
+                w: row.get(4)?,
+                h: row.get(5)?,
+                class_id: row.get(6)?,
+                created_at: row.get(7)?,
+                user_session: row.get(8)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
+    }
 }
 
 #[cfg(test)]
@@ -304,5 +467,33 @@ mod tests {
         }
         let recent = db.recent_class_decisions(3).unwrap();
         assert_eq!(recent.len(), 3);
+    }
+
+    #[test]
+    fn save_and_query_annotations() {
+        let db = LabelDb::open_in_memory().unwrap();
+        let id1 = db
+            .save_annotation(&Annotation::new("sys-1", 10, 20, 30, 40, "ton/viertel"))
+            .unwrap();
+        db.save_annotation(&Annotation::new("sys-1", 50, 20, 30, 40, "ton/achtel"))
+            .unwrap();
+        db.save_annotation(&Annotation::new("sys-2", 10, 20, 30, 40, "akkord/2_noten"))
+            .unwrap();
+
+        assert_eq!(db.count_annotations().unwrap(), 3);
+        let s1 = db.annotations_for_system("sys-1").unwrap();
+        assert_eq!(s1.len(), 2);
+        assert_eq!(s1[0].class_id, "ton/viertel");
+
+        db.update_annotation_class(id1, "ton/halbe").unwrap();
+        let s1 = db.annotations_for_system("sys-1").unwrap();
+        let updated = s1.iter().find(|a| a.id == Some(id1)).unwrap();
+        assert_eq!(updated.class_id, "ton/halbe");
+
+        db.delete_annotation(id1).unwrap();
+        assert_eq!(db.count_annotations().unwrap(), 2);
+
+        let counts = db.annotation_counts_per_system().unwrap();
+        assert_eq!(counts.len(), 2);
     }
 }

--- a/src/omr-rust/crates/omr-labeler/src/pipeline.rs
+++ b/src/omr-rust/crates/omr-labeler/src/pipeline.rs
@@ -23,6 +23,11 @@ pub struct RectifiedSystem {
     pub system_idx: usize,
     pub bbox_top: u32,
     pub bbox_bottom: u32,
+    /// Vollständiges Page-Bild (ungeschnitten), gleiche Page-Index.
+    /// Wird für Kontext-View benötigt (oben/unten drumrum).
+    pub page_image: GrayImage,
+    /// Y-Offset des Systems im Page-Bild (top in page-Koordinaten).
+    pub page_top: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -48,6 +53,14 @@ impl PipelineState {
     }
 
     /// Rekursiver Walk durch `dir`; sammelt alle `*.pdf`-Dateien.
+    ///
+    /// Filtert automatisch:
+    /// - Test-/Junk-Files mit Pattern "conduct" oder "test" im Filename
+    /// - Bekannte Multi-Staff-Stuecke (Klavier-Begleitung), die kein Blasmusik-
+    ///   Material sind (Dichterliebe, Schumann, Klavier).
+    /// - Files unter 1 KB (offensichtlich kaputt)
+    ///
+    /// Damit landen nur realistische Single-Staff-Blasmusik-Stimmen im Tool.
     pub fn scan_filestore(dir: &Path) -> Vec<PathBuf> {
         let mut out = Vec::new();
         if !dir.exists() {
@@ -64,9 +77,14 @@ impl PipelineState {
                 if p.is_dir() {
                     stack.push(p);
                 } else if let Some(ext) = p.extension().and_then(|s| s.to_str()) {
-                    if ext.eq_ignore_ascii_case("pdf") {
-                        out.push(p);
+                    if !ext.eq_ignore_ascii_case("pdf") {
+                        continue;
                     }
+                    if !is_realistic_blasmusik_pdf(&p) {
+                        tracing::debug!("Filter: ueberspringe {} (kein Blasmusik-Material)", p.display());
+                        continue;
+                    }
+                    out.push(p);
                 }
             }
         }
@@ -99,6 +117,19 @@ impl PipelineState {
             if systems.is_empty() {
                 continue;
             }
+            // Filter: ueberspringe Multi-Staff-Seiten (Klavier-Grand-Staff,
+            // Chor-Partitur o.ae.). Blasmusik-Stimmen sind immer Single-Staff
+            // pro Zeile. Heuristik: wenn zwei aufeinanderfolgende Systeme
+            // weniger als 3.5 * line_spacing voneinander entfernt sind,
+            // gehoeren sie wahrscheinlich zu einem Grand-Staff/Bracket.
+            if is_multi_staff_page(&systems) {
+                tracing::info!(
+                    "{}#p{}: multi-staff page detected — skipping (kein Blasmusik-Material)",
+                    short_id(pdf),
+                    page_idx
+                );
+                continue;
+            }
             let staff_removed = omr_staff::remove_staff(&bin, &systems);
             for (sys_idx, system) in systems.iter().enumerate() {
                 let (top, bottom) = system_bbox(&gray, system);
@@ -115,9 +146,10 @@ impl PipelineState {
                     gray.width(),
                     crop_h,
                 );
-                let rects = detect_elements(&cropped_removed, system, top);
+                let rects_raw = detect_elements(&cropped_removed, system, top);
 
-                // Detect logical groups for suggested class labels.
+                // Logical-Groups + Slurs: das sind die *primaeren* Elemente.
+                // Atome die zu einer Gruppe gehoeren werden NICHT einzeln gelabelt.
                 let noteheads = omr_symbols::detect_noteheads(&staff_removed, std::slice::from_ref(system));
                 let stems = omr_symbols::stems::detect_stems(&staff_removed, &noteheads, system.line_spacing);
                 let beams = omr_symbols::detect_beams(&staff_removed, system.line_spacing);
@@ -128,24 +160,118 @@ impl PipelineState {
                     &beams,
                     adjusted_system.line_spacing,
                 );
+                let slurs = omr_symbols::slurs::detect_slurs(
+                    &staff_removed,
+                    &noteheads,
+                    std::slice::from_ref(system),
+                );
 
-                for (elt_idx, r) in rects.iter().enumerate() {
+                // Sammle "primary elements":
+                // 1. Logical Groups (BeamedGroup, ChordCluster, ...) — bbox + class_id
+                // 2. Slurs/Ties — werden mit ueberlapenden Logical Groups
+                //    zu einem grossen Element zusammengezogen
+                // 3. Standalone CC-Rects die NICHT von einer Group abgedeckt
+                //    sind (Clefs, KeySigs, TimeSigs, isolierte Symbole)
+                //    — gemerged via merge_close_rects (4/4-Taktangabe!)
+                let mut primary_elements: Vec<(Rect, Option<String>)> = Vec::new();
+
+                // Step A: Logical groups, mit Slur-Erweiterung wenn vorhanden
+                let mut logical_used = vec![false; logical_groups.len()];
+                let mut slur_used = vec![false; slurs.len()];
+
+                for (gi, g) in logical_groups.iter().enumerate() {
+                    if logical_used[gi] {
+                        continue;
+                    }
+                    logical_used[gi] = true;
+                    // crop-koordinaten — Logical groups sind in page-koordinaten,
+                    // slur bbox ebenfalls. Beide in crop-rel transformieren.
+                    let mut bbox = rect_to_crop(&g.bbox, top);
+                    let mut class_id = Some(g.class_id.clone());
+
+                    // Pruefe Slurs die mit dieser Group ueberlappen
+                    for (si, s) in slurs.iter().enumerate() {
+                        if slur_used[si] {
+                            continue;
+                        }
+                        if rects_overlap_or_touch(&g.bbox, &s.bbox, system.line_spacing) {
+                            // Bbox erweitern, klasse auf 'slurred' setzen wenn klein,
+                            // sonst class behalten + Slur hinzufuegen.
+                            slur_used[si] = true;
+                            let s_crop = rect_to_crop(&s.bbox, top);
+                            bbox = union_rect(bbox, s_crop);
+                            if class_id.as_deref() == Some("group/single_note")
+                                || class_id.as_deref() == Some("group/single_note_quarter")
+                            {
+                                class_id = Some(if s.is_tie {
+                                    "group/tied_pair".to_string()
+                                } else {
+                                    "group/slurred_phrase".to_string()
+                                });
+                            }
+                            // Auch andere Logical Groups die unter dem Slur liegen mergen
+                            for (gj, g2) in logical_groups.iter().enumerate() {
+                                if logical_used[gj] {
+                                    continue;
+                                }
+                                if rects_overlap_or_touch(&g2.bbox, &s.bbox, system.line_spacing) {
+                                    logical_used[gj] = true;
+                                    let g2_crop = rect_to_crop(&g2.bbox, top);
+                                    bbox = union_rect(bbox, g2_crop);
+                                    if !s.is_tie {
+                                        class_id = Some("group/slurred_phrase".to_string());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    primary_elements.push((bbox, class_id));
+                }
+
+                // Step B: Slurs ohne uebersnappende Logical Groups
+                for (si, s) in slurs.iter().enumerate() {
+                    if slur_used[si] {
+                        continue;
+                    }
+                    let bbox = rect_to_crop(&s.bbox, top);
+                    let class_id = if s.is_tie {
+                        "group/tied_pair".to_string()
+                    } else {
+                        "group/slurred_phrase".to_string()
+                    };
+                    primary_elements.push((bbox, Some(class_id)));
+                }
+
+                // Step C: CC-Rects die NICHT in einem Logical-Group/Slur liegen
+                // werden gemerged + als standalone-Elements aufgenommen.
+                let standalone_rects: Vec<Rect> = rects_raw
+                    .iter()
+                    .filter(|r| {
+                        !primary_elements.iter().any(|(pb, _)| rect_iou_or_inside(r, pb) > 0.4)
+                    })
+                    .copied()
+                    .collect();
+                let standalone_merged = merge_close_rects(&standalone_rects, system.line_spacing);
+                for r in standalone_merged {
+                    primary_elements.push((r, None));
+                }
+
+                // X-sortieren fuer stabiles Labeling-Ordering.
+                primary_elements.sort_by_key(|(r, _)| (r.x, r.y));
+
+                for (elt_idx, (r, class_id)) in primary_elements.iter().enumerate() {
                     let patch = extract_patch(&cropped, r, 64);
                     let emb = encoder
                         .embed(&patch)
                         .map(|e| e.vec)
                         .unwrap_or_default();
                     let elt_id = format!("{}#e{}", id, elt_idx);
-                    let suggested_class = logical_groups.iter().find(|g| {
-                        let b = &g.bbox;
-                        r.x < b.x + b.w && r.x + r.w > b.x && r.y < b.y + b.h && r.y + r.h > b.y
-                    }).map(|g| g.class_id.clone());
                     self.elements.push(DetectedElement {
                         id: elt_id,
                         system_id: id.clone(),
                         bbox: *r,
                         patch,
-                        suggested_class,
+                        suggested_class: class_id.clone(),
                         hog_embedding: emb,
                     });
                 }
@@ -157,6 +283,8 @@ impl PipelineState {
                     system_idx: sys_idx,
                     bbox_top: top,
                     bbox_bottom: bottom,
+                    page_image: gray.clone(),
+                    page_top: top,
                 });
                 added_systems += 1;
             }
@@ -356,10 +484,285 @@ fn resize_nn(src: &GrayImage, w: u32, h: u32) -> GrayImage {
     dst
 }
 
+/// Filter: ist eine PDF realistisches Blasmusik-Material?
+///
+/// Skip-Liste basiert auf User-Vorgabe: "fast alle unsere Noten sind nur eine
+/// Stimme oder maximal 2 stimmen aber in der gleichen Zeile. Wir haben keine
+/// noten mit mehreren Systemen."
+///
+/// - Skip Files unter 1 KB (Junk-Uploads, leere Test-Files)
+/// - Skip Filenames mit "conduct" / "test" / "demo" / "sample" (Test-Daten)
+/// - Skip Multi-Staff-Stuecke nach Filename: "Dichterliebe", "Schumann",
+///   "Klavier", "piano-trio", etc.
+fn is_realistic_blasmusik_pdf(path: &Path) -> bool {
+    let meta = match std::fs::metadata(path) {
+        Ok(m) => m,
+        Err(_) => return false,
+    };
+    if meta.len() < 1024 {
+        return false;
+    }
+    let name = match path.file_name().and_then(|s| s.to_str()) {
+        Some(s) => s.to_ascii_lowercase(),
+        None => return true,
+    };
+    // Skip Junk/Test-Uploads
+    for skip in [
+        "conduct",
+        "sheetstorm-test",
+        "sheetstorm-demo",
+        "sheetstorm-sample",
+    ] {
+        if name.contains(skip) {
+            return false;
+        }
+    }
+    // Skip Multi-Staff-Stuecke (Klavier-Begleitung, Lieder, Klavier-Trios)
+    for skip in [
+        "dichterliebe",
+        "schumann",
+        "klaviertrio",
+        "piano-trio",
+        "klaviersonate",
+        "piano-sonata",
+        "lied-",
+        "_lied_",
+    ] {
+        if name.contains(skip) {
+            return false;
+        }
+    }
+    true
+}
+
+/// Erkennt ob eine Page Multi-Staff-Material enthaelt (Klavier-Grand-Staff,
+/// Chor-Partitur, Orchestral-Score). Solche Seiten sind kein realistisches
+/// Blasmusik-Material und werden im Labeler ausgeblendet.
+///
+/// Heuristik: zwei Systeme die weniger als 3.5 × line_spacing voneinander
+/// entfernt liegen gehoeren wahrscheinlich zu einem Grand-Staff oder Bracket.
+/// Bei Blasmusik-Stimmen sind aufeinanderfolgende Zeilen ueblicherweise
+/// 4-8 × line_spacing voneinander entfernt.
+fn is_multi_staff_page(systems: &[StaffSystem]) -> bool {
+    if systems.len() < 2 {
+        return false;
+    }
+    let mut sorted: Vec<(f32, f32)> = systems
+        .iter()
+        .map(|s| {
+            let top_y = s.lines.first().map(|l| l.mean_y()).unwrap_or(0.0);
+            let bot_y = s.lines.last().map(|l| l.mean_y()).unwrap_or(0.0);
+            (top_y, bot_y)
+        })
+        .collect();
+    sorted.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    for w in sorted.windows(2) {
+        let gap = w[1].0 - w[0].1;
+        let line_spacing = systems[0].line_spacing.max(1.0);
+        if gap < line_spacing * 3.5 {
+            return true;
+        }
+    }
+    false
+}
+
+/// Konvertiert eine Page-Rect in eine Crop-Rect (top wird abgezogen).
+fn rect_to_crop(r: &Rect, top: u32) -> Rect {
+    Rect {
+        x: r.x,
+        y: r.y.saturating_sub(top),
+        w: r.w,
+        h: r.h,
+    }
+}
+
+/// Vereinigt zwei Rects.
+fn union_rect(a: Rect, b: Rect) -> Rect {
+    let x0 = a.x.min(b.x);
+    let y0 = a.y.min(b.y);
+    let x1 = (a.x + a.w).max(b.x + b.w);
+    let y1 = (a.y + a.h).max(b.y + b.h);
+    Rect {
+        x: x0,
+        y: y0,
+        w: x1.saturating_sub(x0),
+        h: y1.saturating_sub(y0),
+    }
+}
+
+/// Pruefe ob zwei Rects ueberlappen ODER nahe genug sind (Lücke <= tol).
+fn rects_overlap_or_touch(a: &Rect, b: &Rect, line_spacing: f32) -> bool {
+    let tol = (line_spacing * 0.6).max(3.0) as i32;
+    let ax0 = a.x as i32;
+    let ax1 = (a.x + a.w) as i32;
+    let bx0 = b.x as i32;
+    let bx1 = (b.x + b.w) as i32;
+    let dx = if ax1 < bx0 {
+        bx0 - ax1
+    } else if bx1 < ax0 {
+        ax0 - bx1
+    } else {
+        0
+    };
+    let ay0 = a.y as i32;
+    let ay1 = (a.y + a.h) as i32;
+    let by0 = b.y as i32;
+    let by1 = (b.y + b.h) as i32;
+    let dy = if ay1 < by0 {
+        by0 - ay1
+    } else if by1 < ay0 {
+        ay0 - by1
+    } else {
+        0
+    };
+    dx <= tol && dy <= tol
+}
+
+/// Wie viel Prozent von rect r sind innerhalb von rect target (oder
+/// touchen). Returns 1.0 wenn r komplett in target liegt.
+/// (Note: r und target koennen in unterschiedlichen Koordinatensystemen
+/// sein. Diese Funktion vergleicht direkt; Aufrufer muss dafuer sorgen
+/// dass sie kompatibel sind.)
+fn rect_iou_or_inside(r: &Rect, target: &Rect) -> f32 {
+    let rx0 = r.x;
+    let ry0 = r.y;
+    let rx1 = r.x + r.w;
+    let ry1 = r.y + r.h;
+    let tx0 = target.x;
+    let ty0 = target.y;
+    let tx1 = target.x + target.w;
+    let ty1 = target.y + target.h;
+    let ix0 = rx0.max(tx0);
+    let iy0 = ry0.max(ty0);
+    let ix1 = rx1.min(tx1);
+    let iy1 = ry1.min(ty1);
+    if ix0 >= ix1 || iy0 >= iy1 {
+        return 0.0;
+    }
+    let inter = ((ix1 - ix0) as f32) * ((iy1 - iy0) as f32);
+    let r_area = (r.w as f32) * (r.h as f32);
+    if r_area <= 0.0 {
+        return 0.0;
+    }
+    inter / r_area
+}
+
+/// Merget eng beieinander liegende Bboxes zu Element-Gruppen.
+///
+/// Zwei Bboxes werden gemerged wenn:
+/// - vertikal überlappend ODER fast überlappend (Lücke ≤ 0.5 × line_spacing)
+/// - horizontal nahe (Lücke ≤ 0.6 × line_spacing)
+///
+/// Das löst u.a. das 4/4-Taktangabe-Problem: die zwei Ziffern sind getrennte
+/// Pixelinseln aber gehören als ein Element zusammen. Auch Akkorde werden
+/// dadurch zu einer Element-Bbox.
+///
+/// Iteration: Union-Find — repeat bis stabiler Zustand.
+fn merge_close_rects(rects: &[Rect], line_spacing: f32) -> Vec<Rect> {
+    if rects.is_empty() {
+        return Vec::new();
+    }
+    let n = rects.len();
+    // Union-Find
+    let mut parent: Vec<usize> = (0..n).collect();
+    fn find(p: &mut Vec<usize>, x: usize) -> usize {
+        if p[x] != x {
+            let r = find(p, p[x]);
+            p[x] = r;
+        }
+        p[x]
+    }
+    fn union(p: &mut Vec<usize>, a: usize, b: usize) {
+        let ra = find(p, a);
+        let rb = find(p, b);
+        if ra != rb {
+            p[ra] = rb;
+        }
+    }
+
+    let gap_x = (line_spacing * 0.6).max(3.0) as i32;
+    let gap_y = (line_spacing * 0.5).max(3.0) as i32;
+    for i in 0..n {
+        for j in (i + 1)..n {
+            let a = &rects[i];
+            let b = &rects[j];
+            // X-Lücke: 0 wenn überlappen, sonst Distanz
+            let ax0 = a.x as i32;
+            let ax1 = (a.x + a.w) as i32;
+            let bx0 = b.x as i32;
+            let bx1 = (b.x + b.w) as i32;
+            let dx = if ax1 < bx0 {
+                bx0 - ax1
+            } else if bx1 < ax0 {
+                ax0 - bx1
+            } else {
+                0
+            };
+            let ay0 = a.y as i32;
+            let ay1 = (a.y + a.h) as i32;
+            let by0 = b.y as i32;
+            let by1 = (b.y + b.h) as i32;
+            let dy = if ay1 < by0 {
+                by0 - ay1
+            } else if by1 < ay0 {
+                ay0 - by1
+            } else {
+                0
+            };
+            if dx <= gap_x && dy <= gap_y {
+                union(&mut parent, i, j);
+            }
+        }
+    }
+    // Group by root
+    let mut groups: std::collections::BTreeMap<usize, Vec<usize>> = std::collections::BTreeMap::new();
+    for i in 0..n {
+        let r = find(&mut parent, i);
+        groups.entry(r).or_default().push(i);
+    }
+    // Compute union-bbox per group
+    let mut out = Vec::new();
+    for (_root, members) in groups {
+        let mut min_x = u32::MAX;
+        let mut min_y = u32::MAX;
+        let mut max_x = 0u32;
+        let mut max_y = 0u32;
+        for &i in &members {
+            let r = &rects[i];
+            min_x = min_x.min(r.x);
+            min_y = min_y.min(r.y);
+            max_x = max_x.max(r.x + r.w);
+            max_y = max_y.max(r.y + r.h);
+        }
+        if min_x < max_x && min_y < max_y {
+            out.push(Rect {
+                x: min_x,
+                y: min_y,
+                w: max_x - min_x,
+                h: max_y - min_y,
+            });
+        }
+    }
+    // Sort by x for stable ordering
+    out.sort_by_key(|r| (r.x, r.y));
+    out
+}
+
 /// Hilfsfunktion: kodiert ein GrayImage als PNG-Bytes.
 pub fn encode_png(img: &GrayImage) -> Result<Vec<u8>> {
     let mut buf: Vec<u8> = Vec::new();
     let dyn_img = DynamicImage::ImageLuma8(img.clone());
+    dyn_img.write_to(
+        &mut std::io::Cursor::new(&mut buf),
+        image::ImageFormat::Png,
+    )?;
+    Ok(buf)
+}
+
+/// Hilfsfunktion: kodiert ein RGB-Bild (image::RgbImage) als PNG-Bytes.
+pub fn encode_png_rgb(img: &image::RgbImage) -> Result<Vec<u8>> {
+    let mut buf: Vec<u8> = Vec::new();
+    let dyn_img = DynamicImage::ImageRgb8(img.clone());
     dyn_img.write_to(
         &mut std::io::Cursor::new(&mut buf),
         image::ImageFormat::Png,

--- a/src/omr-rust/crates/omr-labeler/src/pipeline.rs
+++ b/src/omr-rust/crates/omr-labeler/src/pipeline.rs
@@ -74,6 +74,10 @@ impl PipelineState {
         // Dedupe-Map: `clean_name + size_kb` -> erster Pfad mit diesem Schluessel.
         let mut seen: std::collections::HashMap<String, PathBuf> =
             std::collections::HashMap::new();
+        // Subdir-Namen die wir komplett ueberspringen.
+        // _unerkannt: Junk-Scans aus dem User-Workflow.
+        // sheetstorm-output: bereits verarbeitete Output-Artefakte.
+        let skip_subdirs: &[&str] = &["_unerkannt", "sheetstorm-output"];
         while let Some(d) = stack.pop() {
             let entries = match std::fs::read_dir(&d) {
                 Ok(e) => e,
@@ -82,6 +86,14 @@ impl PipelineState {
             for entry in entries.flatten() {
                 let p = entry.path();
                 if p.is_dir() {
+                    let name = p
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .unwrap_or("");
+                    if skip_subdirs.iter().any(|s| s.eq_ignore_ascii_case(name)) {
+                        tracing::debug!("Skip-Subdir: {}", p.display());
+                        continue;
+                    }
                     stack.push(p);
                 } else if let Some(ext) = p.extension().and_then(|s| s.to_str()) {
                     if !ext.eq_ignore_ascii_case("pdf") {

--- a/src/omr-rust/crates/omr-labeler/src/pipeline.rs
+++ b/src/omr-rust/crates/omr-labeler/src/pipeline.rs
@@ -230,9 +230,9 @@ impl PipelineState {
                                 || class_id.as_deref() == Some("group/single_note_quarter")
                             {
                                 class_id = Some(if s.is_tie {
-                                    "group/tied_pair".to_string()
+                                    "haltebogen/paar".to_string()
                                 } else {
-                                    "group/slurred_phrase".to_string()
+                                    "bindebogen/phrase".to_string()
                                 });
                             }
                             // Auch andere Logical Groups die unter dem Slur liegen mergen
@@ -245,7 +245,7 @@ impl PipelineState {
                                     let g2_crop = rect_to_crop(&g2.bbox, top);
                                     bbox = union_rect(bbox, g2_crop);
                                     if !s.is_tie {
-                                        class_id = Some("group/slurred_phrase".to_string());
+                                        class_id = Some("bindebogen/phrase".to_string());
                                     }
                                 }
                             }
@@ -261,15 +261,20 @@ impl PipelineState {
                     }
                     let bbox = rect_to_crop(&s.bbox, top);
                     let class_id = if s.is_tie {
-                        "group/tied_pair".to_string()
+                        "haltebogen/paar".to_string()
                     } else {
-                        "group/slurred_phrase".to_string()
+                        "bindebogen/phrase".to_string()
                     };
                     primary_elements.push((bbox, Some(class_id)));
                 }
 
                 // Step C: CC-Rects die NICHT in einem Logical-Group/Slur liegen
-                // werden gemerged + als standalone-Elements aufgenommen.
+                // werden zu Ton-Ereignissen gruppiert.
+                //
+                // Konzept (User-Vorgabe 2026-05-04):
+                // * "Was uebereinander steht, gehoert zusammen" — Spalten-Grouping
+                // * Ausnahmen: Crescendo/Decrescendo-Gabeln, Texte (Taktnummer,
+                //   Tempoangabe, Sprungmarke, ...) — diese stehen STANDALONE.
                 let standalone_rects: Vec<Rect> = rects_raw
                     .iter()
                     .filter(|r| {
@@ -277,9 +282,17 @@ impl PipelineState {
                     })
                     .copied()
                     .collect();
-                let standalone_merged = merge_close_rects(&standalone_rects, system.line_spacing);
-                for r in standalone_merged {
-                    primary_elements.push((r, None));
+                // Staff-Y-Range im Crop-Koordinatensystem berechnen.
+                let staff_top_in_crop = staff_top_in_crop_for(system, top);
+                let staff_bot_in_crop = staff_bottom_in_crop_for(system, top);
+                let tone_events = group_tone_events(
+                    &standalone_rects,
+                    system.line_spacing,
+                    staff_top_in_crop,
+                    staff_bot_in_crop,
+                );
+                for (r, class_id) in tone_events {
+                    primary_elements.push((r, class_id));
                 }
 
                 // X-sortieren fuer stabiles Labeling-Ordering.
@@ -774,6 +787,238 @@ fn merge_close_rects(rects: &[Rect], line_spacing: f32) -> Vec<Rect> {
         }
     }
     // Sort by x for stable ordering
+    out.sort_by_key(|r| (r.x, r.y));
+    out
+}
+
+/// Staff-Top im Crop-Koordinatensystem.
+fn staff_top_in_crop_for(system: &StaffSystem, top: u32) -> u32 {
+    if let Some(line) = system.lines.first() {
+        let y = line.mean_y().round() as i64;
+        (y - top as i64).max(0) as u32
+    } else {
+        0
+    }
+}
+
+/// Staff-Bottom im Crop-Koordinatensystem.
+fn staff_bottom_in_crop_for(system: &StaffSystem, top: u32) -> u32 {
+    if let Some(line) = system.lines.last() {
+        let y = line.mean_y().round() as i64;
+        (y - top as i64).max(0) as u32
+    } else {
+        0
+    }
+}
+
+/// Klassifiziert eine bbox vorab in eine RectKind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RectKind {
+    /// Ton-Kern: Notenkopf, Stem, Faehnchen, Akzidenz, Artikulation,
+    /// Verzierung — alles was zu einer Note gehoert.
+    /// Diese werden spalten-weise gegruppiert.
+    ToneCore,
+    /// Hairpin (Crescendo / Decrescendo): sehr breit + sehr flach.
+    /// Standalone, kein Merge mit Tonen.
+    Hairpin,
+    /// Text / Zahl / Anweisung weit ueber/unter dem Staff: Taktnummer,
+    /// Tempoangabe, Dynamik-Buchstaben, Sprungmarke, Liedtext.
+    /// Werden horizontal zu Wort-Bloecken gemerged, kein Merge mit Tonen.
+    TextOrFar,
+}
+
+fn classify_rect(r: &Rect, line_spacing: f32, staff_top: u32, staff_bottom: u32) -> RectKind {
+    // Hairpin: > 5 line_spacings breit UND <= 1 line_spacing hoch
+    let ls = line_spacing.max(4.0);
+    if (r.w as f32) >= ls * 5.0 && (r.h as f32) <= ls * 1.1 {
+        return RectKind::Hairpin;
+    }
+    // Far-from-staff: bbox liegt vollstaendig ausserhalb Staff +/- 2.5 ls
+    let band = (ls * 2.5) as u32;
+    let band_top = staff_top.saturating_sub(band);
+    let band_bot = staff_bottom.saturating_add(band);
+    let r_bot = r.y + r.h;
+    if r_bot <= band_top || r.y >= band_bot {
+        return RectKind::TextOrFar;
+    }
+    RectKind::ToneCore
+}
+
+/// Gruppiert CC-Rects nach User-Vorgabe in Ton-Ereignisse.
+///
+/// Regeln:
+/// 1. ToneCore-Rects (Note + Drumrum) werden spaltenweise zu einem
+///    Element gemerged (alles uebereinander = ein Ton-Ereignis).
+/// 2. Hairpins (Cresc./Decresc.-Gabeln) bleiben standalone.
+/// 3. TextOrFar-Rects werden horizontal in Wort-Bloecke gemerged und
+///    bleiben standalone.
+fn group_tone_events(
+    rects: &[Rect],
+    line_spacing: f32,
+    staff_top: u32,
+    staff_bottom: u32,
+) -> Vec<(Rect, Option<String>)> {
+    if rects.is_empty() {
+        return Vec::new();
+    }
+    let kinds: Vec<RectKind> = rects
+        .iter()
+        .map(|r| classify_rect(r, line_spacing, staff_top, staff_bottom))
+        .collect();
+
+    let mut out: Vec<(Rect, Option<String>)> = Vec::new();
+
+    // -- Step A: Spalten-Grouping fuer ToneCore -------------------------
+    let tone_indices: Vec<usize> = (0..rects.len())
+        .filter(|&i| kinds[i] == RectKind::ToneCore)
+        .collect();
+    let n = tone_indices.len();
+    if n > 0 {
+        // Two CCs sind in der gleichen Spalte wenn ihre x-Bereiche
+        // ueberlappen ODER der x-Gap < 0.4 * line_spacing ist.
+        let gap_x = ((line_spacing * 0.4) as i32).max(2);
+        let mut parent: Vec<usize> = (0..n).collect();
+        fn find(p: &mut [usize], x: usize) -> usize {
+            if p[x] != x {
+                let r = find(p, p[x]);
+                p[x] = r;
+            }
+            p[x]
+        }
+        fn union(p: &mut [usize], a: usize, b: usize) {
+            let ra = find(p, a);
+            let rb = find(p, b);
+            if ra != rb {
+                p[ra] = rb;
+            }
+        }
+        for i in 0..n {
+            for j in (i + 1)..n {
+                let a = &rects[tone_indices[i]];
+                let b = &rects[tone_indices[j]];
+                let ax0 = a.x as i32;
+                let ax1 = (a.x + a.w) as i32;
+                let bx0 = b.x as i32;
+                let bx1 = (b.x + b.w) as i32;
+                let dx = if ax1 < bx0 {
+                    bx0 - ax1
+                } else if bx1 < ax0 {
+                    ax0 - bx1
+                } else {
+                    0
+                };
+                if dx <= gap_x {
+                    union(&mut parent, i, j);
+                }
+            }
+        }
+        let mut groups: std::collections::BTreeMap<usize, Vec<usize>> =
+            std::collections::BTreeMap::new();
+        for i in 0..n {
+            let r = find(&mut parent, i);
+            groups.entry(r).or_default().push(tone_indices[i]);
+        }
+        for (_, members) in groups {
+            let mut bbox = rects[members[0]];
+            for &i in members.iter().skip(1) {
+                bbox = union_rect(bbox, rects[i]);
+            }
+            out.push((bbox, None));
+        }
+    }
+
+    // -- Step B: TextOrFar horizontal mergen (Worte) -------------------
+    let text_indices: Vec<usize> = (0..rects.len())
+        .filter(|&i| kinds[i] == RectKind::TextOrFar)
+        .collect();
+    let text_rects: Vec<Rect> = text_indices.iter().map(|&i| rects[i]).collect();
+    // Horizontale Toleranz fuer Wort-Merge: 0.6 * line_spacing.
+    let merged_text = merge_close_horizontal(&text_rects, line_spacing);
+    for r in merged_text {
+        out.push((r, None));
+    }
+
+    // -- Step C: Hairpins standalone -----------------------------------
+    for i in 0..rects.len() {
+        if kinds[i] == RectKind::Hairpin {
+            // Crescendo vs Decrescendo nur grob — User entscheidet endgueltig.
+            // Heuristik: pruefe ob der Pixel-Schwerpunkt links oder rechts
+            // ist — koennte spaeter ergaenzt werden. Fuer's Erste: keine
+            // Vor-Klassifikation, User waehlt aus hairpin/cres oder /decres.
+            out.push((rects[i], None));
+        }
+    }
+
+    out.sort_by_key(|(r, _)| (r.x, r.y));
+    out
+}
+
+/// Merget Rects horizontal zu Wort-Bloecken (vertikal STRENG nahe + horizontal locker).
+///
+/// Zwei Rects mergen wenn:
+/// - x-Gap <= 0.6 * line_spacing  (typischer Buchstabenabstand)
+/// - y-Bereiche ueberlappen (gleiche Zeile)
+fn merge_close_horizontal(rects: &[Rect], line_spacing: f32) -> Vec<Rect> {
+    if rects.is_empty() {
+        return Vec::new();
+    }
+    let n = rects.len();
+    let mut parent: Vec<usize> = (0..n).collect();
+    fn find(p: &mut [usize], x: usize) -> usize {
+        if p[x] != x {
+            let r = find(p, p[x]);
+            p[x] = r;
+        }
+        p[x]
+    }
+    fn union(p: &mut [usize], a: usize, b: usize) {
+        let ra = find(p, a);
+        let rb = find(p, b);
+        if ra != rb {
+            p[ra] = rb;
+        }
+    }
+    let gap_x = ((line_spacing * 0.6) as i32).max(3);
+    for i in 0..n {
+        for j in (i + 1)..n {
+            let a = &rects[i];
+            let b = &rects[j];
+            let ax1 = (a.x + a.w) as i32;
+            let bx0 = b.x as i32;
+            let bx1 = (b.x + b.w) as i32;
+            let ax0 = a.x as i32;
+            let dx = if ax1 < bx0 {
+                bx0 - ax1
+            } else if bx1 < ax0 {
+                ax0 - bx1
+            } else {
+                0
+            };
+            // Strikte y-Ueberlappung pruefen
+            let ay0 = a.y as i32;
+            let ay1 = (a.y + a.h) as i32;
+            let by0 = b.y as i32;
+            let by1 = (b.y + b.h) as i32;
+            let y_overlap = ay0 < by1 && by0 < ay1;
+            if dx <= gap_x && y_overlap {
+                union(&mut parent, i, j);
+            }
+        }
+    }
+    let mut groups: std::collections::BTreeMap<usize, Vec<usize>> =
+        std::collections::BTreeMap::new();
+    for i in 0..n {
+        let r = find(&mut parent, i);
+        groups.entry(r).or_default().push(i);
+    }
+    let mut out = Vec::new();
+    for (_, members) in groups {
+        let mut bbox = rects[members[0]];
+        for &i in members.iter().skip(1) {
+            bbox = union_rect(bbox, rects[i]);
+        }
+        out.push(bbox);
+    }
     out.sort_by_key(|r| (r.x, r.y));
     out
 }

--- a/src/omr-rust/crates/omr-labeler/src/pipeline.rs
+++ b/src/omr-rust/crates/omr-labeler/src/pipeline.rs
@@ -173,6 +173,15 @@ impl PipelineState {
                 // 3. Standalone CC-Rects die NICHT von einer Group abgedeckt
                 //    sind (Clefs, KeySigs, TimeSigs, isolierte Symbole)
                 //    — gemerged via merge_close_rects (4/4-Taktangabe!)
+                //
+                // SANITY-CHECK fuer logical_groups:
+                // Manche Detektoren liefern absurd grosse Bboxes (z.B. h=2153px
+                // statt 60px). Solche Groups schluck en alle Noten in einen
+                // einzigen Riesen-Block und kosten dem User damit jegliche
+                // Granularitaet beim Labeln. Wir verwerfen sie hart und
+                // greifen stattdessen auf Standalone-CC-Rects zurueck.
+                let max_group_h = (system.line_spacing * 8.0).max(80.0) as u32; // ~ Note + Stem + Beam + Akzent + Schrift
+                let max_group_w = (system.line_spacing * 50.0).max(800.0) as u32; // bis zu lange Beam-Phrasen
                 let mut primary_elements: Vec<(Rect, Option<String>)> = Vec::new();
 
                 // Step A: Logical groups, mit Slur-Erweiterung wenn vorhanden
@@ -181,6 +190,23 @@ impl PipelineState {
 
                 for (gi, g) in logical_groups.iter().enumerate() {
                     if logical_used[gi] {
+                        continue;
+                    }
+                    // Sanity-Check: Grotesk grosse Groups (z.B. h=2153px in einem
+                    // 141px-System) entstehen wenn der Detector Beam-Bboxes oder
+                    // Notehead-Bboxes nicht korrekt aggregiert. Solche Groups
+                    // verschlucken die ganze Zeile in einen Riesen-Block und sind
+                    // nutzlos zum Labeln — verwerfen.
+                    if g.bbox.w > max_group_w || g.bbox.h > max_group_h {
+                        tracing::warn!(
+                            "{}: logical_group bbox out-of-bounds {}x{} (max {}x{}) — verwerfe",
+                            id,
+                            g.bbox.w,
+                            g.bbox.h,
+                            max_group_w,
+                            max_group_h
+                        );
+                        logical_used[gi] = true;
                         continue;
                     }
                     logical_used[gi] = true;
@@ -650,12 +676,16 @@ fn rect_iou_or_inside(r: &Rect, target: &Rect) -> f32 {
 /// Merget eng beieinander liegende Bboxes zu Element-Gruppen.
 ///
 /// Zwei Bboxes werden gemerged wenn:
-/// - vertikal überlappend ODER fast überlappend (Lücke ≤ 0.5 × line_spacing)
-/// - horizontal nahe (Lücke ≤ 0.6 × line_spacing)
+/// - vertikal überlappend ODER fast überlappend (Lücke ≤ 0.4 × line_spacing)
+/// - horizontal nahe (Lücke ≤ 0.35 × line_spacing)
 ///
 /// Das löst u.a. das 4/4-Taktangabe-Problem: die zwei Ziffern sind getrennte
-/// Pixelinseln aber gehören als ein Element zusammen. Auch Akkorde werden
-/// dadurch zu einer Element-Bbox.
+/// Pixelinseln aber gehören als ein Element zusammen. Akkord-Köpfe werden
+/// dadurch vertikal zu einer Bbox vereint.
+///
+/// Die Schwellen sind bewusst klein gehalten, damit zwei *benachbarte*
+/// Noten / Akkorde / Beam-Gruppen NICHT mergen — sonst verlieren wir
+/// jegliche Note-Granularitaet beim Labeln.
 ///
 /// Iteration: Union-Find — repeat bis stabiler Zustand.
 fn merge_close_rects(rects: &[Rect], line_spacing: f32) -> Vec<Rect> {
@@ -680,8 +710,8 @@ fn merge_close_rects(rects: &[Rect], line_spacing: f32) -> Vec<Rect> {
         }
     }
 
-    let gap_x = (line_spacing * 0.6).max(3.0) as i32;
-    let gap_y = (line_spacing * 0.5).max(3.0) as i32;
+    let gap_x = (line_spacing * 0.35).max(2.0) as i32;
+    let gap_y = (line_spacing * 0.4).max(2.0) as i32;
     for i in 0..n {
         for j in (i + 1)..n {
             let a = &rects[i];

--- a/src/omr-rust/crates/omr-labeler/src/pipeline.rs
+++ b/src/omr-rust/crates/omr-labeler/src/pipeline.rs
@@ -59,6 +59,10 @@ impl PipelineState {
     /// - Bekannte Multi-Staff-Stuecke (Klavier-Begleitung), die kein Blasmusik-
     ///   Material sind (Dichterliebe, Schumann, Klavier).
     /// - Files unter 1 KB (offensichtlich kaputt)
+    /// - **Duplikate**: Der Filestore enthaelt typischerweise mehrere Uploads
+    ///   desselben PDFs mit unterschiedlichen UUID-Praefixen. Wir
+    ///   deduplizieren ueber `clean_filename` + Filegroesse: dasselbe Lied
+    ///   mit derselben Groesse landet nur EINMAL in der Queue.
     ///
     /// Damit landen nur realistische Single-Staff-Blasmusik-Stimmen im Tool.
     pub fn scan_filestore(dir: &Path) -> Vec<PathBuf> {
@@ -67,6 +71,9 @@ impl PipelineState {
             return out;
         }
         let mut stack = vec![dir.to_path_buf()];
+        // Dedupe-Map: `clean_name + size_kb` -> erster Pfad mit diesem Schluessel.
+        let mut seen: std::collections::HashMap<String, PathBuf> =
+            std::collections::HashMap::new();
         while let Some(d) = stack.pop() {
             let entries = match std::fs::read_dir(&d) {
                 Ok(e) => e,
@@ -81,9 +88,23 @@ impl PipelineState {
                         continue;
                     }
                     if !is_realistic_blasmusik_pdf(&p) {
-                        tracing::debug!("Filter: ueberspringe {} (kein Blasmusik-Material)", p.display());
+                        tracing::debug!(
+                            "Filter: ueberspringe {} (kein Blasmusik-Material)",
+                            p.display()
+                        );
                         continue;
                     }
+                    let size = std::fs::metadata(&p).map(|m| m.len()).unwrap_or(0);
+                    let key = dedupe_key(&p, size);
+                    if let Some(existing) = seen.get(&key) {
+                        tracing::debug!(
+                            "Dedupe: ueberspringe {} (Duplikat von {})",
+                            p.display(),
+                            existing.display()
+                        );
+                        continue;
+                    }
+                    seen.insert(key, p.clone());
                     out.push(p);
                 }
             }
@@ -572,6 +593,57 @@ fn is_realistic_blasmusik_pdf(path: &Path) -> bool {
         }
     }
     true
+}
+
+/// Liefert einen Filename ohne UUID-Praefix.
+///
+/// Filestore-Filenames haben die Form `<uuid>-<echter_name>.pdf`, wobei
+/// die UUID entweder als 32 Hex-Zeichen oder im Standard-Format
+/// `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` vorkommt.
+fn clean_filename(name: &str) -> String {
+    let n = name.to_string();
+    let bytes = n.as_bytes();
+    // 32-Hex + Bindestrich
+    if n.len() > 33 && bytes[32] == b'-' && bytes[..32].iter().all(|&b| b.is_ascii_hexdigit()) {
+        return n[33..].to_string();
+    }
+    // 8-4-4-4-12 + Bindestrich
+    if n.len() > 37
+        && bytes[8] == b'-'
+        && bytes[13] == b'-'
+        && bytes[18] == b'-'
+        && bytes[23] == b'-'
+        && bytes[36] == b'-'
+        && bytes[..8].iter().all(|&b| b.is_ascii_hexdigit())
+    {
+        return n[37..].to_string();
+    }
+    n
+}
+
+/// Schluessel fuer die Dedupe-Map: Hash der ersten 8 KB + Filegroesse.
+///
+/// Filenames variieren oft ("-Stimme.pdf" Suffix, doppeltes ".pdf",
+/// unterschiedliche Schreibweise) waehrend der Inhalt identisch ist.
+/// Ein Content-Hash der ersten 8 KB ist ausreichend um Duplikate
+/// zuverlaessig zu erkennen, ohne die ganze Datei zu lesen.
+fn dedupe_key(path: &Path, size: u64) -> String {
+    use std::io::Read;
+    let mut buf = [0u8; 8192];
+    let head = match std::fs::File::open(path) {
+        Ok(mut f) => match f.read(&mut buf) {
+            Ok(n) => &buf[..n],
+            Err(_) => return format!("err|{}", size),
+        },
+        Err(_) => return format!("err|{}", size),
+    };
+    // Einfacher 64-bit FNV-1a Hash — kollisionsfest genug fuer ein paar 100 PDFs.
+    let mut h: u64 = 0xcbf29ce484222325;
+    for &b in head {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    format!("{:x}|{}", h, size)
 }
 
 /// Erkennt ob eine Page Multi-Staff-Material enthaelt (Klavier-Grand-Staff,
@@ -1087,8 +1159,12 @@ mod tests {
         let p2 = dir.join("sub").join("b.pdf");
         let p3 = dir.join("c.txt");
         std::fs::create_dir_all(dir.join("sub")).unwrap();
-        File::create(&p1).unwrap().write_all(b"x").unwrap();
-        File::create(&p2).unwrap().write_all(b"x").unwrap();
+        // Mindestgroesse 1 KB damit der Filter sie nicht aussperrt.
+        // Unterschiedliche Inhalte damit der Content-Hash sie nicht als Duplikate sieht.
+        let blob_a = vec![1u8; 2048];
+        let blob_b = vec![2u8; 2048];
+        File::create(&p1).unwrap().write_all(&blob_a).unwrap();
+        File::create(&p2).unwrap().write_all(&blob_b).unwrap();
         File::create(&p3).unwrap().write_all(b"x").unwrap();
 
         let found = PipelineState::scan_filestore(&dir);
@@ -1097,6 +1173,57 @@ mod tests {
         assert!(found.iter().any(|p| p.ends_with("b.pdf")));
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn scan_filestore_dedupes_by_clean_name_and_size() {
+        let dir = make_test_dir("dedupe");
+        // Drei "Uploads" desselben PDFs mit unterschiedlichen UUID-Praefixen.
+        let p1 = dir.join("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-ANGELS.pdf");
+        let p2 = dir.join("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-ANGELS.pdf");
+        let p3 = dir
+            .join("cccccccc-cccc-cccc-cccc-cccccccccccc-ANGELS.pdf");
+        // Eines davon mit anderem Inhalt (echte andere Stimme).
+        let p4 = dir.join("dddddddddddddddddddddddddddddddd-Boehmischer-Traum.pdf");
+        let blob_a = vec![1u8; 2048];
+        let blob_b = vec![2u8; 4096];
+        File::create(&p1).unwrap().write_all(&blob_a).unwrap();
+        File::create(&p2).unwrap().write_all(&blob_a).unwrap();
+        File::create(&p3).unwrap().write_all(&blob_a).unwrap();
+        File::create(&p4).unwrap().write_all(&blob_b).unwrap();
+
+        let found = PipelineState::scan_filestore(&dir);
+        // ANGELS hat 3 Kopien mit gleicher Groesse -> 1 Eintrag.
+        // Boehmischer Traum hat eigenen Eintrag.
+        assert_eq!(found.len(), 2, "Erwartet 2 Eintraege, gefunden: {:?}", found);
+        assert_eq!(
+            found.iter().filter(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.contains("ANGELS"))
+                    .unwrap_or(false)
+            }).count(),
+            1,
+            "ANGELS sollte nur einmal vorkommen"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn clean_filename_strips_uuid_prefix() {
+        // 32-Hex-Format
+        assert_eq!(
+            clean_filename("0e50bc8b811e4720a86e3834001b7a81-ANGELS.pdf"),
+            "ANGELS.pdf"
+        );
+        // 8-4-4-4-12-Format
+        assert_eq!(
+            clean_filename("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-Strauss-Marsch.pdf"),
+            "Strauss-Marsch.pdf"
+        );
+        // Kein UUID-Praefix -> unveraendert
+        assert_eq!(clean_filename("plainname.pdf"), "plainname.pdf");
     }
 
     #[test]

--- a/src/omr-rust/crates/omr-labeler/web/annotate.html
+++ b/src/omr-rust/crates/omr-labeler/web/annotate.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>OMR Labeler — Annotation</title>
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body class="annotate-mode">
+  <header class="topbar">
+    <h1>🎼 Annotation-Modus</h1>
+    <nav class="topnav">
+      <a href="/">↩ Y/N-Queue</a>
+      <span id="ann-stats" class="muted">—</span>
+    </nav>
+  </header>
+
+  <main class="annotate-layout">
+    <aside id="ann-sidebar">
+      <h2>Notenzeilen</h2>
+      <p class="hint">Sortiert: am wenigsten annotiert zuerst.</p>
+      <input id="ann-filter" type="text" placeholder="Filter Lied/Seite..." />
+      <ul id="ann-system-list"></ul>
+    </aside>
+
+    <section id="ann-editor">
+      <div class="ann-toolbar">
+        <span id="ann-current-info">Wähle eine Notenzeile links</span>
+        <span class="ann-help">
+          <kbd>Click+Drag</kbd> = Box ziehen ·
+          <kbd>Click</kbd> auf graue Box = übernehmen ·
+          <kbd>Click</kbd> auf grüne Box = neu klassifizieren ·
+          <kbd>Del</kbd> oder Rechtsklick = löschen
+        </span>
+        <label class="ann-checkbox">
+          <input type="checkbox" id="ann-show-auto" checked />
+          Auto-Boxen anzeigen
+        </label>
+      </div>
+      <div id="ann-canvas-wrap">
+        <div id="ann-canvas-inner">
+          <img id="ann-system-img" alt="" />
+          <svg id="ann-overlay" xmlns="http://www.w3.org/2000/svg"></svg>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <!-- Class-Picker Popup -->
+  <div id="class-picker" class="class-picker hidden">
+    <div class="cp-inner">
+      <h3>Welche Klasse?</h3>
+      <div id="cp-top5" class="cp-top5"></div>
+      <input id="cp-search" type="text" placeholder="Suche oder freie Klasse..." autocomplete="off" />
+      <ul id="cp-results"></ul>
+      <div class="cp-actions">
+        <button id="cp-cancel" class="btn">[Esc] Abbrechen</button>
+        <button id="cp-delete" class="btn btn-danger hidden">[Del] Löschen</button>
+      </div>
+    </div>
+  </div>
+
+  <script src="/annotate.js"></script>
+</body>
+</html>

--- a/src/omr-rust/crates/omr-labeler/web/annotate.js
+++ b/src/omr-rust/crates/omr-labeler/web/annotate.js
@@ -1,0 +1,474 @@
+// OMR Labeler — Annotation-Modus Frontend.
+//
+// Verantwortlich für:
+//   * System-Liste laden + filtern (linke Sidebar)
+//   * SVG-Overlay über System-Bild fuer Box-Drawing
+//   * Click-Drag um neue Boxen zu erstellen
+//   * Click auf bestehende Boxen (auto = grau, manuell = gruen) zum Bearbeiten
+//   * Class-Picker-Popup mit Top-5-Hotkey + Live-Suche
+//
+// Vanilla-JS, kein Framework.
+(function () {
+  "use strict";
+
+  const state = {
+    systems: [],
+    classes: [],
+    recentClasses: [],
+    currentSystemId: null,
+    currentSystemMeta: null,
+    autoBoxes: [],
+    annotations: [],
+    showAuto: true,
+    // Aktive Drawing-Operation
+    drawing: false,
+    drawStart: null,
+    pendingBox: null, // {x,y,w,h}
+    // Editing-Mode
+    editingId: null, // id der manuell gesetzten Box (zur Reklassifikation)
+    promotingAutoBox: null, // {x,y,w,h} aus auto -> wartet auf Klasse
+  };
+
+  function $(id) { return document.getElementById(id); }
+  async function jget(url) {
+    const r = await fetch(url, { headers: { Accept: "application/json" } });
+    if (!r.ok) throw new Error("GET " + url + " -> " + r.status);
+    return r.json();
+  }
+  async function jpost(url, body, method) {
+    const r = await fetch(url, {
+      method: method || "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body || {}),
+    });
+    if (!r.ok) throw new Error(method + " " + url + " -> " + r.status);
+    return r.json();
+  }
+
+  // ---------- Klassen laden -----------------------------------------
+
+  async function loadClasses() {
+    try {
+      const builtin = await jget("/api/classes?include_atoms=1&include_phrases=0");
+      let recent = [];
+      try { recent = await jget("/api/classes/recent?limit=20"); } catch (e) {}
+      state.recentClasses = recent || [];
+      const seen = new Set(builtin.map(c => c.id));
+      const customs = state.recentClasses
+        .filter(rc => rc.custom && !seen.has(rc.id))
+        .map(rc => ({ id: rc.id, display_name: rc.display_name + " (eigene)", level: "custom", atoms: [] }));
+      state.classes = customs.concat(builtin);
+    } catch (e) {
+      console.error("loadClasses failed", e);
+    }
+  }
+
+  // ---------- Systems-Liste -----------------------------------------
+
+  async function loadSystems() {
+    try {
+      const r = await jget("/api/annotation/systems");
+      state.systems = r.systems;
+      renderSystemList();
+      updateStats();
+    } catch (e) {
+      console.error("loadSystems failed", e);
+    }
+  }
+
+  function renderSystemList() {
+    const ul = $("ann-system-list");
+    if (!ul) return;
+    const filter = ($("ann-filter").value || "").toLowerCase();
+    ul.innerHTML = "";
+    const filtered = filter
+      ? state.systems.filter(s => s.system_id.toLowerCase().includes(filter))
+      : state.systems;
+    filtered.slice(0, 200).forEach(sys => {
+      const li = document.createElement("li");
+      li.className = "ann-sys" + (sys.system_id === state.currentSystemId ? " active" : "");
+      const title = prettySystemId(sys.system_id);
+      const badge = sys.annotation_count > 0
+        ? `<span class="badge badge-done">${sys.annotation_count}</span>`
+        : `<span class="badge">${sys.auto_element_count} auto</span>`;
+      li.innerHTML = `<span class="ann-sys-title">${title}</span>${badge}`;
+      li.dataset.systemId = sys.system_id;
+      li.addEventListener("click", () => loadSystem(sys.system_id));
+      ul.appendChild(li);
+    });
+  }
+
+  function prettySystemId(id) {
+    // "<hash>-Title#p0s0" -> "Title  ·  P1 S1"
+    const m = id.match(/^([0-9a-f]{32}-)?(.+?)#p(\d+)s(\d+)$/);
+    if (!m) return id;
+    const title = m[2].replace(/^\d+-/, "").replace(/\.pdf-Stimme$/, "").replace(/_/g, " ");
+    return `<strong>${title}</strong> <span class="muted">· P${parseInt(m[3])+1} S${parseInt(m[4])+1}</span>`;
+  }
+
+  function updateStats() {
+    const total = state.systems.length;
+    const annotated = state.systems.filter(s => s.annotation_count > 0).length;
+    const totalAnns = state.systems.reduce((a, s) => a + s.annotation_count, 0);
+    $("ann-stats").textContent = `${annotated}/${total} Notenzeilen · ${totalAnns} Boxen`;
+  }
+
+  // ---------- System laden ------------------------------------------
+
+  async function loadSystem(systemId) {
+    state.currentSystemId = systemId;
+    state.editingId = null;
+    state.promotingAutoBox = null;
+    state.pendingBox = null;
+    const meta = state.systems.find(s => s.system_id === systemId);
+    state.currentSystemMeta = meta;
+    $("ann-current-info").innerHTML = prettySystemId(systemId);
+    $("ann-system-img").src = "/api/system/" + encodeURIComponent(systemId) + "/image";
+    try {
+      const r = await jget("/api/annotation/system/" + encodeURIComponent(systemId));
+      state.annotations = r.annotations || [];
+      state.autoBoxes = r.auto_boxes || [];
+      renderSystemList();
+      renderOverlay();
+    } catch (e) {
+      console.error("loadSystem failed", e);
+    }
+  }
+
+  // ---------- Overlay rendering -------------------------------------
+
+  function renderOverlay() {
+    const svg = $("ann-overlay");
+    const img = $("ann-system-img");
+    if (!svg || !img || !state.currentSystemMeta) return;
+    const w = state.currentSystemMeta.width;
+    const h = state.currentSystemMeta.height;
+    svg.setAttribute("viewBox", `0 0 ${w} ${h}`);
+    svg.setAttribute("preserveAspectRatio", "none");
+    svg.innerHTML = "";
+
+    // Auto-Boxen (grau, gestrichelt, klickbar)
+    if (state.showAuto) {
+      state.autoBoxes.forEach(b => {
+        // Skip auto boxes that overlap heavily with manual ones
+        const overlapped = state.annotations.some(a => iou(a, b) > 0.5);
+        if (overlapped) return;
+        const r = svgRect(b.x, b.y, b.w, b.h, "auto-box");
+        r.dataset.kind = "auto";
+        r.dataset.x = b.x;
+        r.dataset.y = b.y;
+        r.dataset.w = b.w;
+        r.dataset.h = b.h;
+        r.dataset.suggested = b.suggested_class || "";
+        svg.appendChild(r);
+      });
+    }
+
+    // Manuelle Boxen (gruen, mit Label)
+    state.annotations.forEach(a => {
+      const r = svgRect(a.x, a.y, a.w, a.h, "manual-box");
+      r.dataset.kind = "manual";
+      r.dataset.id = a.id;
+      svg.appendChild(r);
+      // Klassenname-Label oben links
+      const lbl = document.createElementNS("http://www.w3.org/2000/svg", "text");
+      lbl.setAttribute("x", a.x + 2);
+      lbl.setAttribute("y", a.y - 2);
+      lbl.setAttribute("class", "manual-label");
+      lbl.textContent = shortClass(a.class_id);
+      svg.appendChild(lbl);
+    });
+
+    // Pending-Box (waehrend gerade gezogen wird)
+    if (state.pendingBox) {
+      const p = state.pendingBox;
+      const r = svgRect(p.x, p.y, p.w, p.h, "pending-box");
+      svg.appendChild(r);
+    }
+  }
+
+  function svgRect(x, y, w, h, cls) {
+    const r = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+    r.setAttribute("x", x);
+    r.setAttribute("y", y);
+    r.setAttribute("width", w);
+    r.setAttribute("height", h);
+    r.setAttribute("class", cls);
+    return r;
+  }
+
+  function iou(a, b) {
+    const ix0 = Math.max(a.x, b.x);
+    const iy0 = Math.max(a.y, b.y);
+    const ix1 = Math.min(a.x + a.w, b.x + b.w);
+    const iy1 = Math.min(a.y + a.h, b.y + b.h);
+    if (ix0 >= ix1 || iy0 >= iy1) return 0;
+    const inter = (ix1 - ix0) * (iy1 - iy0);
+    const ua = a.w * a.h + b.w * b.h - inter;
+    return ua > 0 ? inter / ua : 0;
+  }
+
+  function shortClass(id) {
+    // "ton/viertel" -> "viertel"
+    const i = id.indexOf("/");
+    return i >= 0 ? id.slice(i + 1) : id;
+  }
+
+  // ---------- Mouse-Drag -------------------------------------------
+
+  function setupCanvas() {
+    const wrap = $("ann-canvas-inner");
+    const svg = $("ann-overlay");
+    if (!wrap || !svg) return;
+
+    function imgCoords(evt) {
+      if (!state.currentSystemMeta) return null;
+      const rect = svg.getBoundingClientRect();
+      const sx = (evt.clientX - rect.left) / rect.width;
+      const sy = (evt.clientY - rect.top) / rect.height;
+      return {
+        x: Math.round(sx * state.currentSystemMeta.width),
+        y: Math.round(sy * state.currentSystemMeta.height),
+      };
+    }
+
+    svg.addEventListener("mousedown", (e) => {
+      if (e.button !== 0) return;
+      const target = e.target;
+      // Click auf existierende Box?
+      if (target && target.dataset && target.dataset.kind) {
+        e.preventDefault();
+        if (target.dataset.kind === "manual") {
+          state.editingId = parseInt(target.dataset.id);
+          openClassPicker({ deletable: true });
+        } else if (target.dataset.kind === "auto") {
+          // Promote: erstelle eine manual annotation aus diesem auto-bbox
+          state.promotingAutoBox = {
+            x: parseInt(target.dataset.x),
+            y: parseInt(target.dataset.y),
+            w: parseInt(target.dataset.w),
+            h: parseInt(target.dataset.h),
+          };
+          openClassPicker({ suggestion: target.dataset.suggested });
+        }
+        return;
+      }
+      // Sonst: Drawing starten
+      const c = imgCoords(e);
+      if (!c) return;
+      state.drawing = true;
+      state.drawStart = c;
+      state.pendingBox = { x: c.x, y: c.y, w: 1, h: 1 };
+      renderOverlay();
+    });
+
+    window.addEventListener("mousemove", (e) => {
+      if (!state.drawing || !state.drawStart) return;
+      const c = imgCoords(e);
+      if (!c) return;
+      const x0 = Math.min(state.drawStart.x, c.x);
+      const y0 = Math.min(state.drawStart.y, c.y);
+      const x1 = Math.max(state.drawStart.x, c.x);
+      const y1 = Math.max(state.drawStart.y, c.y);
+      state.pendingBox = { x: x0, y: y0, w: x1 - x0, h: y1 - y0 };
+      renderOverlay();
+    });
+
+    window.addEventListener("mouseup", (e) => {
+      if (!state.drawing) return;
+      state.drawing = false;
+      const b = state.pendingBox;
+      if (!b || b.w < 4 || b.h < 4) {
+        state.pendingBox = null;
+        renderOverlay();
+        return;
+      }
+      // Open class picker for new box
+      openClassPicker({});
+    });
+
+    // Rechtsklick auf manuelle Box: schnell loeschen
+    svg.addEventListener("contextmenu", (e) => {
+      const target = e.target;
+      if (target && target.dataset && target.dataset.kind === "manual") {
+        e.preventDefault();
+        const id = parseInt(target.dataset.id);
+        deleteAnnotation(id);
+      }
+    });
+  }
+
+  // ---------- Class-Picker Popup ------------------------------------
+
+  function openClassPicker(opts) {
+    const picker = $("class-picker");
+    picker.classList.remove("hidden");
+    const top5 = $("cp-top5");
+    top5.innerHTML = "";
+    const recent = state.recentClasses.slice(0, 5);
+    if (recent.length === 0) {
+      // Default-Top-5 aus state.classes (erste 5 Group-Klassen)
+      const groups = state.classes.filter(c => c.level === "group").slice(0, 5);
+      groups.forEach((c, i) => {
+        const btn = document.createElement("button");
+        btn.className = "btn btn-top";
+        btn.textContent = `${i + 1}. ${c.display_name}`;
+        btn.dataset.cls = c.id;
+        top5.appendChild(btn);
+      });
+    } else {
+      recent.forEach((c, i) => {
+        const btn = document.createElement("button");
+        btn.className = "btn btn-top";
+        btn.textContent = `${i + 1}. ${c.display_name} (${c.count}×)`;
+        btn.dataset.cls = c.id;
+        top5.appendChild(btn);
+      });
+    }
+    if (top5.children.length > 0) {
+      Array.from(top5.children).forEach(b => {
+        b.addEventListener("click", () => commitClass(b.dataset.cls));
+      });
+    }
+
+    const search = $("cp-search");
+    search.value = opts.suggestion || "";
+    setTimeout(() => search.focus(), 0);
+    renderPickerResults(search.value);
+    search.oninput = () => renderPickerResults(search.value);
+    search.onkeydown = (e) => {
+      if (e.key === "Enter") {
+        const first = $("cp-results").querySelector("li");
+        if (first) commitClass(first.dataset.cls);
+        else if (search.value.trim()) commitClass(search.value.trim());
+      } else if (e.key === "Escape") {
+        closePicker();
+      }
+    };
+
+    const del = $("cp-delete");
+    if (opts.deletable && state.editingId != null) {
+      del.classList.remove("hidden");
+      del.onclick = () => deleteAnnotation(state.editingId);
+    } else {
+      del.classList.add("hidden");
+    }
+    $("cp-cancel").onclick = closePicker;
+  }
+
+  function renderPickerResults(q) {
+    const list = $("cp-results");
+    if (!list) return;
+    list.innerHTML = "";
+    const ql = (q || "").toLowerCase();
+    const matches = state.classes.filter(c => {
+      if (!ql) return true;
+      return c.id.toLowerCase().includes(ql) || c.display_name.toLowerCase().includes(ql);
+    }).slice(0, 30);
+    matches.forEach(c => {
+      const li = document.createElement("li");
+      const tag = c.level === "custom" ? " [eigene]" : "";
+      li.textContent = c.display_name + " — " + c.id + tag;
+      li.dataset.cls = c.id;
+      li.onclick = () => commitClass(c.id);
+      list.appendChild(li);
+    });
+  }
+
+  function closePicker() {
+    $("class-picker").classList.add("hidden");
+    state.pendingBox = null;
+    state.editingId = null;
+    state.promotingAutoBox = null;
+    renderOverlay();
+  }
+
+  async function commitClass(classId) {
+    if (!classId) return classId;
+    classId = classId.trim();
+    if (!classId) return;
+    try {
+      if (state.editingId != null) {
+        // Reklassifikation
+        await jpost(`/api/annotation/box/${state.editingId}`, { class_id: classId }, "PATCH");
+      } else {
+        // Neu speichern (entweder pendingBox oder promotingAutoBox)
+        const b = state.pendingBox || state.promotingAutoBox;
+        if (!b) return;
+        await jpost("/api/annotation/box", {
+          system_id: state.currentSystemId,
+          x: b.x, y: b.y, w: b.w, h: b.h,
+          class_id: classId,
+        });
+      }
+      closePicker();
+      await loadSystem(state.currentSystemId);
+      await loadSystems();
+    } catch (e) {
+      console.error("commitClass failed", e);
+      alert("Speichern fehlgeschlagen: " + e.message);
+    }
+  }
+
+  async function deleteAnnotation(id) {
+    try {
+      await jpost(`/api/annotation/box/${id}`, {}, "DELETE");
+      closePicker();
+      await loadSystem(state.currentSystemId);
+      await loadSystems();
+    } catch (e) {
+      console.error("delete failed", e);
+    }
+  }
+
+  // ---------- Hotkeys ----------------------------------------------
+
+  function setupHotkeys() {
+    window.addEventListener("keydown", (e) => {
+      // Im Suchfeld nur Esc abfangen
+      if (e.target && (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA")) {
+        if (e.key === "Escape") {
+          if ($("class-picker").classList.contains("hidden")) {
+            e.target.blur();
+          } else {
+            closePicker();
+          }
+        }
+        return;
+      }
+      // Hotkey 1-5 fuer Top-5
+      if (/^[1-5]$/.test(e.key) && !$("class-picker").classList.contains("hidden")) {
+        const idx = parseInt(e.key) - 1;
+        const btn = $("cp-top5").children[idx];
+        if (btn) commitClass(btn.dataset.cls);
+        return;
+      }
+      if (e.key === "Escape" && !$("class-picker").classList.contains("hidden")) {
+        closePicker();
+      }
+      if (e.key === "Delete" && state.editingId != null) {
+        deleteAnnotation(state.editingId);
+      }
+    });
+  }
+
+  // ---------- Init -------------------------------------------------
+
+  function init() {
+    setupCanvas();
+    setupHotkeys();
+    $("ann-filter").addEventListener("input", renderSystemList);
+    $("ann-show-auto").addEventListener("change", (e) => {
+      state.showAuto = e.target.checked;
+      renderOverlay();
+    });
+    loadClasses().then(() => loadSystems());
+    setInterval(loadSystems, 30000);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/src/omr-rust/crates/omr-labeler/web/app.js
+++ b/src/omr-rust/crates/omr-labeler/web/app.js
@@ -20,6 +20,13 @@
     /// Custom + haeufig genutzte Klassen aus der DB ({id, display_name, count, custom}).
     /// Werden zu state.classes gemerged und priorisieren Top-5.
     recentClasses: [],
+    /// Stabile Hotkey-Belegung (Hotkey 1-5 -> {id, display, count}).
+    /// Bleibt zwischen Class-Items konstant, damit Hotkey 1 immer dieselbe
+    /// Klasse aufruft. Aenderungen werden dem User als Banner angekuendigt.
+    lockedTopK: null,
+    /// Pending Update-Vorschlag fuer lockedTopK (wenn neue Klassen
+    /// haeufiger werden) — wird im Banner angezeigt, User kann anwenden.
+    pendingTopK: null,
   };
 
   // ---------- Utility ---------------------------------------------------
@@ -178,7 +185,34 @@
         (item.suggested_class ? " · suggested " + item.suggested_class : ""),
     );
 
+    // Element-Info (bbox-Groesse) async holen und anzeigen — hilft dabei
+    // unrealistisch grosse Detektionen zu erkennen.
+    if (item.level !== "line" && item.element_id) {
+      fetchElementInfo(item.element_id);
+    } else {
+      setText("element-info", "");
+    }
+
     renderClassButtons(item);
+  }
+
+  async function fetchElementInfo(eid) {
+    try {
+      const info = await jsonGet("/api/element/" + encodeURIComponent(eid) + "/info");
+      const b = info.bbox;
+      const sys = info.system_size;
+      let warn = "";
+      if (b && sys && (b[2] > sys[0] * 0.85 || b[3] > sys[1] * 1.5)) {
+        warn = " ⚠ verdächtig groß";
+      }
+      setText(
+        "element-info",
+        "Bbox " + (b ? b[2] + "×" + b[3] + "px @ (" + b[0] + "," + b[1] + ")" : "?") +
+          " · System " + (sys ? sys[0] + "×" + sys[1] : "?") + warn,
+      );
+    } catch (e) {
+      setText("element-info", "");
+    }
   }
 
   // (renderContextImages entfernt — Kontext kommt jetzt direkt vom Server)
@@ -202,45 +236,93 @@
       return id;
     };
 
-    // Top-5 (Hotkey 1-5) — bevorzuge Recent-Klassen aus der DB
-    // (User-Praeferenz, inkl. Custom). Fallback: server-seitiges top_k oder
-    // erste 5 aus state.classes.
-    let topK;
-    if (state.recentClasses.length >= 5) {
-      topK = state.recentClasses.slice(0, 5).map((c) => ({
+    // -- Stabile Hotkey-Belegung --------------------------------------
+    //
+    // 1 sollte zwischen aufeinanderfolgenden Class-Items dieselbe Klasse
+    // aufrufen. Wir frieren daher state.lockedTopK ein und aktualisieren
+    // ihn NUR auf User-Wunsch (oder beim allerersten Class-Item).
+    //
+    // Wenn der DB-State sich aendert (z.B. eine neue Klasse wird haeufig
+    // verwendet), faellt das in pendingTopK und wird via Banner angezeigt.
+    const computeServerTopK = () => {
+      if (state.recentClasses.length >= 5) {
+        return state.recentClasses.slice(0, 5).map((c) => ({
+          id: c.id,
+          display: c.display_name,
+          count: c.count,
+        }));
+      }
+      if (item.top_k && item.top_k.length > 0) {
+        return item.top_k.slice(0, 5).map((e) => ({
+          id: e[0],
+          display: displayFor(e[0]),
+          count: 0,
+        }));
+      }
+      return state.classes.slice(0, 5).map((c) => ({
         id: c.id,
-        score: 0,
         display: c.display_name,
-        count: c.count,
+        count: 0,
       }));
-    } else if (item.top_k && item.top_k.length > 0) {
-      topK = item.top_k.slice(0, 5).map((e) => ({
-        id: e[0],
-        score: e[1],
-        display: displayFor(e[0]),
-      }));
+    };
+
+    const serverTopK = computeServerTopK();
+
+    if (!state.lockedTopK || state.lockedTopK.length === 0) {
+      // Erstes Class-Item: locken
+      state.lockedTopK = serverTopK;
+      state.pendingTopK = null;
     } else {
-      topK = state.classes.slice(0, 5).map((c) => ({
-        id: c.id,
-        score: 0,
-        display: c.display_name,
-      }));
+      // Pruefen ob sich die SET der IDs geaendert hat (neue rein / alte raus)
+      const lockedIds = new Set(state.lockedTopK.map((e) => e.id));
+      const serverIds = new Set(serverTopK.map((e) => e.id));
+      const newComers = serverTopK.filter((e) => !lockedIds.has(e.id));
+      const droppedOut = state.lockedTopK.filter((e) => !serverIds.has(e.id));
+      if (newComers.length > 0 || droppedOut.length > 0) {
+        state.pendingTopK = serverTopK;
+      } else {
+        state.pendingTopK = null;
+        // Counts aktualisieren, Reihenfolge bleibt stabil.
+        state.lockedTopK = state.lockedTopK.map((e) => {
+          const fresh = serverTopK.find((s) => s.id === e.id);
+          return fresh ? { ...e, count: fresh.count } : e;
+        });
+      }
     }
+
+    // Banner mit Diff-Info (nur wenn pending Update vorliegt)
+    if (state.pendingTopK) {
+      const newComers = state.pendingTopK.filter(
+        (e) => !state.lockedTopK.some((l) => l.id === e.id),
+      );
+      const droppedOut = state.lockedTopK.filter(
+        (l) => !state.pendingTopK.some((e) => e.id === l.id),
+      );
+      const banner = document.createElement("div");
+      banner.className = "topk-banner";
+      const newList = newComers
+        .map((e) => `<strong>${e.display}</strong> (${e.count}×)`)
+        .join(", ");
+      const dropList = droppedOut.map((e) => `${e.display}`).join(", ");
+      banner.innerHTML =
+        '<span class="topk-banner-title">⚡ Neue häufige Klasse:</span> ' +
+        (newList || "—") +
+        (dropList ? ` &nbsp;·&nbsp; rausfallen: ${dropList}` : "") +
+        ' <button class="btn btn-small" data-action="apply-topk">[t] Übernehmen</button>' +
+        ' <button class="btn btn-small" data-action="dismiss-topk">Behalten</button>';
+      wrap.appendChild(banner);
+    }
+
+    const topK = state.lockedTopK;
+
     const topWrap = document.createElement("div");
     topWrap.className = "class-top5";
-    const usingRecent = state.recentClasses.length >= 5;
-    topWrap.innerHTML = "<h3>" +
-      (usingRecent ? "Häufig verwendet" : "Top 5") +
-      " (Hotkey 1–5)</h3>";
+    topWrap.innerHTML =
+      "<h3>Häufig verwendet (Hotkey 1–5) <span class='hint'>· stabile Reihenfolge</span></h3>";
     topK.forEach((entry, idx) => {
       const btn = document.createElement("button");
       btn.className = "btn btn-top";
-      let suffix = "";
-      if (entry.count) {
-        suffix = " (" + entry.count + "×)";
-      } else if (entry.score > 0) {
-        suffix = " (" + (entry.score * 100).toFixed(0) + "%)";
-      }
+      const suffix = entry.count > 0 ? " (" + entry.count + "×)" : "";
       btn.textContent = (idx + 1) + ". " + entry.display + suffix;
       btn.dataset.action = "class";
       btn.dataset.value = entry.id;
@@ -309,6 +391,18 @@
       '<button class="btn" data-action="edit">[e] Eigene Klasse</button>' +
       '<button class="btn" data-action="skip">[Space] Skip</button>';
     wrap.appendChild(special);
+  }
+
+  /// Wendet pendingTopK an und macht ihn zur neuen lockedTopK-Belegung.
+  function applyPendingTopK() {
+    if (!state.pendingTopK) return;
+    state.lockedTopK = state.pendingTopK;
+    state.pendingTopK = null;
+    if (state.currentItem) renderClassButtons(state.currentItem);
+  }
+  function dismissPendingTopK() {
+    state.pendingTopK = null;
+    if (state.currentItem) renderClassButtons(state.currentItem);
   }
 
   async function fetchClasses() {
@@ -516,13 +610,22 @@
       const idx = parseInt(k, 10) - 1;
       const item = state.currentItem;
       if (!item) return;
-      // Top-K aus Suggestions, fallback auf state.classes
+      // Stabile Hotkey-Belegung: zuerst lockedTopK (wenn class-Level),
+      // dann server-Top-K, dann state.classes.
+      if (item.level === "class" && state.lockedTopK && state.lockedTopK[idx]) {
+        return sendAnswer("class", state.lockedTopK[idx].id);
+      }
       if (item.top_k && item.top_k[idx]) {
         return sendAnswer("class", item.top_k[idx][0]);
       }
       if (state.classes && state.classes[idx]) {
         return sendAnswer("class", state.classes[idx].id);
       }
+    }
+    if (k === "t" && state.pendingTopK) {
+      // Top-5 Update anwenden
+      applyPendingTopK();
+      return;
     }
   }
 
@@ -548,6 +651,8 @@
         if (cls && cls.trim().length > 0) sendAnswer("class", cls.trim());
         return;
       }
+      if (action === "apply-topk") return applyPendingTopK();
+      if (action === "dismiss-topk") return dismissPendingTopK();
       if (action === "drill") return showDrillDown(t.dataset.value || "");
       if (action === "class") return sendAnswer("class", t.dataset.value || "");
     });

--- a/src/omr-rust/crates/omr-labeler/web/app.js
+++ b/src/omr-rust/crates/omr-labeler/web/app.js
@@ -17,6 +17,9 @@
     currentItem: null,
     contextSystems: [],
     classes: [],
+    /// Custom + haeufig genutzte Klassen aus der DB ({id, display_name, count, custom}).
+    /// Werden zu state.classes gemerged und priorisieren Top-5.
+    recentClasses: [],
   };
 
   // ---------- Utility ---------------------------------------------------
@@ -190,25 +193,62 @@
     }
     wrap.classList.remove("hidden");
 
-    // Top-5 (Hotkey 1-5) — eingebaute Vorschlaege oder erste 5 aus Klassen-Liste.
-    const topK = (item.top_k && item.top_k.length > 0)
-      ? item.top_k.slice(0, 5).map((e) => ({ id: e[0], score: e[1], display: e[0] }))
-      : (state.classes.slice(0, 5).map((c) => ({ id: c.id, score: 0, display: c.display_name })));
+    // Display-Name fuer eine Klassen-ID nachschlagen.
+    const displayFor = (id) => {
+      const recent = state.recentClasses.find((c) => c.id === id);
+      if (recent) return recent.display_name;
+      const cls = state.classes.find((c) => c.id === id);
+      if (cls) return cls.display_name;
+      return id;
+    };
+
+    // Top-5 (Hotkey 1-5) — bevorzuge Recent-Klassen aus der DB
+    // (User-Praeferenz, inkl. Custom). Fallback: server-seitiges top_k oder
+    // erste 5 aus state.classes.
+    let topK;
+    if (state.recentClasses.length >= 5) {
+      topK = state.recentClasses.slice(0, 5).map((c) => ({
+        id: c.id,
+        score: 0,
+        display: c.display_name,
+        count: c.count,
+      }));
+    } else if (item.top_k && item.top_k.length > 0) {
+      topK = item.top_k.slice(0, 5).map((e) => ({
+        id: e[0],
+        score: e[1],
+        display: displayFor(e[0]),
+      }));
+    } else {
+      topK = state.classes.slice(0, 5).map((c) => ({
+        id: c.id,
+        score: 0,
+        display: c.display_name,
+      }));
+    }
     const topWrap = document.createElement("div");
     topWrap.className = "class-top5";
-    topWrap.innerHTML = "<h3>Top 5 (Hotkey 1–5)</h3>";
+    const usingRecent = state.recentClasses.length >= 5;
+    topWrap.innerHTML = "<h3>" +
+      (usingRecent ? "Häufig verwendet" : "Top 5") +
+      " (Hotkey 1–5)</h3>";
     topK.forEach((entry, idx) => {
       const btn = document.createElement("button");
       btn.className = "btn btn-top";
-      const pct = entry.score > 0 ? " (" + (entry.score * 100).toFixed(0) + "%)" : "";
-      btn.textContent = (idx + 1) + ". " + entry.display + pct;
+      let suffix = "";
+      if (entry.count) {
+        suffix = " (" + entry.count + "×)";
+      } else if (entry.score > 0) {
+        suffix = " (" + (entry.score * 100).toFixed(0) + "%)";
+      }
+      btn.textContent = (idx + 1) + ". " + entry.display + suffix;
       btn.dataset.action = "class";
       btn.dataset.value = entry.id;
       topWrap.appendChild(btn);
     });
     wrap.appendChild(topWrap);
 
-    // Suche-Filter mit Live-Filter
+    // Suche-Filter mit Live-Filter (durchsucht built-in + custom)
     const searchWrap = document.createElement("div");
     searchWrap.className = "class-search";
     searchWrap.innerHTML = '<h3>Alle Klassen (<kbd>/</kbd>)</h3>' +
@@ -227,7 +267,8 @@
         }).slice(0, 30);
         matches.forEach((c) => {
           const li = document.createElement("li");
-          li.textContent = c.display_name + " — " + c.id;
+          const tag = c.level === "custom" ? " [eigene]" : "";
+          li.textContent = c.display_name + " — " + c.id + tag;
           li.dataset.action = "class";
           li.dataset.value = c.id;
           list.appendChild(li);
@@ -272,11 +313,64 @@
 
   async function fetchClasses() {
     try {
-      state.classes = await jsonGet("/api/classes?include_atoms=1&include_phrases=0");
+      const builtin = await jsonGet("/api/classes?include_atoms=1&include_phrases=0");
+      // Recent / custom classes vom Server (inkl. User-Eingaben).
+      let recent = [];
+      try {
+        recent = await jsonGet("/api/classes/recent?limit=20");
+      } catch (re) {
+        console.warn("recent classes fetch failed", re);
+      }
+      state.recentClasses = recent || [];
+
+      // Merge: zuerst built-in. Custom-Klassen (id nicht in built-in) als
+      // ClassEntry-aehnliche Objekte appenden, damit sie in der Suche
+      // auftauchen.
+      const seen = new Set(builtin.map((c) => c.id));
+      const customEntries = state.recentClasses
+        .filter((rc) => rc.custom && !seen.has(rc.id))
+        .map((rc) => ({
+          id: rc.id,
+          display_name: rc.display_name + " (eigene)",
+          level: "custom",
+          atoms: [],
+        }));
+      state.classes = customEntries.concat(builtin);
     } catch (e) {
       console.error("fetchClasses failed", e);
       state.classes = [];
     }
+  }
+
+  /// Lokale Aktualisierung nach einer User-Antwort: wenn der User eine
+  /// Custom-Klasse eingegeben hat, fuegen wir sie sofort zu state.classes
+  /// + state.recentClasses hinzu, damit sie beim naechsten Item bereits
+  /// in der Suche und in den Top-5 sichtbar ist (ohne Roundtrip).
+  function rememberClass(classId) {
+    if (!classId) return;
+    const existsInClasses = state.classes.some((c) => c.id === classId);
+    const known = state.classes.find((c) => c.id === classId);
+    const isBuiltin = known && (known.level === "atom" || known.level === "group" || known.level === "phrase");
+    if (!existsInClasses) {
+      state.classes.unshift({
+        id: classId,
+        display_name: classId + " (eigene)",
+        level: "custom",
+        atoms: [],
+      });
+    }
+    const idx = state.recentClasses.findIndex((rc) => rc.id === classId);
+    if (idx >= 0) {
+      state.recentClasses[idx].count += 1;
+    } else {
+      state.recentClasses.unshift({
+        id: classId,
+        display_name: isBuiltin ? known.display_name : classId,
+        count: 1,
+        custom: !isBuiltin,
+      });
+    }
+    state.recentClasses.sort((a, b) => b.count - a.count);
   }
 
   async function showDrillDown(groupId) {
@@ -326,6 +420,11 @@
         decision: decision,
         value: value || null,
       });
+      // Optimistic update: Custom-Klasse merken, damit sie sofort
+      // in der Suche und in den Top-5 auftaucht — ohne Roundtrip.
+      if (decision === "class" && value) {
+        rememberClass(value);
+      }
     } catch (e) {
       console.error("answer failed", e);
     }

--- a/src/omr-rust/crates/omr-labeler/web/app.js
+++ b/src/omr-rust/crates/omr-labeler/web/app.js
@@ -95,47 +95,90 @@
 
   function renderEmpty(msg) {
     state.currentItem = null;
-    const m = $("main-image");
-    if (m) m.innerHTML = '<p class="empty">' + (msg || "Queue leer — alle Items bearbeitet 🎉") + "</p>";
-    const c = $("class-buttons");
-    if (c) c.classList.add("hidden");
+    const c = $("context-view");
+    if (c) c.innerHTML = '<p class="empty">' + (msg || "Queue leer — alle Items bearbeitet 🎉") + "</p>";
+    const p = $("patch-view");
+    if (p) p.classList.add("hidden");
+    const cb = $("class-buttons");
+    if (cb) cb.classList.add("hidden");
+    setQuestion("Fertig!", "Alle Items bearbeitet oder Pipeline noch beim Laden.");
     setText("current-info", "—");
   }
 
+  function setQuestion(text, hint) {
+    setText("question-text", text || "");
+    setText("question-hint", hint || "");
+  }
+
   function renderLevel(item) {
-    const m = $("main-image");
-    if (!m) return;
-    m.innerHTML = "";
-    const img = document.createElement("img");
+    // Frage je nach Level klar formulieren
     if (item.level === "line") {
-      img.src = "/api/system/" + encodeURIComponent(item.system_id) + "/image";
-    } else {
-      const id = item.element_id || item.system_id;
-      img.src = "/api/element/" + encodeURIComponent(id) + "/image";
+      setQuestion(
+        "Ist das eine gültige Notenzeile?",
+        "Y = Ja, das ist eine vollständige Notenzeile. N = Nein (Müll, abgeschnitten, kein Notensystem). Space = unsicher.",
+      );
+    } else if (item.level === "element") {
+      const sug = item.suggested_class
+        ? ` Vorschlag: <code>${item.suggested_class}</code>.`
+        : "";
+      setQuestion(
+        "Ist der rote Rahmen ein gültiges Notations-Element?",
+        `Y = Ja, der Rahmen umschließt sauber ein erkennbares Element (Notenkopf, Beam-Group, Akkord, Akzidens, …).${sug} N = Nein, der Rahmen ist Müll oder umschließt mehrere Elemente.`,
+      );
+    } else if (item.level === "class") {
+      const sug = item.suggested_class
+        ? ` Vorschlag: <code>${item.suggested_class}</code> — drücke 1, oder wähle eine andere.`
+        : " (Top-5 erscheinen rechts)";
+      setQuestion(
+        "Was ist im roten Rahmen?",
+        `Wähle die Klasse:${sug} Tippe <kbd>/</kbd> für Suche durch alle Klassen.`,
+      );
     }
-    img.alt = "Item " + item.id;
-    img.onerror = () => {
-      m.innerHTML = '<p class="empty">Kein Bild verfügbar (id=' + item.id + ").</p>";
-    };
-    m.appendChild(img);
+
+    // Kontext-Bild
+    const ctx = $("context-view");
+    if (ctx) {
+      ctx.innerHTML = "";
+      const img = document.createElement("img");
+      img.className = "context-image";
+      if (item.level === "line") {
+        img.src = "/api/system/" + encodeURIComponent(item.system_id) + "/image";
+        img.alt = "Notenzeile " + item.system_id;
+      } else {
+        const eid = item.element_id || item.system_id;
+        img.src = "/api/element/" + encodeURIComponent(eid) + "/context";
+        img.alt = "Element im Kontext " + eid;
+      }
+      img.onerror = () => {
+        ctx.innerHTML = '<p class="empty">Kein Bild verfügbar (id=' + item.id + ").</p>";
+      };
+      ctx.appendChild(img);
+    }
+
+    // Patch-Detail (nur bei element/class)
+    const patchView = $("patch-view");
+    const patchImg = $("patch-image");
+    if (patchView && patchImg) {
+      if (item.level === "line") {
+        patchView.classList.add("hidden");
+      } else {
+        const eid = item.element_id || item.system_id;
+        patchImg.src = "/api/element/" + encodeURIComponent(eid) + "/image";
+        patchImg.alt = "Patch " + eid;
+        patchView.classList.remove("hidden");
+      }
+    }
+
     setText(
       "current-info",
       "ID " + item.id + " · Level " + item.level + " · u=" + (item.uncertainty || 0).toFixed(2) +
         (item.suggested_class ? " · suggested " + item.suggested_class : ""),
     );
 
-    renderContextImages(item);
     renderClassButtons(item);
   }
 
-  function renderContextImages(item) {
-    // Platzhalter: wir laden keine echten Nachbar-Systeme, aber zeigen
-    // die letzten beiden gelabelten als gedimmte Strip-Items.
-    const prev = $("context-prev");
-    const next = $("context-next");
-    if (prev) prev.innerHTML = "";
-    if (next) next.innerHTML = "";
-  }
+  // (renderContextImages entfernt — Kontext kommt jetzt direkt vom Server)
 
   function renderClassButtons(item) {
     const wrap = $("class-buttons");

--- a/src/omr-rust/crates/omr-labeler/web/index.html
+++ b/src/omr-rust/crates/omr-labeler/web/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="de">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -18,35 +18,44 @@
   </header>
   <main class="layout">
     <section class="main-panel">
-      <div id="context-prev" class="context-strip"></div>
-      <div id="main-image" class="main-image">
-        <p class="empty">Loading next item…</p>
+      <div id="question-bar" class="question-bar">
+        <div id="question-text" class="question-text">Lädt Frage…</div>
+        <div id="question-hint" class="question-hint"></div>
       </div>
-      <div id="context-next" class="context-strip"></div>
+      <div id="context-view" class="context-view">
+        <p class="empty">Lädt Kontext…</p>
+      </div>
+      <div id="patch-view" class="patch-view hidden">
+        <h3>Element im Detail (zoom)</h3>
+        <img id="patch-image" alt="Element" />
+      </div>
       <div id="action-bar" class="action-bar">
-        <button data-action="yes" class="btn yes">Yes (Y)</button>
-        <button data-action="no" class="btn no">No (N)</button>
-        <button data-action="skip" class="btn">Skip (Space)</button>
-        <button data-action="undo" class="btn">Undo (U)</button>
+        <button data-action="yes" class="btn yes" title="Ja, das markierte ist korrekt erkannt"><kbd>Y</kbd> Ja, korrekt</button>
+        <button data-action="no" class="btn no" title="Nein, das ist falsch / Müll"><kbd>N</kbd> Nein, falsch</button>
+        <button data-action="skip" class="btn" title="Bin unsicher, später nochmal"><kbd>Space</kbd> Skip</button>
+        <button data-action="undo" class="btn" title="Letzte Antwort rückgängig"><kbd>U</kbd> Undo</button>
       </div>
       <div id="class-buttons" class="class-buttons hidden"></div>
     </section>
     <aside class="sidebar">
-      <h2>Hotkeys</h2>
+      <h2>Was bedeuten die Tasten?</h2>
       <ul class="hotkey-list">
-        <li><kbd>Y</kbd> Yes</li>
-        <li><kbd>N</kbd> No</li>
-        <li><kbd>Space</kbd> Skip</li>
-        <li><kbd>U</kbd> Undo</li>
-        <li><kbd>1</kbd>–<kbd>5</kbd> Class shortcut</li>
-        <li><kbd>E</kbd> Edit class…</li>
+        <li><kbd>Y</kbd> <strong>Ja</strong>, der rote Rahmen umschließt ein gültiges Element</li>
+        <li><kbd>N</kbd> <strong>Nein</strong>, das ist falsch / kein Element / Müll</li>
+        <li><kbd>Space</kbd> <strong>Skip</strong> — unsicher, später nochmal</li>
+        <li><kbd>U</kbd> <strong>Undo</strong> letzte Antwort rückgängig</li>
+        <li><kbd>1</kbd>–<kbd>5</kbd> Top-5 Klasse direkt wählen</li>
+        <li><kbd>/</kbd> Live-Filter über alle Klassen öffnen</li>
+        <li><kbd>d</kbd> Drill-Down von Group → Atome</li>
+        <li><kbd>n</kbd> (auf Klassen-Ebene) Keine passende → manuell</li>
+        <li><kbd>e</kbd> Eigene Klasse manuell tippen</li>
       </ul>
-      <h2>Progress</h2>
+      <h2>Fortschritt</h2>
       <div class="progress">
         <div id="progress-bar" class="progress-bar"></div>
       </div>
       <p id="progress-text">0 / 0</p>
-      <h2>Current</h2>
+      <h2>Aktuell</h2>
       <p id="current-info">—</p>
     </aside>
   </main>

--- a/src/omr-rust/crates/omr-labeler/web/index.html
+++ b/src/omr-rust/crates/omr-labeler/web/index.html
@@ -14,6 +14,7 @@
       <span id="stat-systems">Systems: …</span>
       <span id="stat-elements">Elements: …</span>
       <span id="stat-labels">Labels: …</span>
+      <a href="/annotate" class="topbar-link">✏️ Annotation-Modus →</a>
     </div>
   </header>
   <main class="layout">

--- a/src/omr-rust/crates/omr-labeler/web/index.html
+++ b/src/omr-rust/crates/omr-labeler/web/index.html
@@ -57,6 +57,7 @@
       <p id="progress-text">0 / 0</p>
       <h2>Aktuell</h2>
       <p id="current-info">—</p>
+      <p id="element-info" class="element-info"></p>
     </aside>
   </main>
   <script src="/app.js"></script>

--- a/src/omr-rust/crates/omr-labeler/web/style.css
+++ b/src/omr-rust/crates/omr-labeler/web/style.css
@@ -378,3 +378,57 @@ kbd {
   color: var(--muted);
   margin: 0.3rem 0 0;
 }
+
+/* ====== Annotation-Modus ====== */
+.annotate-mode { background: #0e1116; }
+.topnav { display: flex; gap: 1rem; align-items: center; }
+.topnav a { color: var(--accent); text-decoration: none; padding: 0.3rem 0.6rem; border: 1px solid var(--border); border-radius: 4px; }
+.topnav a:hover { background: var(--panel-light); }
+
+.annotate-layout { display: grid; grid-template-columns: 320px 1fr; height: calc(100vh - 60px); gap: 0; }
+#ann-sidebar { background: var(--panel); border-right: 1px solid var(--border); overflow-y: auto; padding: 0.75rem; }
+#ann-sidebar h2 { margin: 0 0 0.5rem 0; font-size: 1rem; }
+#ann-sidebar .hint { font-size: 0.78rem; color: var(--muted); margin: 0.2rem 0 0.5rem; }
+#ann-filter { width: 100%; padding: 0.4rem; background: var(--panel-light); color: var(--fg); border: 1px solid var(--border); border-radius: 4px; margin-bottom: 0.5rem; }
+#ann-system-list { list-style: none; padding: 0; margin: 0; }
+.ann-sys { padding: 0.4rem 0.5rem; cursor: pointer; border-radius: 4px; display: flex; align-items: center; justify-content: space-between; gap: 0.4rem; font-size: 0.85rem; }
+.ann-sys:hover { background: var(--panel-light); }
+.ann-sys.active { background: #1f3050; color: var(--fg); }
+.ann-sys-title { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.badge { background: var(--panel-light); color: var(--muted); padding: 0.05rem 0.4rem; border-radius: 10px; font-size: 0.72rem; }
+.badge-done { background: #134f1c; color: #6ee07e; }
+
+#ann-editor { display: flex; flex-direction: column; background: var(--bg); }
+.ann-toolbar { display: flex; gap: 1rem; align-items: center; padding: 0.5rem 1rem; background: var(--panel); border-bottom: 1px solid var(--border); flex-wrap: wrap; }
+.ann-help { color: var(--muted); font-size: 0.78rem; }
+.ann-checkbox { color: var(--muted); font-size: 0.85rem; display: flex; align-items: center; gap: 0.3rem; }
+#ann-canvas-wrap { flex: 1; overflow: auto; padding: 1rem; }
+#ann-canvas-inner { position: relative; display: inline-block; }
+#ann-system-img { display: block; max-width: 100%; user-select: none; -webkit-user-drag: none; }
+#ann-overlay { position: absolute; top: 0; left: 0; width: 100%; height: 100%; cursor: crosshair; }
+
+.auto-box { fill: rgba(160, 160, 160, 0.05); stroke: #6a7280; stroke-width: 1.5; stroke-dasharray: 3 2; cursor: pointer; }
+.auto-box:hover { fill: rgba(160, 160, 160, 0.18); stroke: #b9bcc7; }
+.manual-box { fill: rgba(74, 222, 128, 0.13); stroke: #22c55e; stroke-width: 2; cursor: pointer; }
+.manual-box:hover { fill: rgba(74, 222, 128, 0.28); stroke: #4ade80; }
+.pending-box { fill: rgba(74, 163, 255, 0.18); stroke: #4ea3ff; stroke-width: 2; pointer-events: none; }
+.manual-label { fill: #4ade80; font-size: 11px; font-family: ui-monospace, "Cascadia Code", Consolas, monospace; pointer-events: none; }
+
+/* Class-Picker Popup */
+.class-picker { position: fixed; inset: 0; background: rgba(0,0,0,0.55); display: flex; align-items: center; justify-content: center; z-index: 100; }
+.class-picker.hidden { display: none; }
+.cp-inner { width: min(560px, 92vw); max-height: 80vh; background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: 1rem; display: flex; flex-direction: column; gap: 0.5rem; overflow: auto; }
+.cp-inner h3 { margin: 0; }
+.cp-top5 { display: grid; grid-template-columns: 1fr; gap: 0.25rem; }
+.cp-top5 .btn-top { text-align: left; }
+#cp-search { padding: 0.5rem; background: var(--panel-light); color: var(--fg); border: 1px solid var(--border); border-radius: 4px; }
+#cp-results { list-style: none; padding: 0; margin: 0; max-height: 35vh; overflow-y: auto; }
+#cp-results li { padding: 0.3rem 0.5rem; cursor: pointer; border-radius: 4px; font-size: 0.88rem; }
+#cp-results li:hover { background: var(--panel-light); }
+.cp-actions { display: flex; gap: 0.5rem; justify-content: flex-end; margin-top: 0.5rem; }
+.btn-danger { background: #5a1a1a; color: #ff8c8c; border: 1px solid #842525; }
+.btn-danger:hover { background: #6e2020; }
+.muted { color: var(--muted); }
+
+.topbar-link { color: var(--accent); text-decoration: none; padding: 0.25rem 0.6rem; border: 1px solid var(--accent); border-radius: 4px; font-size: 0.85rem; margin-left: 0.5rem; }
+.topbar-link:hover { background: var(--accent); color: #0e1116; }

--- a/src/omr-rust/crates/omr-labeler/web/style.css
+++ b/src/omr-rust/crates/omr-labeler/web/style.css
@@ -270,3 +270,89 @@ kbd {
   font-size: 0.8rem; 
   padding: 0.3rem 0.5rem; 
 }
+
+/* ── Context-View (Big Picture) ────────────────────────────────────── */
+.question-bar {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.8rem 1.2rem;
+  margin-bottom: 0.8rem;
+}
+.question-text {
+  font-size: 1.15rem;
+  font-weight: 600;
+  margin-bottom: 0.3rem;
+  color: var(--accent);
+}
+.question-hint {
+  font-size: 0.9rem;
+  color: var(--muted);
+  line-height: 1.4;
+}
+.question-hint code {
+  background: var(--panel-light);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-family: ui-monospace, monospace;
+  color: var(--fg);
+}
+.question-hint kbd {
+  background: var(--panel-light);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 1px 6px;
+  font-family: ui-monospace, monospace;
+}
+
+.context-view {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.8rem;
+  margin-bottom: 0.8rem;
+  overflow-x: auto;
+  text-align: center;
+  min-height: 100px;
+}
+.context-image {
+  max-width: 100%;
+  height: auto;
+  display: inline-block;
+  border-radius: 4px;
+}
+
+.patch-view {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.6rem 0.8rem;
+  margin-bottom: 0.8rem;
+}
+.patch-view h3 {
+  margin: 0 0 0.4rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.patch-view img {
+  display: block;
+  width: 128px;
+  height: 128px;
+  image-rendering: pixelated;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: white;
+}
+
+.btn[title] { cursor: help; }
+.action-bar .btn kbd {
+  background: rgba(255,255,255,0.1);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: 3px;
+  padding: 0 5px;
+  margin-right: 4px;
+  font-family: ui-monospace, monospace;
+  font-size: 0.85em;
+}

--- a/src/omr-rust/crates/omr-labeler/web/style.css
+++ b/src/omr-rust/crates/omr-labeler/web/style.css
@@ -356,3 +356,25 @@ kbd {
   font-family: ui-monospace, monospace;
   font-size: 0.85em;
 }
+
+/* Top-K Stable Hotkey Banner */
+.topk-banner {
+  background: linear-gradient(90deg, #4a3c1e, #2a2010);
+  border: 1px solid #b88a30;
+  color: #ffce6b;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  margin-bottom: 0.5rem;
+}
+.topk-banner .topk-banner-title { font-weight: bold; margin-right: 0.4rem; }
+.btn-small { padding: 0.15rem 0.5rem; font-size: 0.85rem; margin-left: 0.4rem; }
+.class-top5 .hint { color: var(--muted); font-weight: normal; font-size: 0.8rem; }
+
+/* Element-Info (bbox-Groesse zur Diagnose) */
+.element-info {
+  font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+  font-size: 0.8rem;
+  color: var(--muted);
+  margin: 0.3rem 0 0;
+}


### PR DESCRIPTION
## Summary

Sammlung aller UX-Verbesserungen am `omr-labeler`, die beim ersten richtigen Labeling-Lauf vom User eingefordert wurden, plus die fehlende Class-Queue-Logik.

## UX (vom User eingefordert)

- **Logical-Group-First Element-Detection** — Beam-Group / Akkord / Slur werden als _ein_ Element angeboten, nicht als Einzel-Notenköpfe. Bindebogen über einem Lauf → 1 großes `slurred_phrase`-Element.
- **Vertikaler Kontext** (200 px oben/unten) via volles Page-Bild — die `4/4`-Taktangabe wird nicht mehr oben abgeschnitten.
- **4/4-Merge** über `merge_close_rects` (Union-Find) — zusammengehörige Symbole bleiben zusammen.
- **Multi-Staff-Filter** — Klavier-Begleitung / Lieder / Klaviertrios werden automatisch ausgeblendet (Filename-Filter `dichterliebe`, `klavier`, `lied-` + Heuristik: Gap < 3.5 × line_spacing → Multi-Staff).
- **Klare Fragen pro Level**: "Ist das eine gültige Notenzeile?", "Ist der rote Rahmen ein gültiges Element?", "Was ist im roten Rahmen?".
- **Hotkey-Liste** prominent in der UI (`<kbd>`-Tags).
- **Drill-Down** Group → Atom + Live-Suche per `/` + Top-5 auf 1–5.

## Queue-Logik (das war der Blocker beim zweiten Login)

- **Auto-Promote**: User antwortet "Yes" auf Element → Tool schiebt automatisch ein `class`-Item für genau dieses Element hinterher. Workflow läuft ohne Pause durch.
- **Backfill bei Start**: Bereits in der DB persistierte Labels (`line`, `element`, `class`) werden gelesen. Bereits gelabelte Items werden nicht mehr neu gefragt. yes-Elements ohne Class-Label bekommen automatisch ein Class-Item — dadurch ist die Queue nach Restart nicht mehr leer, sondern enthält genau die Klassifikations-Fragen, die noch offen sind.
- **Default-Top-5** für Class-Items ohne trainiertes Modell: `single_note_quarter`, `single_note_eighth`, `beamed_group_2_eighths`, `beamed_group_4_sixteenths`, `chord_2_notes`.

## Verifikation

- `cargo build --release -p omr-labeler` ✅
- Lokal mit echter `labeler.db` (248 bestehende Labels) gestartet:
  - Bestehende Labels: line=75, element=173, yes_elements=68, class=0
  - Queue gefüllt: line+=0, element+=5, class+=68 (gesamt 73 items)
- API liefert die 68 Class-Items mit Top-5 als Hotkey-Vorschlag.

## Domain-Constraint vom User

> "Fast alle unsere Noten sind nur eine Stimme oder maximal 2 Stimmen aber in der gleichen Zeile. Wir haben keine Noten mit mehreren Systemen."

Filter (`is_realistic_blasmusik_pdf` + `is_multi_staff_page`) gehen genau diesen Fall an — von 132 PDFs werden 19 als Single-Staff-Blasmusik akzeptiert.